### PR TITLE
[JENKINS-42175] Support temporary/experimental marker files to disable reporters (archive-artifacts, junit, findbugs…).

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenSpyLogProcessor.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenSpyLogProcessor.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.pipeline.maven;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
+import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
 import hudson.plugins.findbugs.FindBugsReporter;
 import hudson.tasks.Fingerprinter;
@@ -34,6 +35,7 @@ import jenkins.model.ArtifactManager;
 import jenkins.util.BuildListenerAdapter;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pipeline.maven.reporters.FindbugsAnalysisReporter;
+import org.jenkinsci.plugins.pipeline.maven.reporters.GeneratedArtifactsReporter;
 import org.jenkinsci.plugins.pipeline.maven.reporters.JunitTestsReporter;
 import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -41,6 +43,7 @@ import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -75,13 +78,12 @@ public class MavenSpyLogProcessor implements Serializable {
 
     public void processMavenSpyLogs(StepContext context, FilePath mavenSpyLogFolder) throws IOException, InterruptedException {
         FilePath[] mavenSpyLogsList = mavenSpyLogFolder.list("maven-spy-*.log");
+        LOGGER.log(Level.FINE, "Found {0} maven execution reports in {1}", new Object[]{mavenSpyLogsList.length, mavenSpyLogFolder});
 
-        Run run = context.get(Run.class);
-        ArtifactManager artifactManager = run.pickArtifactManager();
-        Launcher launcher = context.get(Launcher.class);
         TaskListener listener = context.get(TaskListener.class);
         if (listener == null) {
-            LOGGER.warning("listener is NULL"); // TODO
+            LOGGER.warning("TaskListener is NULL, default to stderr");
+            listener = new StreamBuildListener((OutputStream) System.err);
         }
         FilePath workspace = context.get(FilePath.class); // TODO check that it's the good workspace
 
@@ -90,55 +92,28 @@ public class MavenSpyLogProcessor implements Serializable {
                 LOGGER.log(Level.INFO, "Evaluate Maven Spy logs: " + mavenSpyLogs.getRemote());
                 Element mavenSpyLogsElt = documentBuilder.parse(mavenSpyLogs.read()).getDocumentElement();
 
-                List<MavenArtifact> mavenArtifacts = listArtifacts(mavenSpyLogsElt);
-                List<MavenArtifact> attachedMavenArtifacts = listAttachedArtifacts(mavenSpyLogsElt);
-                List<MavenArtifact> join = new ArrayList<>();
-                join.addAll(mavenArtifacts);
-                join.addAll(attachedMavenArtifacts);
-
-
-                Map<String, String> artifactsToArchive = new HashMap<>(); // artifactPathInArchiveZone -> artifactPathInWorkspace
-                Map<String, String> artifactsToFingerPrint = new HashMap<>(); // artifactPathInArchiveZone -> artifactMd5
-                for (MavenArtifact mavenArtifact : join) {
-                    if (StringUtils.isEmpty(mavenArtifact.file)) {
-                        listener.error("Can't archive maven artifact with no file attached: " + mavenArtifact);
-                        continue;
-                    }
-
-                    String artifactPathInArchiveZone =
-                            mavenArtifact.groupId.replace('.', '/') + "/" +
-                                    mavenArtifact.artifactId + "/" +
-                                    mavenArtifact.version + "/" +
-                                    mavenArtifact.getFileName();
-
-                    String artifactPathInWorkspace = XmlUtils.getPathInWorkspace(mavenArtifact.file, workspace);
-
-                    if (StringUtils.isEmpty(artifactPathInWorkspace)) {
-                        listener.error("Invalid path in the workspace (" + workspace.getRemote() + ") for artifact " + mavenArtifact);
-                    } else {
-                        listener.getLogger().println("Archive " + mavenArtifact + " under " + artifactPathInArchiveZone);
-                        artifactsToArchive.put(artifactPathInArchiveZone, artifactPathInWorkspace);
-                        FilePath artifactFilePath = new FilePath(workspace, artifactPathInWorkspace);
-                        String artifactDigest = artifactFilePath.digest();
-                        listener.getLogger().println("Archive " + mavenArtifact + " under " + artifactPathInArchiveZone + " has digest " + artifactDigest);
-                        artifactsToFingerPrint.put(artifactPathInArchiveZone, artifactDigest);
-                    }
-                }
-
-                // ARCHIVE GENERATED MAVEN ARTIFACT
-                // see org.jenkinsci.plugins.workflow.steps.ArtifactArchiverStepExecution#run
-                artifactManager.archive(workspace, launcher, new BuildListenerAdapter(listener), artifactsToArchive);
-
-                // FINGERPRINT GENERATED MAVEN ARTIFACT
-                Fingerprinter.FingerprintAction fingerprintAction = run.getAction(Fingerprinter.FingerprintAction.class);
-                if (fingerprintAction == null) {
-                    run.addAction(new Fingerprinter.FingerprintAction(run, artifactsToFingerPrint));
+                FilePath skipArchiveArtifactsFile = workspace.child(".skip-archive-generated-artifacts");
+                if (skipArchiveArtifactsFile.exists()) {
+                    listener.getLogger().println("Skip archiving of generated artifacts, file '" + skipArchiveArtifactsFile + "' found in workspace");
                 } else {
-                    fingerprintAction.add(artifactsToFingerPrint);
+                    LOGGER.log(Level.FINE, "Look for generated artifacts to archive, file {0} NOT found in workspace", skipArchiveArtifactsFile);
+                    new GeneratedArtifactsReporter().process(context, mavenSpyLogsElt);
                 }
 
-                new JunitTestsReporter().process(context, mavenSpyLogsElt);
-                new FindbugsAnalysisReporter().process(context, mavenSpyLogsElt);
+                FilePath skipJunitFile = workspace.child(".skip-publish-junit-results");
+                if (skipJunitFile.exists()) {
+                    listener.getLogger().println("Skip publishing of JUnit results, file '" + skipJunitFile + "' found in workspace");
+                } else {
+                    LOGGER.log(Level.FINE, "Look for JUnit results to publish, file {0} NOT found in workspace", skipJunitFile);
+                    new JunitTestsReporter().process(context, mavenSpyLogsElt);
+                }
+                FilePath skipFindbugsFile = workspace.child(".skip-publish-findbugs-results");
+                if (skipFindbugsFile.exists()) {
+                    listener.getLogger().println("Skip publishing of FindBugs results, file '" + skipFindbugsFile + "' found in workspace");
+                } else {
+                    LOGGER.log(Level.FINE, "Look for Findbugs results to publish, file {0} NOT found in workspace", skipFindbugsFile);
+                    new FindbugsAnalysisReporter().process(context, mavenSpyLogsElt);
+                }
             } catch (SAXException e) {
                 listener.error("Exception parsing maven spy logs " + mavenSpyLogs + ", ignore file");
                 e.printStackTrace(listener.getLogger());
@@ -146,119 +121,13 @@ public class MavenSpyLogProcessor implements Serializable {
         }
     }
 
-    /*
-    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-01-31 00:15:42.255">
-    <project artifactId="pipeline-maven" groupId="org.jenkins-ci.plugins" name="Pipeline Maven Integration Plugin" version="0.6-SNAPSHOT"/>
-    <no-execution-found/>
-    <artifact groupId="org.jenkins-ci.plugins" artifactId="pipeline-maven" id="org.jenkins-ci.plugins:pipeline-maven:hpi:0.6-SNAPSHOT" type="hpi" version="0.6-SNAPSHOT">
-      <file>/Users/cleclerc/git/jenkins/pipeline-maven-plugin/target/pipeline-maven.hpi</file>
-    </artifact>
-    <attachedArtifacts>
-      <artifact groupId="org.jenkins-ci.plugins" artifactId="pipeline-maven" id="org.jenkins-ci.plugins:pipeline-maven:jar:0.6-SNAPSHOT" type="jar" version="0.6-SNAPSHOT">
-        <file>/Users/cleclerc/git/jenkins/pipeline-maven-plugin/target/pipeline-maven.jar</file>
-      </artifact>
-    </attachedArtifacts>
-  </ExecutionEvent>
-     */
 
-    /**
-     * @param mavenSpyLogs Root XML element
-     * @return list of {@link MavenArtifact}
-     */
-    /*
-
-    <artifact artifactId="demo-pom" groupId="com.example" id="com.example:demo-pom:pom:0.0.1-SNAPSHOT" type="pom" version="0.0.1-SNAPSHOT">
-      <file/>
-    </artifact>
-     */
-    @Nonnull
-    public List<MavenArtifact> listArtifacts(Element mavenSpyLogs) {
-
-        List<MavenArtifact> result = new ArrayList<>();
-
-        for (Element projectSucceededElt : XmlUtils.getExecutionEvents(mavenSpyLogs, "ProjectSucceeded")) {
-
-            Element projectElt = XmlUtils.getUniqueChildElement(projectSucceededElt, "project");
-            MavenArtifact projectArtifact = XmlUtils.newMavenArtifact(projectElt);
-
-            MavenArtifact pomArtifact = new MavenArtifact();
-            pomArtifact.groupId = projectArtifact.groupId;
-            pomArtifact.artifactId = projectArtifact.artifactId;
-            pomArtifact.version = projectArtifact.version;
-            pomArtifact.type = "pom";
-            pomArtifact.file = projectElt.getAttribute("file");
-
-            result.add(pomArtifact);
-
-            Element artifactElt = XmlUtils.getUniqueChildElement(projectSucceededElt, "artifact");
-            MavenArtifact mavenArtifact = XmlUtils.newMavenArtifact(artifactElt);
-            if ("pom".equals(mavenArtifact.type)) {
-                // NO file is generated by Maven for pom projects, skip
-                continue;
-            }
-
-            Element fileElt = XmlUtils.getUniqueChildElementOrNull(artifactElt, "file");
-            if (fileElt.getTextContent() == null || fileElt.getTextContent().isEmpty()) {
-                LOGGER.log(Level.WARNING, "listArtifacts: Project " + projectArtifact + ":  no associated file found for " + mavenArtifact + " in " + XmlUtils.toString(artifactElt));
-            }
-            mavenArtifact.file = StringUtils.trim(fileElt.getTextContent());
-            result.add(mavenArtifact);
-        }
-
-        return result;
-    }
-
-
-    /**
-     * @param mavenSpyLogs Root XML element
-     * @return list of {@link FilePath#getRemote()}
-     */
-    /*
-    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-01-31 00:15:42.255">
-    <project artifactId="pipeline-maven" groupId="org.jenkins-ci.plugins" name="Pipeline Maven Integration Plugin" version="0.6-SNAPSHOT"/>
-    <no-execution-found/>
-    <artifact groupId="org.jenkins-ci.plugins" artifactId="pipeline-maven" id="org.jenkins-ci.plugins:pipeline-maven:hpi:0.6-SNAPSHOT" type="hpi" version="0.6-SNAPSHOT">
-      <file>/Users/cleclerc/git/jenkins/pipeline-maven-plugin/target/pipeline-maven.hpi</file>
-    </artifact>
-    <attachedArtifacts>
-      <artifact groupId="org.jenkins-ci.plugins" artifactId="pipeline-maven" id="org.jenkins-ci.plugins:pipeline-maven:jar:0.6-SNAPSHOT" type="jar" version="0.6-SNAPSHOT">
-        <file>/Users/cleclerc/git/jenkins/pipeline-maven-plugin/target/pipeline-maven.jar</file>
-      </artifact>
-    </attachedArtifacts>
-  </ExecutionEvent>
-     */
-    @Nonnull
-    public List<MavenArtifact> listAttachedArtifacts(Element mavenSpyLogs) {
-        List<MavenArtifact> result = new ArrayList<>();
-
-        for (Element projectSucceededElt : XmlUtils.getExecutionEvents(mavenSpyLogs, "ProjectSucceeded")) {
-
-            Element projectElt = XmlUtils.getUniqueChildElement(projectSucceededElt, "project");
-            MavenArtifact projectArtifact = XmlUtils.newMavenArtifact(projectElt);
-
-            Element attachedArtifactsParentElt = XmlUtils.getUniqueChildElement(projectSucceededElt, "attachedArtifacts");
-            List<Element> attachedArtifactsElts = XmlUtils.getChildrenElements(attachedArtifactsParentElt, "artifact");
-            for (Element attachedArtifactElt : attachedArtifactsElts) {
-                MavenArtifact attachedMavenArtifact = XmlUtils.newMavenArtifact(attachedArtifactElt);
-
-                Element fileElt = XmlUtils.getUniqueChildElementOrNull(attachedArtifactElt, "file");
-                if (fileElt.getTextContent() == null || fileElt.getTextContent().isEmpty()) {
-                    LOGGER.log(Level.WARNING, "Project " + projectArtifact + ", no associated file found for attached artifact " + attachedMavenArtifact + " in " + XmlUtils.toString(attachedArtifactElt));
-                }
-                attachedMavenArtifact.file = StringUtils.trim(fileElt.getTextContent());
-                result.add(attachedMavenArtifact);
-            }
-
-
-        }
-        return result;
-    }
 
     public static class MavenArtifact {
         public String groupId, artifactId, version, type, classifier;
         public String file;
 
-        String getFileName() {
+        public String getFileName() {
             return artifactId + "-" + version + ((classifier == null || classifier.isEmpty()) ? "" : "-" + classifier) + "." + type;
         }
 

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/FindbugsAnalysisReporter.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/FindbugsAnalysisReporter.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.pipeline.maven.reporters;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
+import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
 import hudson.plugins.findbugs.FindBugsPublisher;
 import hudson.tasks.junit.JUnitResultArchiver;
@@ -37,6 +38,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.w3c.dom.Element;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -154,7 +156,8 @@ public class FindbugsAnalysisReporter implements ResultsReporter {
 
         TaskListener listener = context.get(TaskListener.class);
         if (listener == null) {
-            LOGGER.warning("listener is NULL"); // TODO
+            LOGGER.warning("TaskListener is NULL, default to stderr");
+            listener = new StreamBuildListener((OutputStream) System.err);
         }
         FilePath workspace = context.get(FilePath.class); // TODO check that it's the good workspace
         Run run = context.get(Run.class);

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/GeneratedArtifactsReporter.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/GeneratedArtifactsReporter.java
@@ -1,0 +1,203 @@
+package org.jenkinsci.plugins.pipeline.maven.reporters;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.StreamBuildListener;
+import hudson.model.TaskListener;
+import hudson.tasks.Fingerprinter;
+import jenkins.model.ArtifactManager;
+import jenkins.util.BuildListenerAdapter;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor;
+import org.jenkinsci.plugins.pipeline.maven.ResultsReporter;
+import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+public class GeneratedArtifactsReporter implements ResultsReporter{
+    private static final Logger LOGGER = Logger.getLogger(MavenSpyLogProcessor.class.getName());
+
+    @Override
+    public void process(@Nonnull StepContext context, @Nonnull Element mavenSpyLogsElt) throws IOException, InterruptedException {
+
+        Run run = context.get(Run.class);
+        ArtifactManager artifactManager = run.pickArtifactManager();
+        Launcher launcher = context.get(Launcher.class);
+        TaskListener listener = context.get(TaskListener.class);
+        if (listener == null) {
+            LOGGER.warning("TaskListener is NULL, default to stderr");
+            listener = new StreamBuildListener((OutputStream) System.err);
+        }
+        FilePath workspace = context.get(FilePath.class); // TODO check that it's the good workspace
+
+        List<MavenSpyLogProcessor.MavenArtifact> mavenArtifacts = listArtifacts(mavenSpyLogsElt);
+        List<MavenSpyLogProcessor.MavenArtifact> attachedMavenArtifacts = listAttachedArtifacts(mavenSpyLogsElt);
+        List<MavenSpyLogProcessor.MavenArtifact> join = new ArrayList<>();
+        join.addAll(mavenArtifacts);
+        join.addAll(attachedMavenArtifacts);
+
+
+        Map<String, String> artifactsToArchive = new HashMap<>(); // artifactPathInArchiveZone -> artifactPathInWorkspace
+        Map<String, String> artifactsToFingerPrint = new HashMap<>(); // artifactPathInArchiveZone -> artifactMd5
+        for (MavenSpyLogProcessor.MavenArtifact mavenArtifact : join) {
+            if (StringUtils.isEmpty(mavenArtifact.file)) {
+                listener.error("Can't archive maven artifact with no file attached: " + mavenArtifact);
+                continue;
+            }
+
+            String artifactPathInArchiveZone =
+                    mavenArtifact.groupId.replace('.', '/') + "/" +
+                            mavenArtifact.artifactId + "/" +
+                            mavenArtifact.version + "/" +
+                            mavenArtifact.getFileName();
+
+            String artifactPathInWorkspace = XmlUtils.getPathInWorkspace(mavenArtifact.file, workspace);
+
+            if (StringUtils.isEmpty(artifactPathInWorkspace)) {
+                listener.error("Invalid path in the workspace (" + workspace.getRemote() + ") for artifact " + mavenArtifact);
+            } else {
+                listener.getLogger().println("Archive " + mavenArtifact + " under " + artifactPathInArchiveZone);
+                artifactsToArchive.put(artifactPathInArchiveZone, artifactPathInWorkspace);
+                FilePath artifactFilePath = new FilePath(workspace, artifactPathInWorkspace);
+                String artifactDigest = artifactFilePath.digest();
+                listener.getLogger().println("Archive " + mavenArtifact + " under " + artifactPathInArchiveZone + " has digest " + artifactDigest);
+                artifactsToFingerPrint.put(artifactPathInArchiveZone, artifactDigest);
+            }
+        }
+
+        // ARCHIVE GENERATED MAVEN ARTIFACT
+        // see org.jenkinsci.plugins.workflow.steps.ArtifactArchiverStepExecution#run
+        artifactManager.archive(workspace, launcher, new BuildListenerAdapter(listener), artifactsToArchive);
+
+        // FINGERPRINT GENERATED MAVEN ARTIFACT
+        Fingerprinter.FingerprintAction fingerprintAction = run.getAction(Fingerprinter.FingerprintAction.class);
+        if (fingerprintAction == null) {
+            run.addAction(new Fingerprinter.FingerprintAction(run, artifactsToFingerPrint));
+        } else {
+            fingerprintAction.add(artifactsToFingerPrint);
+        }
+    }
+
+       /*
+    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-01-31 00:15:42.255">
+    <project artifactId="pipeline-maven" groupId="org.jenkins-ci.plugins" name="Pipeline Maven Integration Plugin" version="0.6-SNAPSHOT"/>
+    <no-execution-found/>
+    <artifact groupId="org.jenkins-ci.plugins" artifactId="pipeline-maven" id="org.jenkins-ci.plugins:pipeline-maven:hpi:0.6-SNAPSHOT" type="hpi" version="0.6-SNAPSHOT">
+      <file>/Users/cleclerc/git/jenkins/pipeline-maven-plugin/target/pipeline-maven.hpi</file>
+    </artifact>
+    <attachedArtifacts>
+      <artifact groupId="org.jenkins-ci.plugins" artifactId="pipeline-maven" id="org.jenkins-ci.plugins:pipeline-maven:jar:0.6-SNAPSHOT" type="jar" version="0.6-SNAPSHOT">
+        <file>/Users/cleclerc/git/jenkins/pipeline-maven-plugin/target/pipeline-maven.jar</file>
+      </artifact>
+    </attachedArtifacts>
+  </ExecutionEvent>
+     */
+
+    /**
+     * @param mavenSpyLogs Root XML element
+     * @return list of {@link MavenSpyLogProcessor.MavenArtifact}
+     */
+    /*
+
+    <artifact artifactId="demo-pom" groupId="com.example" id="com.example:demo-pom:pom:0.0.1-SNAPSHOT" type="pom" version="0.0.1-SNAPSHOT">
+      <file/>
+    </artifact>
+     */
+    @Nonnull
+    public List<MavenSpyLogProcessor.MavenArtifact> listArtifacts(Element mavenSpyLogs) {
+
+        List<MavenSpyLogProcessor.MavenArtifact> result = new ArrayList<>();
+
+        for (Element projectSucceededElt : XmlUtils.getExecutionEvents(mavenSpyLogs, "ProjectSucceeded")) {
+
+            Element projectElt = XmlUtils.getUniqueChildElement(projectSucceededElt, "project");
+            MavenSpyLogProcessor.MavenArtifact projectArtifact = XmlUtils.newMavenArtifact(projectElt);
+
+            MavenSpyLogProcessor.MavenArtifact pomArtifact = new MavenSpyLogProcessor.MavenArtifact();
+            pomArtifact.groupId = projectArtifact.groupId;
+            pomArtifact.artifactId = projectArtifact.artifactId;
+            pomArtifact.version = projectArtifact.version;
+            pomArtifact.type = "pom";
+            pomArtifact.file = projectElt.getAttribute("file");
+
+            result.add(pomArtifact);
+
+            Element artifactElt = XmlUtils.getUniqueChildElement(projectSucceededElt, "artifact");
+            MavenSpyLogProcessor.MavenArtifact mavenArtifact = XmlUtils.newMavenArtifact(artifactElt);
+            if ("pom".equals(mavenArtifact.type)) {
+                // NO file is generated by Maven for pom projects, skip
+                continue;
+            }
+
+            Element fileElt = XmlUtils.getUniqueChildElementOrNull(artifactElt, "file");
+            if (fileElt.getTextContent() == null || fileElt.getTextContent().isEmpty()) {
+                LOGGER.log(Level.WARNING, "listArtifacts: Project " + projectArtifact + ":  no associated file found for " + mavenArtifact + " in " + XmlUtils.toString(artifactElt));
+            }
+            mavenArtifact.file = StringUtils.trim(fileElt.getTextContent());
+            result.add(mavenArtifact);
+        }
+
+        return result;
+    }
+
+
+    /**
+     * @param mavenSpyLogs Root XML element
+     * @return list of {@link FilePath#getRemote()}
+     */
+    /*
+    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-01-31 00:15:42.255">
+    <project artifactId="pipeline-maven" groupId="org.jenkins-ci.plugins" name="Pipeline Maven Integration Plugin" version="0.6-SNAPSHOT"/>
+    <no-execution-found/>
+    <artifact groupId="org.jenkins-ci.plugins" artifactId="pipeline-maven" id="org.jenkins-ci.plugins:pipeline-maven:hpi:0.6-SNAPSHOT" type="hpi" version="0.6-SNAPSHOT">
+      <file>/Users/cleclerc/git/jenkins/pipeline-maven-plugin/target/pipeline-maven.hpi</file>
+    </artifact>
+    <attachedArtifacts>
+      <artifact groupId="org.jenkins-ci.plugins" artifactId="pipeline-maven" id="org.jenkins-ci.plugins:pipeline-maven:jar:0.6-SNAPSHOT" type="jar" version="0.6-SNAPSHOT">
+        <file>/Users/cleclerc/git/jenkins/pipeline-maven-plugin/target/pipeline-maven.jar</file>
+      </artifact>
+    </attachedArtifacts>
+  </ExecutionEvent>
+     */
+    @Nonnull
+    public List<MavenSpyLogProcessor.MavenArtifact> listAttachedArtifacts(Element mavenSpyLogs) {
+        List<MavenSpyLogProcessor.MavenArtifact> result = new ArrayList<>();
+
+        for (Element projectSucceededElt : XmlUtils.getExecutionEvents(mavenSpyLogs, "ProjectSucceeded")) {
+
+            Element projectElt = XmlUtils.getUniqueChildElement(projectSucceededElt, "project");
+            MavenSpyLogProcessor.MavenArtifact projectArtifact = XmlUtils.newMavenArtifact(projectElt);
+
+            Element attachedArtifactsParentElt = XmlUtils.getUniqueChildElement(projectSucceededElt, "attachedArtifacts");
+            List<Element> attachedArtifactsElts = XmlUtils.getChildrenElements(attachedArtifactsParentElt, "artifact");
+            for (Element attachedArtifactElt : attachedArtifactsElts) {
+                MavenSpyLogProcessor.MavenArtifact attachedMavenArtifact = XmlUtils.newMavenArtifact(attachedArtifactElt);
+
+                Element fileElt = XmlUtils.getUniqueChildElementOrNull(attachedArtifactElt, "file");
+                if (fileElt.getTextContent() == null || fileElt.getTextContent().isEmpty()) {
+                    LOGGER.log(Level.WARNING, "Project " + projectArtifact + ", no associated file found for attached artifact " + attachedMavenArtifact + " in " + XmlUtils.toString(attachedArtifactElt));
+                }
+                attachedMavenArtifact.file = StringUtils.trim(fileElt.getTextContent());
+                result.add(attachedMavenArtifact);
+            }
+
+
+        }
+        return result;
+    }
+}

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/JunitTestsReporter.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/JunitTestsReporter.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.pipeline.maven.reporters;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
+import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
 import hudson.tasks.junit.JUnitResultArchiver;
 import org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor;
@@ -36,6 +37,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.w3c.dom.Element;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -135,7 +137,8 @@ public class JunitTestsReporter implements ResultsReporter {
 
         TaskListener listener = context.get(TaskListener.class);
         if (listener == null) {
-            LOGGER.warning("listener is NULL"); // TODO
+            LOGGER.warning("TaskListener is NULL, default to stderr");
+            listener = new StreamBuildListener((OutputStream) System.err);
         }
         FilePath workspace = context.get(FilePath.class); // TODO check that it's the good workspace
         Run run = context.get(Run.class);

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/reporters/GeneratedArtifactsReporterTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/reporters/GeneratedArtifactsReporterTest.java
@@ -1,6 +1,8 @@
-package org.jenkinsci.plugins.pipeline.maven;
+package org.jenkinsci.plugins.pipeline.maven.reporters;
 
 import org.hamcrest.CoreMatchers;
+import org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor;
+import org.jenkinsci.plugins.pipeline.maven.reporters.GeneratedArtifactsReporter;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,10 +16,10 @@ import javax.xml.parsers.DocumentBuilderFactory;
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
-public class MavenSpyLogProcessorTest {
+public class GeneratedArtifactsReporterTest {
 
     Document doc;
-    MavenSpyLogProcessor mavenSpyLogProcessor = new MavenSpyLogProcessor();
+    GeneratedArtifactsReporter generatedArtifactsReporter = new GeneratedArtifactsReporter();
 
     @Before
     public void before() throws Exception {
@@ -28,7 +30,7 @@ public class MavenSpyLogProcessorTest {
 
     @Test
     public void testListArtifacts() throws Exception {
-        List<MavenSpyLogProcessor.MavenArtifact> mavenArtifacts = mavenSpyLogProcessor.listArtifacts(doc.getDocumentElement());
+        List<MavenSpyLogProcessor.MavenArtifact> mavenArtifacts = generatedArtifactsReporter.listArtifacts(doc.getDocumentElement());
         System.out.println(mavenArtifacts);
         Assert.assertThat(mavenArtifacts.size(), CoreMatchers.is(2));
 
@@ -43,7 +45,7 @@ public class MavenSpyLogProcessorTest {
 
     @Test
     public void testListAttachedArtifacts() throws Exception {
-        List<MavenSpyLogProcessor.MavenArtifact> mavenArtifacts = mavenSpyLogProcessor.listAttachedArtifacts(doc.getDocumentElement());
+        List<MavenSpyLogProcessor.MavenArtifact> mavenArtifacts = generatedArtifactsReporter.listAttachedArtifacts(doc.getDocumentElement());
         Assert.assertThat(mavenArtifacts.size(), CoreMatchers.is(1));
         MavenSpyLogProcessor.MavenArtifact mavenArtifact = mavenArtifacts.get(0);
         System.out.println(mavenArtifacts);


### PR DESCRIPTION
[JENKINS-42175](https://issues.jenkins-ci.org/browse/JENKINS-42175) Support marker files to disable reporters (archive-artifacts, junit, findbugs…).

It's a kind of temporary / experimental feature to stabilize the plugin. Later, we may introduce a clean API, probably parameters of the "`withMaven(){...}`" step.

Marker file (located in the home directory of the build):

* `.skip-archive-generated-artifacts`: skip the archiving and the fingerprinting of the artifacts and attached artifacts generated by the Maven build (jar, sources jar, javadocs jar...)
* `.skip-publish-junit-results`: skip the publishing of the JUnit / Surefire reports generated by the Maven build
* `.skip-publish-findbugs-results`: skip the publishing of the Findbugs reports generated by the Maven build

Messages displayed in the job console output when a reporter is skipped:

```
Skip archiving of generated artifacts, file '/path/to/job-workspace/.skip-archive-generated-artifacts' found in workspace
Skip publishing of JUnit results, file '/path/to/job-workspace/.skip-publish-junit-results' found in workspace
Skip publishing of FindBugs results, file '/path/to/job-workspace/.skip-publish-findbugs-results' found in workspace
```