### PR TITLE
[JENKINS-44250] use File.getCanonicalPath() instead of File.getAbsolutePath()

### DIFF
--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
@@ -133,7 +133,7 @@ public class JenkinsMavenEventSpy extends AbstractEventSpy {
         }
 
         reporter.print(element);
-        reporter.print("new File(.): " + new File(".").getAbsolutePath());
+        reporter.print("new File(.): " + new File(".").getCanonicalPath());
     }
 
     @Override

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/RuntimeIOException.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/RuntimeIOException.java
@@ -1,0 +1,20 @@
+package org.jenkinsci.plugins.pipeline.maven.eventspy;
+
+/**
+ * Subclass of {@link RuntimeException} to propagate and {@link java.io.IOException}
+ *
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+public class RuntimeIOException extends RuntimeException {
+    public RuntimeIOException(Throwable cause) {
+        super(cause);
+    }
+
+    public RuntimeIOException(String message) {
+        super(message);
+    }
+
+    public RuntimeIOException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/ProjectSucceededExecutionHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/ProjectSucceededExecutionHandler.java
@@ -28,9 +28,11 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.RuntimeIOException;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -59,7 +61,11 @@ public class ProjectSucceededExecutionHandler extends AbstractExecutionHandler {
         } else {
             Xpp3Dom artifactElt = newElement("artifact", artifact);
             File file = artifact.getFile();
-            artifactElt.addChild(newElement("file", file == null ? null : file.getAbsolutePath()));
+            try {
+                artifactElt.addChild(newElement("file", file == null ? null : file.getCanonicalPath()));
+            } catch (IOException e) {
+                throw new RuntimeIOException(e);
+            }
             element.addChild(artifactElt);
         }
 
@@ -68,7 +74,11 @@ public class ProjectSucceededExecutionHandler extends AbstractExecutionHandler {
         for (Artifact attachedArtifact : project.getAttachedArtifacts()) {
             Xpp3Dom artifactElt = newElement("artifact", attachedArtifact);
             File file = attachedArtifact.getFile();
-            artifactElt.addChild(newElement("file", file == null ? null : file.getAbsolutePath()));
+            try {
+                artifactElt.addChild(newElement("file", file == null ? null : file.getCanonicalPath()));
+            } catch (IOException e) {
+                throw new RuntimeIOException(e);
+            }
             attachedArtifactsElt.addChild(artifactElt);
         }
 

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.util.xml.XMLWriter;
 import org.codehaus.plexus.util.xml.XmlWriterUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomWriter;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.RuntimeIOException;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -81,7 +82,11 @@ public class FileMavenEventReporter implements MavenEventReporter {
         xmlWriter.startElement("mavenExecution");
         xmlWriter.addAttribute("_time", new Timestamp(System.currentTimeMillis()).toString());
 
-        System.out.println("[jenkins-maven-event-spy] INFO generate " + outFile.getAbsolutePath() + " ...");
+        try {
+            System.out.println("[jenkins-maven-event-spy] INFO generate " + outFile.getCanonicalPath() + " ...");
+        } catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
     }
 
     @Override
@@ -102,6 +107,10 @@ public class FileMavenEventReporter implements MavenEventReporter {
         xmlWriter.endElement();
 
         out.close();
-        System.out.println("[jenkins-maven-event-spy] INFO generated " + outFile.getAbsolutePath());
+        try {
+            System.out.println("[jenkins-maven-event-spy] INFO generated " + outFile.getCanonicalPath());
+        } catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
     }
 }


### PR DESCRIPTION
[JENKINS-44250](https://issues.jenkins-ci.org/browse/JENKINS-44250) use `File.getCanonicalPath()` instead of `File.getAbsolutePath()` to prevent mismatches between folder paths in the maven-event-spy and the jerkins-plugin