### PR TITLE
[JENKINS-43529] Don’t create an invalid build xml logs file when the Maven Event Spy is disabled

### DIFF
--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
@@ -81,7 +81,7 @@ public class FileMavenEventReporter implements MavenEventReporter {
         xmlWriter.startElement("mavenExecution");
         xmlWriter.addAttribute("_time", new Timestamp(System.currentTimeMillis()).toString());
 
-        System.out.println("[jenkins-maven-event-spy] generate " + outFile.getAbsolutePath() + " ...");
+        System.out.println("[jenkins-maven-event-spy] INFO generate " + outFile.getAbsolutePath() + " ...");
     }
 
     @Override
@@ -102,6 +102,6 @@ public class FileMavenEventReporter implements MavenEventReporter {
         xmlWriter.endElement();
 
         out.close();
-        System.out.println("[jenkins-maven-event-spy] generated " + outFile.getAbsolutePath());
+        System.out.println("[jenkins-maven-event-spy] INFO generated " + outFile.getAbsolutePath());
     }
 }

--- a/maven-spy/src/test/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpyDisablementTest.java
+++ b/maven-spy/src/test/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpyDisablementTest.java
@@ -53,6 +53,14 @@ public class JenkinsMavenEventSpyDisablementTest {
                 return true;
             }
         };
+        Assert.assertThat(spy.getReporter(), CoreMatchers.nullValue());
+        spy.init(new EventSpy.Context() {
+            @Override
+            public Map<String, Object> getData() {
+                return new HashMap<String, Object>();
+            }
+        });
+
         Assert.assertThat(spy.getReporter(), CoreMatchers.instanceOf(DevNullMavenEventReporter.class));
         Assert.assertThat(spy.disabled, CoreMatchers.is(true));
     }


### PR DESCRIPTION
[JENKINS-43529](https://issues.jenkins-ci.org/browse/JENKINS-43529) Don’t create an invalid build xml logs file when the Maven Event Spy is disabled