### PR TITLE
WIP [JENKINS-40665] Add support for Maven settings.xml and Maven global settings.xml defined in Jenkins global configuration

### DIFF
--- a/jenkins-plugin/README.md
+++ b/jenkins-plugin/README.md
@@ -38,7 +38,30 @@ Default locale: en_US, platform encoding: UTF-8
 OS name: "linux", version: "3.13.0-109-generic", arch: "amd64", family: "unix"
 ```
 
+## settings.xml provided by Maven global configuration with the file path settings provider
 
+```
+[Pipeline] withMaven
+[withMaven] use JDK installation provided by the build agent
+$ /bin/sh -c "which mvn"
+[withMaven] use Maven installation provided by the build agent with executable /usr/local/bin/mvn
+[withMaven] use Maven settings provided Jenkins Global configuration '/path/to/maven-settings-defined-in-jenkins-global-configuration.xml' 
+...
+```
+
+## settings.xml provided by Maven global configuration with the config file provider
+
+This log message should be improved
+
+```
+[Pipeline] withMaven
+[withMaven] use JDK installation provided by the build agent
+$ /bin/sh -c "which mvn"
+[withMaven] use Maven installation provided by the build agent with executable /usr/local/bin/mvn
+Inject in Maven settings.xml credentials for maven servers (replaceAll: true): github->com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl@b5c11be3, nexus->com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl@63dd3ff
+[withMaven] use Maven settings provided Jenkins Global configuration '/Users/cyrilleleclerc/git/jenkins/pipeline-maven-plugin/jenkins-plugin/work/jobs/pipeline-maven-plugin/workspace@tmp/maven-5485254522648220427-settings.xml' 
+...
+```
 
 
 # Maven Build Phases Reporters

--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -68,7 +68,7 @@
   </developers>
 
   <properties>
-    <jenkins.version>1.642.4</jenkins.version>
+    <jenkins.version>2.38-SNAPSHOT</jenkins.version>
   </properties>
   <dependencies>
     <dependency>
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>config-file-provider</artifactId>
-      <version>2.15.1</version>
+      <version>2.15.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Support Maven Settings Provider and Maven Global Settings Provider for pipeline and make it work with `withMaven(){}`

See
* [JENKINS-40665 Maven SettingsProvider and GlobalSettingsProvider should support Pipeline jobs](https://issues.jenkins-ci.org/browse/JENKINS-40665)
* [JENKINS-39407 Use system default Maven, Maven Settings if not specified](https://issues.jenkins-ci.org/browse/JENKINS-39407)
* PR https://github.com/jenkinsci/jenkins/pull/2818
* PR https://github.com/jenkinsci/pipeline-maven-plugin/pull/31
* PR https://github.com/jenkinsci/config-file-provider-plugin/pull/25
