### PR TITLE
[JENKINS-43449] Ensure that the maven-event-spy is thread safe

### DIFF
--- a/maven-spy/pom.xml
+++ b/maven-spy/pom.xml
@@ -95,6 +95,19 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.4</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
                 <version>1.4</version>

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
@@ -41,13 +41,15 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
+@ThreadSafe
 public class FileMavenEventReporter implements MavenEventReporter {
     File outFile;
     PrintWriter out;
-
     XMLWriter xmlWriter;
 
     public FileMavenEventReporter() throws IOException {
@@ -77,20 +79,20 @@ public class FileMavenEventReporter implements MavenEventReporter {
     }
 
     @Override
-    public void print(Object message) {
+    public synchronized void print(Object message) {
         XmlWriterUtil.writeComment(xmlWriter, new Timestamp(System.currentTimeMillis()) + " - " + message);
         XmlWriterUtil.writeLineBreak(xmlWriter);
     }
 
     @Override
-    public void print(Xpp3Dom element) {
+    public synchronized void print(Xpp3Dom element) {
         element.setAttribute("_time", new Timestamp(System.currentTimeMillis()).toString());
         Xpp3DomWriter.write(xmlWriter, element);
         XmlWriterUtil.writeLineBreak(xmlWriter);
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         xmlWriter.endElement();
 
         out.close();

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
@@ -41,6 +41,7 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -49,7 +50,9 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class FileMavenEventReporter implements MavenEventReporter {
     File outFile;
+    @GuardedBy("this")
     PrintWriter out;
+    @GuardedBy("this")
     XMLWriter xmlWriter;
 
     public FileMavenEventReporter() throws IOException {

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/MavenEventReporter.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/MavenEventReporter.java
@@ -24,15 +24,27 @@
 
 package org.jenkinsci.plugins.pipeline.maven.eventspy.reporter;
 
+import org.apache.maven.eventspy.EventSpy;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 /**
+ * WARNING: implementations of {@link MavenEventReporter} MUST be thread safe.
+ *
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
+@ThreadSafe
 public interface MavenEventReporter {
     void print(Object message);
 
     void print(Xpp3Dom element);
 
+    /**
+     * Close the reporter at the end of the Maven execution.
+     * No call to {@link #print(Object)} or {@link #print(Xpp3Dom)} will be made after the invocation of this method.
+     *
+     * @see EventSpy#close()
+     */
     void close();
 }

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/OutputStreamEventReporter.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/OutputStreamEventReporter.java
@@ -37,9 +37,12 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
+@ThreadSafe
 public class OutputStreamEventReporter implements MavenEventReporter {
 
     final PrintWriter out;
@@ -61,7 +64,7 @@ public class OutputStreamEventReporter implements MavenEventReporter {
     }
 
     @Override
-    public void print(Object message) {
+    public synchronized void print(Object message) {
         String comment = new Timestamp(System.currentTimeMillis()) + " - " + message;
         XmlWriterUtil.writeComment(xmlWriter, comment);
         XmlWriterUtil.writeLineBreak(xmlWriter);
@@ -70,7 +73,7 @@ public class OutputStreamEventReporter implements MavenEventReporter {
     }
 
     @Override
-    public void print(Xpp3Dom element) {
+    public synchronized void print(Xpp3Dom element) {
         Xpp3DomWriter.write(xmlWriter, element);
         XmlWriterUtil.writeLineBreak(xmlWriter);
 
@@ -78,7 +81,7 @@ public class OutputStreamEventReporter implements MavenEventReporter {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         xmlWriter.endElement();
         out.flush();
     }

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/OutputStreamEventReporter.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/OutputStreamEventReporter.java
@@ -37,6 +37,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -45,7 +46,9 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class OutputStreamEventReporter implements MavenEventReporter {
 
+    @GuardedBy("this")
     final PrintWriter out;
+    @GuardedBy("this")
     final XMLWriter xmlWriter;
 
     public OutputStreamEventReporter(OutputStream out) {


### PR DESCRIPTION
Ensure that the maven-event-spy is thread safe. Ensure that all the implementations of [MavenEventReporter](https://github.com/jenkinsci/pipeline-maven-plugin/blob/pipeline-maven-parent-2.0/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/MavenEventReporter.java) are thread safe.

Should fix thread safety issues. See [JENKINS-43159
maven-spy log contains invalid XML](https://issues.jenkins-ci.org/browse/JENKINS-43159)