### PR TITLE
[JENKINS-43101] Fix “The fingerprint xyz did not match any of the recorded data."

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/GeneratedArtifactsReporter.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/GeneratedArtifactsReporter.java
@@ -2,11 +2,13 @@ package org.jenkinsci.plugins.pipeline.maven.reporters;
 
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.model.FingerprintMap;
 import hudson.model.Run;
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
 import hudson.tasks.Fingerprinter;
 import jenkins.model.ArtifactManager;
+import jenkins.model.Jenkins;
 import jenkins.util.BuildListenerAdapter;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor;
@@ -97,6 +99,14 @@ public class GeneratedArtifactsReporter implements ResultsReporter{
         artifactManager.archive(workspace, launcher, new BuildListenerAdapter(listener), artifactsToArchive);
 
         // FINGERPRINT GENERATED MAVEN ARTIFACT
+        FingerprintMap fingerprintMap = Jenkins.getActiveInstance().getFingerprintMap();
+        for (Map.Entry<String, String> artifactToFingerprint : artifactsToFingerPrint.entrySet()) {
+            String artifactPathInArchiveZone = artifactToFingerprint.getKey();
+            String artifactMd5 = artifactToFingerprint.getValue();
+            fingerprintMap.getOrCreate(run, artifactPathInArchiveZone, artifactMd5);
+        }
+
+        // add action
         Fingerprinter.FingerprintAction fingerprintAction = run.getAction(Fingerprinter.FingerprintAction.class);
         if (fingerprintAction == null) {
             run.addAction(new Fingerprinter.FingerprintAction(run, artifactsToFingerPrint));


### PR DESCRIPTION
[JENKINS-43101](https://issues.jenkins-ci.org/browse/JENKINS-JENKINS-43101) Fix “The fingerprint xyz did not match any of the recorded data.", add the artifacts produced by the maven build to jenkins.fingerprintMap.

ℹ️ I'll add integration tests when merging https://github.com/jenkinsci/pipeline-maven-plugin/tree/add-tests