### PR TITLE
WIP [JENKINS-40665] Add support for Maven settings.xml and Maven global settings.xml defined in Jenkins global configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>config-file-provider</artifactId>
-      <version>2.11</version>
+      <version>2.14.2-beta</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,12 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.11</version>
+    <version>2.19</version>
+    <relativePath />
   </parent>
 
   <artifactId>pipeline-maven</artifactId>
-  <version>0.4-SNAPSHOT</version>
+  <version>0.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Pipeline Maven Integration Plugin</name>
@@ -66,7 +67,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.642.4</jenkins.version>
+    <jenkins.version>2.38-SNAPSHOT</jenkins.version>
   </properties>
 
   <repositories>
@@ -85,14 +86,128 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.8</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.2</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>config-file-provider</artifactId>
-      <version>2.14.2-beta</version>
+      <version>2.15.2-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-aggregator</artifactId>
+      <version>2.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <version>2.8</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-scm-step</artifactId>
+      <version>2.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.23</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.9</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <version>2.5</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.6</version>
+      <classifier>tests</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>2.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>2.9</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>subversion</artifactId>
+      <version>2.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <version>2.6.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git-client</artifactId>
+      <version>1.21.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>token-macro</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mailer</artifactId>
+      <version>1.18</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.19</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
@@ -24,14 +24,17 @@
 
 package org.jenkinsci.plugins.pipeline.maven;
 
+import hudson.model.ItemGroup;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigFiles;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig.GlobalMavenSettingsConfigProvider;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.MavenSettingsConfigProvider;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -195,27 +198,21 @@ public class WithMavenStep extends AbstractStepImpl {
         }
         
         @Restricted(NoExternalUse.class) // Only for UI calls
-        public ListBoxModel doFillMavenSettingsConfigItems() {
-            ExtensionList<MavenSettingsConfigProvider> providers = Jenkins.getActiveInstance().getExtensionList(MavenSettingsConfigProvider.class);
+        public ListBoxModel doFillMavenSettingsConfigItems(@AncestorInPath ItemGroup context) {
             ListBoxModel r = new ListBoxModel();
             r.add("--- Use system default settings or file path ---",null);
-            for (ConfigProvider provider : providers) {
-                for(Config config:provider.getAllConfigs()){
-                    r.add(config.name, config.id);
-                }
+            for (Config config : ConfigFiles.getConfigsInContext(context, MavenSettingsConfigProvider.class)) {
+                r.add(config.name, config.id);
             }
             return r;
         }
 
         @Restricted(NoExternalUse.class) // Only for UI calls
-        public ListBoxModel doFillGlobalMavenSettingsConfigItems() {
-            ExtensionList<GlobalMavenSettingsConfigProvider> providers = Jenkins.getActiveInstance().getExtensionList(GlobalMavenSettingsConfigProvider.class);
+        public ListBoxModel doFillGlobalMavenSettingsConfigItems(@AncestorInPath ItemGroup context) {
             ListBoxModel r = new ListBoxModel();
             r.add("--- Use system default settings or file path ---",null);
-            for (ConfigProvider provider : providers) {
-                for(Config config:provider.getAllConfigs()){
-                    r.add(config.name, config.id);
-                }
+            for (Config config : ConfigFiles.getConfigsInContext(context, GlobalMavenSettingsConfigProvider.class)) {
+                r.add(config.name, config.id);
             }
             return r;
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -519,17 +519,7 @@ public class WithMavenStepExecution extends AbstractStepExecutionImpl {
      */
     private void settingsFromConfig(String settingsConfigId, FilePath settingsFile) throws AbortException {
 
-        Executor executor = Executor.currentExecutor();
-        if (executor == null) {
-            throw new AbortException("Executor.currentExecutor() is NULL, probably not desired");
-        }
-
-        Queue.Executable currentExecutable = executor.getCurrentExecutable();
-        if (currentExecutable == null) {
-            throw new AbortException("Executor.currentExecutor().getCurrentExecutable() is NULL, probably not desired");
-        }
-
-        Config c = ConfigFiles.getByIdOrNull((Run<?, ?>) currentExecutable, settingsConfigId);
+        Config c = ConfigFiles.getByIdOrNull(build, settingsConfigId);
         if (c == null) {
             throw new AbortException("Could not find the Maven settings.xml config file id:" + settingsConfigId + ". Make sure it exists on Managed Files");
         }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -567,48 +567,39 @@ public class WithMavenStepExecution extends AbstractStepExecutionImpl {
      */
     private void globalSettingsFromConfig(String globalSettingsConfigId, FilePath globalSettingsFile) throws AbortException {
 
-        Config c = null;
-        Executor executor = Executor.currentExecutor();
-        if (executor != null) {
-            Queue.Executable currentExecutable = executor.getCurrentExecutable();
-            if (currentExecutable != null) {
-                c = ConfigFiles.getByIdOrNull((Run<?, ?>) currentExecutable, globalSettingsConfigId);
-            }
+        Config c = ConfigFiles.getByIdOrNull(build, globalSettingsConfigId);
+        if (c == null) {
+            throw new AbortException("Could not find the Maven global settings.xml config file id:" + globalSettingsFile + ". Make sure it exists on Managed Files");
+        }
+        if (StringUtils.isBlank(c.content)) {
+            throw new AbortException("Could not create Maven global settings.xml config file id:" + globalSettingsFile + ". Content of the file is empty");
         }
 
-        if (c != null) {
-            GlobalMavenSettingsConfig config;
-            if (c instanceof GlobalMavenSettingsConfig) {
-                config = (GlobalMavenSettingsConfig) c;
-            } else {
-                config = new GlobalMavenSettingsConfig(c.id, c.name, c.comment, c.content, MavenSettingsConfig.isReplaceAllDefault, null);
-            }
-
-            final Boolean isReplaceAll = config.getIsReplaceAll();
-            console.println("Using global settings config with name " + config.name);
-            console.println("Replacing all maven server entries not found in credentials list is " + isReplaceAll);
-            if (StringUtils.isNotBlank(config.content)) {
-                try {
-                    String fileContent = config.content;
-
-                    final List<ServerCredentialMapping> serverCredentialMappings = config.getServerCredentialMappings();
-                    final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(build, serverCredentialMappings);
-
-                    if (!resolvedCredentials.isEmpty()) {
-                        List<String> tempFiles = new ArrayList<String>();
-                        fileContent = CredentialsHelper.fillAuthentication(fileContent, isReplaceAll, resolvedCredentials, tempBinDir, tempFiles);
-                    }
-
-                    globalSettingsFile.write(fileContent, getComputer().getDefaultCharset().name());
-                    LOGGER.log(Level.FINE, "Created global config file {0}", new Object[] { globalSettingsFile });
-                } catch (Exception e) {
-                    throw new IllegalStateException("the globalSettings.xml could not be supplied for the current build: " + e.getMessage(), e);
-                }
-            } else {
-                throw new AbortException("Could not create Global Maven settings.xml config file id:" + globalSettingsConfigId + ". Content of the file is empty");
-            }
+        GlobalMavenSettingsConfig config;
+        if (c instanceof GlobalMavenSettingsConfig) {
+            config = (GlobalMavenSettingsConfig) c;
         } else {
-            throw new AbortException("Could not find the Global Maven settings.xml config file id:" + globalSettingsConfigId + ". Make sure it exists on Managed Files");
+            config = new GlobalMavenSettingsConfig(c.id, c.name, c.comment, c.content, MavenSettingsConfig.isReplaceAllDefault, null);
+        }
+
+        final Boolean isReplaceAll = config.getIsReplaceAll();
+        console.println("Using global settings config with name " + config.name);
+        console.println("Replacing all maven server entries not found in credentials list is " + isReplaceAll);
+        try {
+            String fileContent = config.content;
+
+            final List<ServerCredentialMapping> serverCredentialMappings = config.getServerCredentialMappings();
+            final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(build, serverCredentialMappings);
+
+            if (!resolvedCredentials.isEmpty()) {
+                List<String> tempFiles = new ArrayList<String>();
+                fileContent = CredentialsHelper.fillAuthentication(fileContent, isReplaceAll, resolvedCredentials, tempBinDir, tempFiles);
+            }
+
+            globalSettingsFile.write(fileContent, getComputer().getDefaultCharset().name());
+            LOGGER.log(Level.FINE, "Created global config file {0}", new Object[]{globalSettingsFile});
+        } catch (Exception e) {
+            throw new IllegalStateException("the globalSettings.xml could not be supplied for the current build: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -45,6 +45,7 @@ import javax.annotation.Nonnull;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigFiles;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig;
 import org.jenkinsci.plugins.configfiles.maven.security.CredentialsHelper;
@@ -517,7 +518,16 @@ public class WithMavenStepExecution extends AbstractStepExecutionImpl {
      * @throws AbortException in case of error
      */
     private void settingsFromConfig(String settingsConfigId, FilePath settingsFile) throws AbortException {
-        Config c = Config.getByIdOrNull(settingsConfigId);
+
+        Config c = null;
+        Executor executor = Executor.currentExecutor();
+        if (executor != null) {
+            Queue.Executable currentExecutable = executor.getCurrentExecutable();
+            if (currentExecutable != null) {
+                c = ConfigFiles.getByIdOrNull((Run<?, ?>) currentExecutable, settingsConfigId);
+            }
+        }
+
         if (c != null) {
             MavenSettingsConfig config;
             if (c instanceof MavenSettingsConfig) {
@@ -564,7 +574,16 @@ public class WithMavenStepExecution extends AbstractStepExecutionImpl {
      * @throws AbortException in case of error
      */
     private void globalSettingsFromConfig(String globalSettingsConfigId, FilePath globalSettingsFile) throws AbortException {
-        Config c = Config.getByIdOrNull(globalSettingsConfigId);
+
+        Config c = null;
+        Executor executor = Executor.currentExecutor();
+        if (executor != null) {
+            Queue.Executable currentExecutable = executor.getCurrentExecutable();
+            if (currentExecutable != null) {
+                c = ConfigFiles.getByIdOrNull((Run<?, ?>) currentExecutable, globalSettingsConfigId);
+            }
+        }
+
         if (c != null) {
             GlobalMavenSettingsConfig config;
             if (c instanceof GlobalMavenSettingsConfig) {


### PR DESCRIPTION
Support Maven Settings Provider and Maven Global Settings Provider for pipeline and make it work with `withMaven(){}`

See
* [JENKINS-40665 Maven SettingsProvider and GlobalSettingsProvider should support Pipeline jobs](https://issues.jenkins-ci.org/browse/JENKINS-40665)
* [JENKINS-39407 Use system default Maven, Maven Settings if not specified](https://issues.jenkins-ci.org/browse/JENKINS-39407)
* PR https://github.com/jenkinsci/jenkins/pull/2678
* PR https://github.com/jenkinsci/pipeline-maven-plugin/pull/15
* PR https://github.com/jenkinsci/config-file-provider-plugin/pull/25