### PR TITLE
[JENKINS-43650] Add dependency to org.jenkins-ci.main:maven-plugin.

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -79,6 +79,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>maven-plugin</artifactId>
+      <version>2.14</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
       <version>2.9</version>


### PR DESCRIPTION
[JENKINS-43650](https://issues.jenkins-ci.org/browse/JENKINS-43650) Add dependency to org.jenkins-ci.main:maven-plugin.

Will also be needed to manage global-level and folder-level settings.