### PR TITLE
Demonstrate SECURITY-441 in a test

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -155,6 +155,18 @@
       <version>2.10</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.test</groupId>
+      <artifactId>docker-fixtures</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-slaves</artifactId>
+      <version>1.13</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
f563095590299bf94fdf3faf34e26df2b38b4531 removed a faulty test; showing how it should be done. Fails in the expected way if you

    git checkout pipeline-maven-parent-2.0-beta-5 -- jenkins-plugin/src/main

(`docker-fixtures` is pretty new so there are not many good examples out there.)

@reviewbybees