### PR TITLE
[JENKINS-42179] use the JAVA_TOOL_OPTIONS environment variable to pass `-Dmaven.ext.class.path`

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -86,6 +86,15 @@
       <version>4.69</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <!--
+      Match the version used in jenkins-core
+      -->
+      <version>2.6</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
[JENKINS-42179](https://issues.jenkins-ci.org/browse/JENKINS-42179) use the JAVA_TOOL_OPTIONS environment variable to pass `-Dmaven.ext.class.path` and `-Dorg.jenkinsci.plugins.pipeline.maven.reportsFolder` 