### PR TITLE
JENKINS-39916 update config-file-provider plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>pipeline-maven</artifactId>
-  <version>0.3-SNAPSHOT</version>
+  <version>0.3</version>
   <packaging>hpi</packaging>
 
   <name>Pipeline Maven Integration Plugin</name>
@@ -62,7 +62,7 @@
     <connection>scm:git:git://github.com/jenkinsci/pipeline-maven-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-maven-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/pipeline-maven-plugin</url>
-    <tag>HEAD</tag>
+    <tag>pipeline-maven-0.3</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>config-file-provider</artifactId>
-      <version>2.11</version>
+      <version>2.14.2-beta</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>config-file-provider</artifactId>
-      <version>2.14.2-beta</version>
+      <version>2.15.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>pipeline-maven</artifactId>
-  <version>0.3</version>
+  <version>0.4-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Pipeline Maven Integration Plugin</name>
@@ -62,7 +62,7 @@
     <connection>scm:git:git://github.com/jenkinsci/pipeline-maven-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-maven-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/pipeline-maven-plugin</url>
-    <tag>pipeline-maven-0.3</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
@@ -24,14 +24,17 @@
 
 package org.jenkinsci.plugins.pipeline.maven;
 
+import hudson.model.ItemGroup;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigFiles;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig.GlobalMavenSettingsConfigProvider;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.MavenSettingsConfigProvider;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -195,27 +198,21 @@ public class WithMavenStep extends AbstractStepImpl {
         }
         
         @Restricted(NoExternalUse.class) // Only for UI calls
-        public ListBoxModel doFillMavenSettingsConfigItems() {
-            ExtensionList<MavenSettingsConfigProvider> providers = Jenkins.getActiveInstance().getExtensionList(MavenSettingsConfigProvider.class);
+        public ListBoxModel doFillMavenSettingsConfigItems(@AncestorInPath ItemGroup context) {
             ListBoxModel r = new ListBoxModel();
             r.add("--- Use system default settings or file path ---",null);
-            for (ConfigProvider provider : providers) {
-                for(Config config:provider.getAllConfigs()){
-                    r.add(config.name, config.id);
-                }
+            for (Config config : ConfigFiles.getConfigsInContext(context, MavenSettingsConfigProvider.class)) {
+                r.add(config.name, config.id);
             }
             return r;
         }
 
         @Restricted(NoExternalUse.class) // Only for UI calls
-        public ListBoxModel doFillGlobalMavenSettingsConfigItems() {
-            ExtensionList<GlobalMavenSettingsConfigProvider> providers = Jenkins.getActiveInstance().getExtensionList(GlobalMavenSettingsConfigProvider.class);
+        public ListBoxModel doFillGlobalMavenSettingsConfigItems(@AncestorInPath ItemGroup context) {
             ListBoxModel r = new ListBoxModel();
             r.add("--- Use system default settings or file path ---",null);
-            for (ConfigProvider provider : providers) {
-                for(Config config:provider.getAllConfigs()){
-                    r.add(config.name, config.id);
-                }
+            for (Config config : ConfigFiles.getConfigsInContext(context, GlobalMavenSettingsConfigProvider.class)) {
+                r.add(config.name, config.id);
             }
             return r;
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -45,6 +45,7 @@ import javax.annotation.Nonnull;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigFiles;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig;
 import org.jenkinsci.plugins.configfiles.maven.security.CredentialsHelper;
@@ -517,7 +518,16 @@ public class WithMavenStepExecution extends AbstractStepExecutionImpl {
      * @throws AbortException in case of error
      */
     private void settingsFromConfig(String settingsConfigId, FilePath settingsFile) throws AbortException {
-        Config c = Config.getByIdOrNull(settingsConfigId);
+
+        Config c = null;
+        Executor executor = Executor.currentExecutor();
+        if (executor != null) {
+            Queue.Executable currentExecutable = executor.getCurrentExecutable();
+            if (currentExecutable != null) {
+                c = ConfigFiles.getByIdOrNull((Run<?, ?>) currentExecutable, settingsConfigId);
+            }
+        }
+
         if (c != null) {
             MavenSettingsConfig config;
             if (c instanceof MavenSettingsConfig) {
@@ -564,7 +574,16 @@ public class WithMavenStepExecution extends AbstractStepExecutionImpl {
      * @throws AbortException in case of error
      */
     private void globalSettingsFromConfig(String globalSettingsConfigId, FilePath globalSettingsFile) throws AbortException {
-        Config c = Config.getByIdOrNull(globalSettingsConfigId);
+
+        Config c = null;
+        Executor executor = Executor.currentExecutor();
+        if (executor != null) {
+            Queue.Executable currentExecutable = executor.getCurrentExecutable();
+            if (currentExecutable != null) {
+                c = ConfigFiles.getByIdOrNull((Run<?, ?>) currentExecutable, globalSettingsConfigId);
+            }
+        }
+
         if (c != null) {
             GlobalMavenSettingsConfig config;
             if (c instanceof GlobalMavenSettingsConfig) {


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-39916

The new version of the config-file-provider supports configfiles on folder levels (also nested folders). This PR adds support for the newest version of the config-file-provider.

It updates dependency to the latest (still beta) version of the config-file-provider plugin. The beta version of the config-file-provider plugin is available in the experimental update center.

Please have a look at this PR and let me know it is OK - I will prepare the release of the config-file-provider plugin soon. (...there are multiple plugins I have to update)
