### PR TITLE
Add global maven settings handling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.maven;
 
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig.GlobalMavenSettingsConfigProvider;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.MavenSettingsConfigProvider;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
@@ -54,6 +55,8 @@ public class WithMavenStep extends AbstractStepImpl {
 
     private String mavenSettingsConfig;
     private String mavenSettingsFilePath;
+    private String globalMavenSettingsConfig;
+    private String globalMavenSettingsFilePath;
     private String maven;
     private String mavenOpts;
     private String jdk;
@@ -80,6 +83,24 @@ public class WithMavenStep extends AbstractStepImpl {
     @DataBoundSetter
     public void setMavenSettingsFilePath(String mavenSettingsFilePath) {
         this.mavenSettingsFilePath = mavenSettingsFilePath;
+    }
+
+    public String getGlobalMavenSettingsConfig() {
+        return globalMavenSettingsConfig;
+    }
+
+    @DataBoundSetter
+    public void setGlobalMavenSettingsConfig(String globalMavenSettingsConfig) {
+        this.globalMavenSettingsConfig = globalMavenSettingsConfig;
+    }
+
+    public String getGlobalMavenSettingsFilePath() {
+        return globalMavenSettingsFilePath;
+    }
+
+    @DataBoundSetter
+    public void setGlobalMavenSettingsFilePath(String globalMavenSettingsFilePath) {
+        this.globalMavenSettingsFilePath = globalMavenSettingsFilePath;
     }
 
     public String getMaven() {
@@ -176,6 +197,19 @@ public class WithMavenStep extends AbstractStepImpl {
         @Restricted(NoExternalUse.class) // Only for UI calls
         public ListBoxModel doFillMavenSettingsConfigItems() {
             ExtensionList<MavenSettingsConfigProvider> providers = Jenkins.getActiveInstance().getExtensionList(MavenSettingsConfigProvider.class);
+            ListBoxModel r = new ListBoxModel();
+            r.add("--- Use system default settings or file path ---",null);
+            for (ConfigProvider provider : providers) {
+                for(Config config:provider.getAllConfigs()){
+                    r.add(config.name, config.id);
+                }
+            }
+            return r;
+        }
+
+        @Restricted(NoExternalUse.class) // Only for UI calls
+        public ListBoxModel doFillGlobalMavenSettingsConfigItems() {
+            ExtensionList<GlobalMavenSettingsConfigProvider> providers = Jenkins.getActiveInstance().getExtensionList(GlobalMavenSettingsConfigProvider.class);
             ListBoxModel r = new ListBoxModel();
             r.add("--- Use system default settings or file path ---",null);
             for (ConfigProvider provider : providers) {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -591,7 +591,7 @@ public class WithMavenStepExecution extends AbstractStepExecutionImpl {
                     globalSettingsFile.write(fileContent, getComputer().getDefaultCharset().name());
                     LOGGER.log(Level.FINE, "Created global config file {0}", new Object[] { globalSettingsFile });
                 } catch (Exception e) {
-                    throw new IllegalStateException("the settings.xml could not be supplied for the current build: " + e.getMessage(), e);
+                    throw new IllegalStateException("the globalSettings.xml could not be supplied for the current build: " + e.getMessage(), e);
                 }
             } else {
                 throw new AbortException("Could not create Global Maven settings.xml config file id:" + globalSettingsConfigId + ". Content of the file is empty");

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/config.groovy
@@ -17,6 +17,14 @@ f.entry(field: 'mavenSettingsFilePath', title: _('Maven Settings File Path')) {
     f.textbox()
 }
 
+f.entry(field: 'globalMavenSettingsConfig', title: _('Global Maven Settings Config')) {
+    f.select()
+}
+
+f.entry(field: 'globalMavenSettingsFilePath', title: _('Global Maven Settings File Path')) {
+    f.textbox()
+}
+
 f.entry(field: 'mavenOpts', title: _('Maven JVM Opts')) {
     f.textbox()
 }

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-globalMavenSettingsConfig.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-globalMavenSettingsConfig.html
@@ -1,0 +1,11 @@
+<div>
+  Select a global maven settings element from File Config Provider.
+
+  The settings element in the <code>settings.xml</code> file contains elements used
+  to define values which configure Maven execution in various ways, like the <code>pom.xml</code>,
+  but should not be bundled to any specific project, or distributed to an audience.
+  These include values such as the local repository location, alternate remote repository servers,
+  and authentication information.
+  <p>
+  see also: <a href="http://maven.apache.org/settings.html"><code>settings.xml</code> reference</a>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-globalMavenSettingsFilePath.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-globalMavenSettingsFilePath.html
@@ -1,0 +1,24 @@
+<div>
+  Specify a global maven settings.xml file. The specified path can be absolute or relative to the workspace.
+  Shell-like environment variable expansions work in this field, by using the ${VARIABLE} syntax.
+  The file existence is checked on the build agent, if found, that one is used. If not found it will be checked on the master.
+	
+  The settings element in the <code>settings.xml</code> file contains elements used
+  to define values which configure Maven execution in various ways, like the <code>pom.xml</code>,
+  but should not be bundled to any specific project, or distributed to an audience.
+  These include values such as the local repository location, alternate remote repository servers,
+  and authentication information.
+  <br>
+  There are two locations where a <code>settings.xml</code> file per default may live:
+
+  <ul>
+    <li>The Maven install - default: <code>$M2_HOME/conf/settings.xml</code></li>
+    <li>A user's install  - default: <code>${user.home}/.m2/settings.xml</code></li>
+  </ul>
+
+  The former settings.xml are also called global settings, the latter settings.xml are
+  referred to as user settings. If both files exists, their contents gets merged,
+  with the user-specific settings.xml being dominant.
+  <p>
+  see also: <a href="http://maven.apache.org/settings.html"><code>settings.xml</code> reference</a>
+</div>


### PR DESCRIPTION
Hi,

We use a lot global settings in your Jenkins to store platform wide settings such as http proxy. Users use maven setting to store project specific settings.
So we need to be able to configure both.

Best wishes,
Julien
