### PR TITLE
[JENKINS-44226] add support for the jenkins junit-attachments plugin

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -106,6 +106,13 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit-attachments</artifactId>
+      <version>1.4.2</version>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>findbugs</artifactId>
       <version>4.70</version>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/JunitTestsPublisher/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/JunitTestsPublisher/config.jelly
@@ -32,4 +32,10 @@ THE SOFTWARE.
             <option value="true">True</option>
         </select>
     </f:entry>
+    <f:entry title="${%Ignore Attachments}" field="ignoreAttachments">
+        <select name="ignoreAttachments">
+            <option value="false">False</option>
+            <option value="true">True</option>
+        </select>
+    </f:entry>
 </j:jelly>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/JunitTestsPublisher/help-ignoreAttachments.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/JunitTestsPublisher/help-ignoreAttachments.html
@@ -1,0 +1,7 @@
+<div>
+    Skip the publishing of tests reports attachments.<br/>
+
+    Test result attachments are by default published if the
+    <a href="https://wiki.jenkins-ci.org/display/JENKINS/JUnit+Attachments+Plugin">Jenkins JUnit Attachments Plugin</a>
+    is installed.
+</div>


### PR DESCRIPTION
[JENKINS-44226](https://issues.jenkins-ci.org/browse/JENKINS-44226) add support for the jenkins junit-attachments plugin.

Publishing of junit test attachments are enabled by default if the junit-attachments-plugin is installed.

Junit test attachments can be disabled using `options: [junitPublisher(ignoreAttachments: true)]`. Sample:

```groovy
withMaven(
        maven:"maven-3.3.9", 
        globalMavenSettingsConfig: 'my-global-maven-settings', 
        mavenSettingsConfig: 'my-maven-settings',
        options: [junitPublisher(ignoreAttachments: true)]) {
            
    sh "mvn clean install"
}
```