### PR TITLE
[Jenkins 43491] Feature flag ".archive-jenkins-maven-event-spy-logs" to archive the logs file generated by the Jenkins Maven Event Spy

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenSpyLogProcessor.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenSpyLogProcessor.java
@@ -32,6 +32,7 @@ import jenkins.model.InterruptedBuildAction;
 import org.jenkinsci.plugins.pipeline.maven.reporters.FindbugsAnalysisReporter;
 import org.jenkinsci.plugins.pipeline.maven.reporters.GeneratedArtifactsReporter;
 import org.jenkinsci.plugins.pipeline.maven.reporters.JunitTestsReporter;
+import org.jenkinsci.plugins.pipeline.maven.reporters.JenkinsMavenEventSpyLogsReporter;
 import org.jenkinsci.plugins.pipeline.maven.reporters.TasksScannerReporter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.w3c.dom.Element;
@@ -82,6 +83,12 @@ public class MavenSpyLogProcessor implements Serializable {
                 InputStream mavenSpyLogsInputStream = mavenSpyLogs.read();
                 if (mavenSpyLogsInputStream == null) {
                     throw new IllegalStateException("InputStream for " + mavenSpyLogs.getRemote() + " is null");
+                }
+
+                FilePath archiveJenkinsMavenEventSpyLogs = workspace.child(".archive-jenkins-maven-event-spy-logs");
+                if (archiveJenkinsMavenEventSpyLogs.exists()) {
+                    LOGGER.log(Level.FINE, "Archive Jenkins Maven Event Spy logs {0}", mavenSpyLogs.getRemote());
+                    new JenkinsMavenEventSpyLogsReporter().process(context, mavenSpyLogs);
                 }
 
                 Element mavenSpyLogsElt = documentBuilder.parse(mavenSpyLogsInputStream).getDocumentElement();

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/JenkinsMavenEventSpyLogsReporter.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/JenkinsMavenEventSpyLogsReporter.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.plugins.pipeline.maven.reporters;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.model.ArtifactManager;
+import jenkins.util.BuildListenerAdapter;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Primarily for debugging purpose, archive the Maven build logs
+ *
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+public class JenkinsMavenEventSpyLogsReporter {
+    public void process(@Nonnull StepContext context, @Nonnull FilePath mavenSpyLogs) throws IOException, InterruptedException {
+
+        Run run = context.get(Run.class);
+        ArtifactManager artifactManager = run.pickArtifactManager();
+        Launcher launcher = context.get(Launcher.class);
+        TaskListener listener = context.get(TaskListener.class);
+        FilePath workspace = context.get(FilePath.class);
+
+        // ARCHIVE MAVEN BUILD LOGS
+        FilePath tmpFile = new FilePath(workspace, "." + mavenSpyLogs.getName());
+        try {
+            mavenSpyLogs.copyTo(tmpFile);
+            listener.getLogger().println("[withMaven] archive " + mavenSpyLogs.getRemote() + " as " + mavenSpyLogs.getName());
+            // filePathInArchiveZone -> filePathInWorkspace
+            Map<String, String> mavenBuildLogs = Collections.singletonMap(mavenSpyLogs.getName(), tmpFile.getName());
+            artifactManager.archive(workspace, launcher, new BuildListenerAdapter(listener), mavenBuildLogs);
+        } catch (Exception e) {
+            PrintWriter errorWriter = listener.error("[withMaven] WARNING Exception archiving Maven build logs " + mavenSpyLogs + ", skip file. ");
+            e.printStackTrace(errorWriter);
+        } finally {
+            boolean deleted = tmpFile.delete();
+            if (!deleted) {
+                listener.error("[withMaven] WARNING Failure to delete temporary file " + tmpFile);
+            }
+        }
+    }
+}

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
@@ -67,8 +67,9 @@ public class FileMavenEventReporter implements MavenEventReporter {
             } else {
                 boolean created = reportsFolder.mkdirs();
                 if (!created) {
-                    System.err.println("Failure to create " + reportsFolder.getAbsolutePath());
                     reportsFolder = new File(".");
+                    System.err.println("[jenkins-maven-event-spy] WARNING Failure to create folder '" + reportsFolder.getAbsolutePath() +
+                            "', generate report in '" + reportsFolder.getAbsolutePath() + "'");
                 }
             }
         }
@@ -79,6 +80,8 @@ public class FileMavenEventReporter implements MavenEventReporter {
         xmlWriter = new PrettyPrintXMLWriter(out);
         xmlWriter.startElement("mavenExecution");
         xmlWriter.addAttribute("_time", new Timestamp(System.currentTimeMillis()).toString());
+
+        System.out.println("[jenkins-maven-event-spy] generate " + outFile.getAbsolutePath() + " ...");
     }
 
     @Override
@@ -99,6 +102,6 @@ public class FileMavenEventReporter implements MavenEventReporter {
         xmlWriter.endElement();
 
         out.close();
-        System.out.println("JenkinsMavenEventSpy generated " + outFile.getAbsolutePath());
+        System.out.println("[jenkins-maven-event-spy] generated " + outFile.getAbsolutePath());
     }
 }


### PR DESCRIPTION
[Jenkins 43491](https://issues.jenkins-ci.org/browse/JENKINS-43491) Feature flag `.archive-jenkins-maven-event-spy-logs` to archive the logs file generated by the Jenkins Maven Event Spy. Primarily intended for troubleshooting purpose.

The `.archive-jenkins-maven-event-spy-logs` has to be created in the Jenkins build workspace.