### PR TITLE
MAVEN_TERMINATE_CMD is no longer overriden

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -226,10 +226,6 @@ public class WithMavenStepExecution extends AbstractStepExecutionImpl {
             }
             envOverride.put(MAVEN_OPTS, mavenOpts.replaceAll("[\t\r\n]+", " "));
         }
-
-        // just as a precaution
-        // see http://maven.apache.org/continuum/faqs.html#how-does-continuum-detect-a-successful-build
-        envOverride.put("MAVEN_TERMINATE_CMD", "on");
     }
 
     private String obtainMavenExec() throws AbortException, IOException, InterruptedException {


### PR DESCRIPTION
Hi Alavaro,

we recently moved to Jenkins 2 and we like the pipeline-maven-plugin very much. However we noticed that a certain build showed an odd behavior. We narrowed it down to a batch file, that behaved differently when executed "withMaven". The batch file basically looked like

    mvn.bat some:goal && some-other-cmd

Outside of withMaven both commands got executed as expected. Inside we noticed that some-other-cmd (and everything else following this line) was omitted. The problem here is that the pipeline-maven-plugin forcibly sets the MAVEN_TERMINATE_CMD variable to "on". This causes the mvn.bat script (the original apache-maven version) to call exit %errorcode% instead of exit /b %errorcode%. The trouble is, the former exit command causes the batch execution to stop completely so that some-other-cmd is never called. I see you added this as precaution because of

    http://maven.apache.org/continuum/faqs.html#how-does-continuum-detect-a-successful-build

However, I do not understand their reasoning as the errorlevel should be set correctly no matter what MAVEN_TERMINATE_CMD was set to. I suppose if somebody really needs this, they could set the variable themselves inside their script. This seems to be the suggestion in continuum FAQ anyway.

I would appreciate it if you could release a new version with this pull request included. Let me know if I understood something wrong.

Best wishes,
Jan