### PR TITLE
Attempting to archive a directory will fail miserably

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/GeneratedArtifactsReporter.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/reporters/GeneratedArtifactsReporter.java
@@ -85,7 +85,7 @@ public class GeneratedArtifactsReporter implements ResultsReporter{
                     listener.error("[withMaven] Invalid path in the workspace (" + workspace.getRemote() + ") for artifact " + mavenArtifact);
                 } else {
                     FilePath artifactFilePath = new FilePath(workspace, artifactPathInWorkspace);
-                    if (artifactFilePath.exists()) {
+                    if (artifactFilePath.exists() && !artifactFilePath.isDirectory()) {
                         // the subsequent call to digest could test the existence but we don't want to prematurely optimize performances
                         listener.getLogger().println("[withMaven] Archive artifact " + artifactPathInWorkspace + " under " + artifactPathInArchiveZone);
                         artifactsToArchive.put(artifactPathInArchiveZone, artifactPathInWorkspace);


### PR DESCRIPTION
For example with `mvn test` the artifact produced will be a directory, which cannot be digested. Don't try to archive an artifact in that case.