### PR TITLE
Cleanup pom.xml

### DIFF
--- a/jenkins-plugin/LICENSE
+++ b/jenkins-plugin/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -28,13 +28,15 @@
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>pipeline-maven-parent</artifactId>
-    <version>2.0-beta-7-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <artifactId>plugin</artifactId>
+    <version>2.19</version>
+    <relativePath />
   </parent>
 
+  <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>pipeline-maven</artifactId>
   <packaging>hpi</packaging>
+  <version>2.0-beta-7-SNAPSHOT</version>
 
   <name>Pipeline Maven Integration Plugin</name>
   <description>
@@ -58,6 +60,9 @@
     </developer>
   </developers>
 
+  <properties>
+    <jenkins.version>1.642.4</jenkins.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -92,16 +97,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <!--
-      Match the version used in jenkins-core
-      -->
-      <version>2.6</version>
-      <scope>provided</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
@@ -186,4 +181,17 @@
         </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -52,6 +52,12 @@
     </license>
   </licenses>
 
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/pipeline-maven-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-maven-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/pipeline-maven-plugin</url>
+  </scm>
+
   <developers>
     <developer>
       <id>alvarolobato</id>

--- a/maven-spy/LICENSE
+++ b/maven-spy/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/maven-spy/pom.xml
+++ b/maven-spy/pom.xml
@@ -41,6 +41,20 @@
         Jenkins Pipeline withMaven(){} step.
     </description>
 
+    <licenses>
+        <license>
+            <name>The MIT license</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/pipeline-maven-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-maven-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/pipeline-maven-plugin</url>
+    </scm>
+
     <dependencies>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/maven-spy/src/test/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpyDisablementTest.java
+++ b/maven-spy/src/test/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpyDisablementTest.java
@@ -24,13 +24,8 @@
 
 package org.jenkinsci.plugins.pipeline.maven.eventspy;
 
-import org.apache.commons.collections.map.HashedMap;
 import org.apache.maven.eventspy.EventSpy;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
-import org.apache.maven.execution.ExecutionEvent;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.hamcrest.CoreMatchers;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.DevNullMavenEventReporter;
@@ -40,6 +35,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -88,7 +84,7 @@ public class JenkinsMavenEventSpyDisablementTest {
         spy.init(new EventSpy.Context() {
             @Override
             public Map<String, Object> getData() {
-                return new HashedMap();
+                return new HashMap<String, Object>();
             }
         });
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,19 +25,12 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>2.19</version>
-        <relativePath />
-    </parent>
-
+    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>pipeline-maven-parent</artifactId>
     <version>2.0-beta-7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Pipeline Maven Integration Plugin POM</name>
+    <name>Pipeline Maven Integration Plugin Parent</name>
     <description>
         This plugin provides integration with Pipeline, configures maven environment to use within a pipeline job by calling sh mvn or bat mvn.
         The selected maven installation will be configured and prepended to the path.
@@ -70,11 +63,6 @@
         <url>https://github.com/jenkinsci/pipeline-maven-plugin</url>
         <tag>HEAD</tag>
     </scm>
-
-    <properties> <!-- TODO unwise to use the plugin parent POM for a non-plugin! -->
-        <jenkins.version>1.642.4</jenkins.version>
-    </properties>
-
     <modules>
         <module>maven-spy</module>
         <module>jenkins-plugin</module>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,15 @@
         <module>maven-spy</module>
         <module>jenkins-plugin</module>
     </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+            </plugin>
+        </plugins>
+    </build>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -80,4 +89,15 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+    <distributionManagement>
+        <repository>
+            <uniqueVersion>false</uniqueVersion>
+            <id>maven.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>maven.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
Only `org.jenkins-ci.plugins:pipeline-maven` should have `org.jenkins-ci.plugin:plugin` as parent pom. 

`org.jenkins-ci.plugins:pipeline-maven-parent` should not have `org.jenkins-ci.plugin:plugin` as parent pom.