### PR TITLE
[JENKINS-42606] Integrate with the Jenkins Tasks Scanner Plugin

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -104,6 +104,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.jvnet.hudson.plugins</groupId>
+      <artifactId>tasks</artifactId>
+      <version>4.50</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
       <version>2.23</version>

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/TasksScannerReporter.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/TasksScannerReporter.java
@@ -1,0 +1,106 @@
+package org.jenkinsci.plugins.pipeline.maven.reporters;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.StreamBuildListener;
+import hudson.model.TaskListener;
+import hudson.plugins.findbugs.FindBugsPublisher;
+import hudson.plugins.tasks.TasksPublisher;
+import org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor;
+import org.jenkinsci.plugins.pipeline.maven.ResultsReporter;
+import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ * @see hudson.plugins.tasks.TasksPublisher
+ */
+public class TasksScannerReporter implements ResultsReporter {
+    private static final Logger LOGGER = Logger.getLogger(FindbugsAnalysisReporter.class.getName());
+
+    /*
+    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-03-08 21:03:33.564">
+        <project baseDir="/Users/cleclerc/git/jenkins/pipeline-maven-plugin/maven-spy" file="/Users/cleclerc/git/jenkins/pipeline-maven-plugin/maven-spy/pom.xml" groupId="org.jenkins-ci.plugins" name="Maven Spy for the Pipeline Maven Integration Plugin" artifactId="pipeline-maven-spy" version="2.0-beta-7-SNAPSHOT">
+          <build sourceDirectory="/Users/cleclerc/git/jenkins/pipeline-maven-plugin/maven-spy/src/main/java" directory="/Users/cleclerc/git/jenkins/pipeline-maven-plugin/maven-spy/target"/>
+        </project>
+        ...
+    </ExecutionEvent>
+     */
+    @Override
+    public void process(@Nonnull StepContext context, @Nonnull Element mavenSpyLogsElt) throws IOException, InterruptedException {
+        TaskListener listener = context.get(TaskListener.class);
+        if (listener == null) {
+            LOGGER.warning("TaskListener is NULL, default to stderr");
+            listener = new StreamBuildListener((OutputStream) System.err);
+        }
+        FilePath workspace = context.get(FilePath.class); // TODO check that it's the good workspace
+        Run run = context.get(Run.class);
+        Launcher launcher = context.get(Launcher.class);
+
+
+        try {
+            Class.forName("hudson.plugins.tasks.TasksPublisher");
+        } catch (ClassNotFoundException e) {
+            listener.getLogger().print("[withMaven] Jenkins ");
+            listener.hyperlink("https://wiki.jenkins-ci.org/display/JENKINS/Task+Scanner+Plugin", "Task Scanner Plugin");
+            listener.getLogger().println(" not found, don't display results of source code scanning for 'TODO' and 'FIXME' in pipeline screen.");
+            return;
+        }
+
+        List<String> sourceDirectoriesPatterns = new ArrayList<>();
+        for (Element executionEvent : XmlUtils.getExecutionEvents(mavenSpyLogsElt, "ProjectSucceeded", "ProjectFailed")) {
+
+            /*
+            <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-03-08 21:03:33.564">
+                <project baseDir="/Users/cleclerc/git/jenkins/pipeline-maven-plugin/maven-spy" file="/Users/cleclerc/git/jenkins/pipeline-maven-plugin/maven-spy/pom.xml" groupId="org.jenkins-ci.plugins" name="Maven Spy for the Pipeline Maven Integration Plugin" artifactId="pipeline-maven-spy" version="2.0-beta-7-SNAPSHOT">
+                  <build sourceDirectory="/Users/cleclerc/git/jenkins/pipeline-maven-plugin/maven-spy/src/main/java" directory="/Users/cleclerc/git/jenkins/pipeline-maven-plugin/maven-spy/target"/>
+                </project>
+                ...
+            </ExecutionEvent>
+             */
+            Element buildElement = XmlUtils.getUniqueChildElementOrNull(executionEvent, "project", "build");
+            if (buildElement == null) {
+                if (LOGGER.isLoggable(Level.FINE))
+                    LOGGER.log(Level.FINE, "Ignore execution event with missing 'build' child:" + XmlUtils.toString(executionEvent));
+                continue;
+            }
+            Element projectElt = XmlUtils.getUniqueChildElement(executionEvent, "project");
+            MavenSpyLogProcessor.MavenArtifact mavenArtifact = XmlUtils.newMavenArtifact(projectElt);
+
+            String sourceDirectory = buildElement.getAttribute("sourceDirectory");
+
+            String sourceDirectoryRelativePath = XmlUtils.getPathInWorkspace(sourceDirectory, workspace);
+
+            if (workspace.child(sourceDirectoryRelativePath).exists()) {
+                sourceDirectoriesPatterns.add(sourceDirectoryRelativePath + "/**/*");
+                listener.getLogger().println("[withMaven] Scan Tasks for Maven artifact " + mavenArtifact.toString() + " in source directory " + sourceDirectoryRelativePath);
+            } else {
+                LOGGER.log(Level.FINE, "Skip task scanning for {0}, folder {1} does not exist", new Object[]{mavenArtifact, sourceDirectoryRelativePath});
+            }
+        }
+
+        TasksPublisher tasksPublisher = new TasksPublisher();
+        String pattern = XmlUtils.join(sourceDirectoriesPatterns, ",");
+        tasksPublisher.setPattern(pattern);
+        tasksPublisher.setHigh("FIXME");
+        tasksPublisher.setNormal("TODO");
+
+        try {
+            tasksPublisher.perform(run, workspace, launcher, listener);
+        } catch (Exception e) {
+            listener.error("[withMaven] Silently ignore exception scanning tasks in " + pattern + ": " + e);
+            LOGGER.log(Level.WARNING, "Exception scanning tasks in  " + pattern, e);
+        }
+    }
+}

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
@@ -1,0 +1,132 @@
+package org.jenkinsci.plugins.pipeline.maven.util;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+public class XmlUtilsTest {
+    private DocumentBuilder documentBuilder;
+
+    @Before
+    public void before() throws Exception {
+        documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+    }
+
+    @Test
+    public void getUniqueChildElementOrNull_two_levels_children() throws Exception {
+        String xml =
+                "<a>" +
+                        "   <b><c>my text</c></b>" +
+                        "   <b2>b2</b2>" +
+                        "</a>";
+        Element documentElement = toXml(xml);
+        Element actualElement = XmlUtils.getUniqueChildElementOrNull(documentElement, "b", "c");
+        Assert.assertThat(actualElement.getTextContent(), CoreMatchers.is("my text"));
+    }
+
+    @Test
+    public void getUniqueChildElementOrNull_return_null_on_first_level() throws Exception {
+        String xml =
+                "<a>" +
+                        "   <b><c>my text</c></b>" +
+                        "   <b2>b2</b2>" +
+                        "</a>";
+        Element documentElement = toXml(xml);
+        Element actualElement = XmlUtils.getUniqueChildElementOrNull(documentElement, "does-npt-exist", "c");
+        Assert.assertThat(actualElement, CoreMatchers.nullValue());
+    }
+
+    @Test
+    public void getUniqueChildElementOrNull_return_null_on_second_level() throws Exception {
+        String xml =
+                "<a>" +
+                        "   <b><c>my text</c></b>" +
+                        "   <b2>b2</b2>" +
+                        "</a>";
+        Element documentElement = toXml(xml);
+        Element actualElement = XmlUtils.getUniqueChildElementOrNull(documentElement, "b", "does-not-exist");
+        Assert.assertThat(actualElement, CoreMatchers.nullValue());
+    }
+
+    @Test
+    public void test_getUniqueChildElementOrNull_one_level_child() throws Exception {
+        String xml =
+                "<a>" +
+                        "   <b><c>my text</c></b>" +
+                        "   <b2>b2</b2>" +
+                        "</a>";
+        Element documentElement = toXml(xml);
+        Element actualElement = XmlUtils.getUniqueChildElementOrNull(documentElement, "b");
+        Assert.assertThat(actualElement.getTextContent(), CoreMatchers.is("my text"));
+    }
+
+    @Test
+    public void test_getExecutionEvents_search_one_type() throws Exception {
+        String xml =
+                "<mavenExecution>" +
+                        "<ExecutionEvent type='ProjectSucceeded' />" +
+                        "</mavenExecution>";
+        Element documentElement = toXml(xml);
+        List<Element> actualElements = XmlUtils.getExecutionEvents(documentElement, "ProjectSucceeded");
+        Assert.assertThat(actualElements.size(), CoreMatchers.is(1));
+    }
+
+    @Test
+    public void test_getExecutionEvents_search_two_types() throws Exception {
+        String xml =
+                "<mavenExecution>" +
+                        "<ExecutionEvent type='ProjectSucceeded' />" +
+                        "</mavenExecution>";
+        Element documentElement = toXml(xml);
+        List<Element> actualElements = XmlUtils.getExecutionEvents(documentElement, "ProjectSucceeded", "ProjectFailed");
+        Assert.assertThat(actualElements.size(), CoreMatchers.is(1));
+    }
+
+    @Test
+    public void test_getExecutionEvents_return_empty_searching_one_type() throws Exception {
+        String xml =
+                "<mavenExecution>" +
+                        "<ExecutionEvent type='ProjectSkipped' />" +
+                        "</mavenExecution>";
+        Element documentElement = toXml(xml);
+        List<Element> actualElements = XmlUtils.getExecutionEvents(documentElement, "ProjectSucceeded");
+        Assert.assertThat(actualElements.size(), CoreMatchers.is(0));
+    }
+
+    @Test
+    public void test_getExecutionEvents_return_empty_searching_two_types() throws Exception {
+        String xml =
+                "<mavenExecution>" +
+                        "<ExecutionEvent type='ProjectSkipped' />" +
+                        "</mavenExecution>";
+        Element documentElement = toXml(xml);
+        List<Element> actualElements = XmlUtils.getExecutionEvents(documentElement, "ProjectSucceeded", "ProjectFailed");
+        Assert.assertThat(actualElements.size(), CoreMatchers.is(0));
+    }
+
+    private Element toXml(String xml) throws SAXException, IOException {
+        return documentBuilder.parse(new InputSource(new StringReader(xml))).getDocumentElement();
+    }
+
+    @Test
+    public void concatenate_two_strings(){
+        List<String> elements = Arrays.asList("a", "b", "c");
+        String actual = XmlUtils.join(elements, ",");
+        Assert.assertThat(actual, CoreMatchers.is("a,b,c"));
+    }
+}

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
@@ -35,6 +35,7 @@ import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.JarJarExecutionHand
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.MavenEventHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.MavenExecutionRequestHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.MavenExecutionResultHandler;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.ProjectFailedExecutionHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.ProjectStartedExecutionHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.ProjectSucceededExecutionHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.SessionEndedHandler;
@@ -90,6 +91,7 @@ public class JenkinsMavenEventSpy extends AbstractEventSpy {
 
     public JenkinsMavenEventSpy(MavenEventReporter reporter) throws IOException {
         handlers.add(new ProjectSucceededExecutionHandler(reporter));
+        handlers.add(new ProjectFailedExecutionHandler(reporter));
         handlers.add(new ProjectStartedExecutionHandler(reporter));
         handlers.add(new SurefireTestExecutionHandler(reporter));
         handlers.add(new JarJarExecutionHandler(reporter));

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
@@ -120,6 +120,9 @@ public abstract class AbstractMavenEventHandler<E> implements MavenEventHandler<
             if (build.getOutputDirectory() != null) {
                 buildElt.setAttribute("directory", build.getDirectory());
             }
+            if (build.getSourceDirectory() != null) {
+                buildElt.setAttribute("sourceDirectory", build.getSourceDirectory());
+            }
         }
 
         return projectElt;

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/ProjectFailedExecutionHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/ProjectFailedExecutionHandler.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.maven.eventspy.handler;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+public class ProjectFailedExecutionHandler extends AbstractExecutionHandler {
+
+    public ProjectFailedExecutionHandler(MavenEventReporter reporter) {
+        super(reporter);
+    }
+
+    @Override
+    protected ExecutionEvent.Type getSupportedType() {
+        return ExecutionEvent.Type.ProjectFailed;
+    }
+
+    @Override
+    protected List<String> getConfigurationParametersToReport(ExecutionEvent executionEvent) {
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
[JENKINS-42606](https://issues.jenkins-ci.org/browse/JENKINS-42606) Integrate with the [Jenkins Task Scanner Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Task+Scanner+Plugin).

* Default configuration
   * pattern: `path/to/source/directory/**/*`
   * high: `FIXME`
   * normal: `TODO`
* Marker file: `.skip-task-scanner`

<img width="949" alt="task-scanner-integration" src="https://cloud.githubusercontent.com/assets/459691/23762182/1e99f9fc-04aa-11e7-8aa6-0f3e721bb403.png">
