### PR TITLE
WIP [JENKINS-44384] Support configuration of withMaven publishers in the …

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
@@ -1,0 +1,66 @@
+package org.jenkinsci.plugins.pipeline.maven;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
+import jenkins.tools.ToolConfigurationCategory;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+@Extension(ordinal = 50) @Symbol("pipelineMaven")
+public class GlobalPipelineMavenConfig extends GlobalConfiguration {
+
+    private final static Logger LOGGER = Logger.getLogger(GlobalPipelineMavenConfig.class.getName());
+
+    @DataBoundConstructor
+    public GlobalPipelineMavenConfig() {
+        load();
+    }
+
+    @Override
+    public ToolConfigurationCategory getCategory() {
+        return GlobalConfigurationCategory.get(ToolConfigurationCategory.class);
+    }
+
+    private List<MavenPublisher> publisherOptions;
+
+    @CheckForNull
+    public List<MavenPublisher> getPublisherOptions() {
+        return publisherOptions;
+    }
+
+    @DataBoundSetter
+    public void setPublisherOptions(List<MavenPublisher> publisherOptions) {
+        this.publisherOptions = publisherOptions;
+        save();
+    }
+
+    public void setPublisherOptions(MavenPublisher... publishers) {
+        this.publisherOptions = Arrays.asList(publishers);
+        save();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        return true;
+    }
+
+    @Nullable
+    public static GlobalPipelineMavenConfig get() {
+        return GlobalConfiguration.all().get(GlobalPipelineMavenConfig.class);
+    }
+}

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisher.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisher.java
@@ -6,13 +6,18 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.beanutils.BeanUtilsBean2;
+import org.apache.commons.beanutils.PropertyUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.w3c.dom.Element;
 
+import java.beans.PropertyDescriptor;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,16 +39,14 @@ public abstract class MavenPublisher extends AbstractDescribableImpl<MavenPublis
 
     private final static Logger LOGGER = Logger.getLogger(MavenPublisher.class.getName());
 
-    @CheckForNull
-    private Boolean disabled;
+    private boolean disabled;
 
-    @CheckForNull
-    public Boolean isDisabled() {
+    public boolean isDisabled() {
         return disabled;
     }
 
     @DataBoundSetter
-    public void setDisabled(@Nullable Boolean disabled) {
+    public void setDisabled(boolean disabled) {
         this.disabled = disabled;
     }
 
@@ -74,7 +77,6 @@ public abstract class MavenPublisher extends AbstractDescribableImpl<MavenPublis
 
     public static abstract class DescriptorImpl extends Descriptor<MavenPublisher> implements Comparable<DescriptorImpl> {
         /**
-         *
          * @return the ordinal of this reporter to execute publishers in predictable order
          * @see #compareTo(MavenPublisher)
          */
@@ -103,46 +105,125 @@ public abstract class MavenPublisher extends AbstractDescribableImpl<MavenPublis
         }
     }
 
+    /**
+     * <p>Build the list of {@link MavenPublisher}s that should be invoked for the build execution of the given {@link TaskListener}
+     * with the desired configuration.
+     * </p>
+     * <p>
+     * The desired configuration is based on:
+     * </p>
+     * <ul>
+     * <li>The default configuration of the publishers</li>
+     * <li>The global configuration of the publishers defined in the "Global Tools Configuration' section</li>
+     * <li>The configuration specified in the {@code withMaven(options=[...])} step</li>
+     * </ul>
+     *
+     * @param configuredPublishers
+     * @param listener
+     */
     @Nonnull
-    public static List<MavenPublisher> buildReportersList(@Nonnull List<MavenPublisher> configuredReporters, @Nonnull TaskListener listener){
+    public static List<MavenPublisher> buildPublishersList(@Nonnull List<MavenPublisher> configuredPublishers, @Nonnull TaskListener listener) {
 
-        // mavenReporter.descriptor.id -> mavenReporter
-        Map<String, MavenPublisher> configuredReportersById = new HashMap<>();
-        for (MavenPublisher mavenPublisher : configuredReporters) {
+        // configuration passed as parameter of "withMaven(options=[...]){}"
+        // mavenPublisher.descriptor.id -> mavenPublisher
+        Map<String, MavenPublisher> configuredPublishersById = new HashMap<>();
+        for (MavenPublisher mavenPublisher : configuredPublishers) {
             if (mavenPublisher == null) {
-                // skipp null reporter injected by Jenkins pipeline for an unknown reason
+                // skip null publisher options injected by Jenkins pipeline, probably caused by a missing plugin
             } else {
-                configuredReportersById.put(mavenPublisher.getDescriptor().getId(), mavenPublisher);
+                configuredPublishersById.put(mavenPublisher.getDescriptor().getId(), mavenPublisher);
             }
         }
 
-        // mavenReporter.descriptor.id -> mavenRepoer
-        Map<String, MavenPublisher> defaultReportersById = new HashMap<>();
+        // configuration defined globally
+        Map<String, MavenPublisher> globallyConfiguredPublishersById = new HashMap<>();
+        GlobalPipelineMavenConfig globalPipelineMavenConfig = GlobalPipelineMavenConfig.get();
+
+        List<MavenPublisher> globallyConfiguredPublishers = globalPipelineMavenConfig == null ? Collections.<MavenPublisher>emptyList() : globalPipelineMavenConfig.getPublisherOptions();
+        if (globallyConfiguredPublishers == null) {
+            globallyConfiguredPublishers = Collections.emptyList();
+        }
+        for (MavenPublisher mavenPublisher : globallyConfiguredPublishers) {
+            globallyConfiguredPublishersById.put(mavenPublisher.getDescriptor().getId(), mavenPublisher);
+        }
+
+
+        // mavenPublisher.descriptor.id -> mavenPublisher
+        Map<String, MavenPublisher> defaultPublishersById = new HashMap<>();
         DescriptorExtensionList<MavenPublisher, Descriptor<MavenPublisher>> descriptorList = Jenkins.getInstance().getDescriptorList(MavenPublisher.class);
-        for (Descriptor<MavenPublisher> descriptor:descriptorList) {
-            if (configuredReportersById.containsKey(descriptor.getId())) {
-                // skip, already provided with a configuration
-            } else {
-                try {
-                    defaultReportersById.put(descriptor.getId(), descriptor.clazz.newInstance());
-                } catch (InstantiationException | IllegalAccessException e) {
-                    PrintWriter error = listener.error("[withMaven] Exception instantiation default config for Maven Reporter '" + descriptor.getDisplayName() + "' / " + descriptor.getId() + ": " + e);
-                    e.printStackTrace(error);
-                    error.close();
-                    LOGGER.log(Level.WARNING, "Exception instantiating " + descriptor.clazz + ": " + e, e);
-                    e.printStackTrace();
-                }
+        for (Descriptor<MavenPublisher> descriptor : descriptorList) {
+            try {
+                defaultPublishersById.put(descriptor.getId(), descriptor.clazz.newInstance());
+            } catch (InstantiationException | IllegalAccessException e) {
+                PrintWriter error = listener.error("[withMaven] Exception instantiation default config for Maven Publisher '" + descriptor.getDisplayName() + "' / " + descriptor.getId() + ": " + e);
+                e.printStackTrace(error);
+                error.close();
+                LOGGER.log(Level.WARNING, "Exception instantiating " + descriptor.clazz + ": " + e, e);
+                e.printStackTrace();
             }
         }
+
+
         if (LOGGER.isLoggable(Level.FINE)) {
-            listener.getLogger().println("[withMaven] Maven Reporters with configuration provided by the pipeline: " + configuredReportersById);
-            listener.getLogger().println("[withMaven] Maven Reporters with default configuration: " + defaultReportersById);
+            listener.getLogger().println("[withMaven] Maven Publishers with configuration provided by the pipeline: " + configuredPublishersById.values());
+            listener.getLogger().println("[withMaven] Maven Publishers with configuration defined globally: " + globallyConfiguredPublishersById.values());
+            listener.getLogger().println("[withMaven] Maven Publishers with default configuration: " + defaultPublishersById.values());
         }
 
+        // TODO FILTER
         List<MavenPublisher> results = new ArrayList<>();
-        results.addAll(configuredReportersById.values());
-        results.addAll(defaultReportersById.values());
+        for (Map.Entry<String, MavenPublisher> entry : defaultPublishersById.entrySet()) {
+            String publisherId = entry.getKey();
+            MavenPublisher publisher = buildConfiguredMavenPublisher(
+                    configuredPublishersById.get(publisherId),
+                    globallyConfiguredPublishersById.get(publisherId),
+                    entry.getValue(),
+                    listener);
+            results.add(publisher);
+        }
         Collections.sort(results);
         return results;
+    }
+
+    public static MavenPublisher buildConfiguredMavenPublisher(@Nullable MavenPublisher pipelinePublisher, @Nullable MavenPublisher globallyConfiguredPublisher, @Nonnull MavenPublisher defaultPublisher, @Nonnull TaskListener listener) {
+
+        MavenPublisher result;
+        String logMessage;
+
+        if (pipelinePublisher == null && globallyConfiguredPublisher == null) {
+            result = defaultPublisher;
+            logMessage = "default";
+        } else if (pipelinePublisher == null && globallyConfiguredPublisher != null) {
+            result = globallyConfiguredPublisher;
+            logMessage = "globally";
+        } else if (pipelinePublisher != null && globallyConfiguredPublisher == null) {
+            result = pipelinePublisher;
+            logMessage = "pipeline";
+        } else if (pipelinePublisher != null && globallyConfiguredPublisher != null)  {
+            // workaround FindBugs "Bug kind and pattern: NP - NP_NULL_ON_SOME_PATH"
+            // check pipelinePublisher and globallyConfiguredPublisher are non null even if it is useless
+
+            result = pipelinePublisher;
+            logMessage = "pipeline";
+            listener.getLogger().println("[withMaven] WARNING merging publisher configuration defined in the 'Global Tool Configuration' and at the pipeline level is not yet supported." +
+                    " Use pipeline level configuration for '" + result.getDescriptor().getDisplayName() + "'");
+//
+//            PropertyDescriptor[] propertyDescriptors = PropertyUtils.getPropertyDescriptors(defaultPublisher);
+//            for(PropertyDescriptor propertyDescriptor: propertyDescriptors) {
+//                Method readMethod = propertyDescriptor.getReadMethod();
+//                Method writeMethod = propertyDescriptor.getWriteMethod();
+//
+//                Object defaultValue = readMethod.invoke(defaultPublisher);
+//                Object globallyDefinedValue = readMethod.invoke(globallyConfiguredPublisher);
+//                Object pipelineValue = readMethod.invoke(pipelinePublisher);
+//            }
+        } else {
+            throw new IllegalStateException("Should not happen, workaround for Findbugs NP_NULL_ON_SOME_PATH above");
+        }
+
+        if (LOGGER.isLoggable(Level.FINE))
+            listener.getLogger().println("[withMaven] Use " + logMessage + " defined publisher for '" + result.getDescriptor().getDisplayName() + "'");
+        return result;
+
     }
 }

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenSpyLogProcessor.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenSpyLogProcessor.java
@@ -93,7 +93,7 @@ public class MavenSpyLogProcessor implements Serializable {
 
                 Element mavenSpyLogsElt = documentBuilder.parse(mavenSpyLogsInputStream).getDocumentElement();
 
-                List<MavenPublisher> mavenPublishers = MavenPublisher.buildReportersList(options, listener);
+                List<MavenPublisher> mavenPublishers = MavenPublisher.buildPublishersList(options, listener);
                 for (MavenPublisher mavenPublisher : mavenPublishers){
                     String skipFileName =  mavenPublisher.getDescriptor().getSkipFileName();
                     if (Boolean.TRUE.equals(mavenPublisher.isDisabled())) {

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/config.jelly
@@ -26,10 +26,11 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <f:entry title="${%Disabled}" field="disabled">
-        <select name="disabled">
-            <option value="true">True</option>
-            <option value="false">false</option>
-        </select>
-    </f:entry>
+    <f:section title="${%Pipeline Maven Configuration}">
+        <f:entry title="${%Options}">
+            <f:repeatableHeteroProperty field="publisherOptions" targetType="org.jenkinsci.plugins.pipeline.maven.MavenPublisher"
+                                        addCaption="${%Add Publisher Options}" hasHeader="true" oneEach="true"/>
+        </f:entry>
+    </f:section>
+
 </j:jelly>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/MavenPublisher/maven-publisher.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/MavenPublisher/maven-publisher.jelly
@@ -26,33 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <st:include page="maven-publisher" class="${descriptor.clazz}"/>
-
-    <f:section title="${%Source Code}">
-        <f:entry title="Pattern" field="pattern">
-            <f:textbox/>
-        </f:entry>
-        <f:entry title="Exclude Pattern" field="excludePattern">
-            <f:textbox/>
-        </f:entry>
-    </f:section>
-
-    <f:section title="${%Task Identifiers}">
-        <f:entry title="High Priority Tasks" field="highPriorityTaskIdentifiers">
-            <f:textbox/>
-        </f:entry>
-        <f:entry title="Normal Priority Tasks" field="normalPriorityTaskIdentifiers">
-            <f:textbox/>
-        </f:entry>
-        <f:entry title="Low Priority Tasks" field="lowPriorityTaskIdentifiers">
-            <f:textbox/>
-        </f:entry>
-        <f:entry title="${%Ignore Case}" field="ignoreCase">
-            <f:checkbox/>
-        </f:entry>
-        <f:entry title="${%As Regexp}" field="asRegexp">
-            <f:checkbox/>
-        </f:entry>
-    </f:section>
-
+    <f:entry title="${%Disabled}" field="disabled">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/FindbugsAnalysisPublisher/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/FindbugsAnalysisPublisher/config.jelly
@@ -26,10 +26,6 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <f:entry title="${%Disabled}" field="disabled">
-        <select name="disabled">
-            <option value="false">False</option>
-            <option value="true">True</option>
-        </select>
-    </f:entry>
+    <st:include page="maven-publisher" class="${descriptor.clazz}"/>
+
 </j:jelly>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisher/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisher/config.jelly
@@ -26,10 +26,6 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <f:entry title="${%Disabled}" field="disabled">
-        <select name="disabled">
-            <option value="false">False</option>
-            <option value="true">True</option>
-        </select>
-    </f:entry>
+    <st:include page="maven-publisher" class="${descriptor.clazz}"/>
+
 </j:jelly>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/JunitTestsPublisher/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/JunitTestsPublisher/config.jelly
@@ -26,16 +26,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <f:entry title="${%Disabled}" field="disabled">
-        <select name="disabled">
-            <option value="false">False</option>
-            <option value="true">True</option>
-        </select>
-    </f:entry>
+    <st:include page="maven-publisher" class="${descriptor.clazz}"/>
+
     <f:entry title="${%Ignore Attachments}" field="ignoreAttachments">
-        <select name="ignoreAttachments">
-            <option value="false">False</option>
-            <option value="true">True</option>
-        </select>
+        <f:checkbox/>
     </f:entry>
 </j:jelly>

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherTest.java
@@ -32,7 +32,7 @@ public class MavenPublisherTest {
     public void listMavenReporters() throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        List<MavenPublisher> mavenPublishers = MavenPublisher.buildReportersList(Collections.<MavenPublisher>emptyList(), new StreamTaskListener(baos));
+        List<MavenPublisher> mavenPublishers = MavenPublisher.buildPublishersList(Collections.<MavenPublisher>emptyList(), new StreamTaskListener(baos));
         Assert.assertThat(mavenPublishers.size(), CoreMatchers.is(4));
 
         Map<String, MavenPublisher> reportersByDescriptorId = new HashMap<>();

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepGlobalConfigurationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepGlobalConfigurationTest.java
@@ -1,0 +1,207 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.pipeline.maven;
+
+import hudson.model.Result;
+import hudson.tasks.Maven;
+import jenkins.mvn.DefaultGlobalSettingsProvider;
+import jenkins.mvn.DefaultSettingsProvider;
+import jenkins.mvn.GlobalMavenConfig;
+import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.scm.impl.mock.GitSampleRepoRuleUtils;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.maven.publishers.FindbugsAnalysisPublisher;
+import org.jenkinsci.plugins.pipeline.maven.publishers.GeneratedArtifactsPublisher;
+import org.jenkinsci.plugins.pipeline.maven.publishers.JunitTestsPublisher;
+import org.jenkinsci.plugins.pipeline.maven.publishers.TasksScannerPublisher;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.ExtendedToolInstallations;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * TODO migrate to {@link WithMavenStepTest} once we have implemented a GitRepoRule that can be used on remote agents
+ */
+public class WithMavenStepGlobalConfigurationTest {
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Rule
+    public GitSampleRepoRule gitRepoRule = new GitSampleRepoRule();
+
+    private String mavenInstallationName;
+
+    @Before
+    public void setup() throws Exception {
+        // Maven.MavenInstallation maven3 = ToolInstallations.configureMaven35();
+        Maven.MavenInstallation maven3 = ExtendedToolInstallations.configureMaven35();
+
+        mavenInstallationName = maven3.getName();
+
+        GlobalMavenConfig globalMavenConfig = jenkinsRule.get(GlobalMavenConfig.class);
+        globalMavenConfig.setGlobalSettingsProvider(new DefaultGlobalSettingsProvider());
+        globalMavenConfig.setSettingsProvider(new DefaultSettingsProvider());
+
+    }
+
+    @Test
+    public void maven_build_jar_project_on_master_disable_globally_findbugs_publisher_succeeds() throws Exception {
+        maven_build_jar_project_on_master_with_globally_disabled_publisher_succeeds(new FindbugsAnalysisPublisher.DescriptorImpl());
+    }
+
+    @Test
+    public void maven_build_jar_project_on_master_disable_globally_tasks_publisher_succeeds() throws Exception {
+        maven_build_jar_project_on_master_with_globally_disabled_publisher_succeeds(new TasksScannerPublisher.DescriptorImpl());
+    }
+
+    @Test
+    public void maven_build_jar_project_on_master_disable_globally_junit_publisher_succeeds() throws Exception {
+        maven_build_jar_project_on_master_with_globally_disabled_publisher_succeeds(new JunitTestsPublisher.DescriptorImpl());
+    }
+
+    @Test
+    public void maven_build_jar_project_on_master_disable_globally_generated_artifacts_publisher_succeeds() throws Exception {
+        maven_build_jar_project_on_master_with_globally_disabled_publisher_succeeds(new GeneratedArtifactsPublisher.DescriptorImpl());
+    }
+
+    private void maven_build_jar_project_on_master_with_globally_disabled_publisher_succeeds(MavenPublisher.DescriptorImpl descriptor) throws Exception {
+
+        MavenPublisher publisher = descriptor.clazz.newInstance();
+        publisher.setDisabled(true);
+
+        GlobalPipelineMavenConfig globalPipelineMavenConfig = GlobalPipelineMavenConfig.get();
+
+        globalPipelineMavenConfig.setPublisherOptions(publisher);
+        try {
+
+
+            Symbol symbolAnnotation = descriptor.getClass().getAnnotation(Symbol.class);
+            String symbol = symbolAnnotation.value()[0];
+            String displayName = descriptor.getDisplayName();
+
+            loadMavenJarProjectInGitRepo(this.gitRepoRule);
+
+            String pipelineScript = "node('master') {\n" +
+                    "    git($/" + gitRepoRule.toString() + "/$)\n" +
+                    "    withMaven() {\n" +
+                    "        sh 'mvn package verify'\n" +
+                    "    }\n" +
+                    "}";
+
+            WorkflowJob pipeline = jenkinsRule.createProject(WorkflowJob.class, "build-on-master-" + symbol + "-publisher-globally-disabled");
+            pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+            WorkflowRun build = jenkinsRule.assertBuildStatus(Result.SUCCESS, pipeline.scheduleBuild2(0));
+
+            String message = "[withMaven] Skip '" + displayName + "' disabled by configuration";
+            jenkinsRule.assertLogContains(message, build);
+        } finally {
+            globalPipelineMavenConfig.setPublisherOptions((List<MavenPublisher>) null);
+        }
+    }
+
+
+    @Test
+    public void maven_build_jar_project_on_master_with_findbugs_publisher_configured_both_globally_and_on_the_pipeline_succeeds() throws Exception {
+        maven_build_jar_project_on_master_with_publisher_configured_both_globally_and_on_the_pipeline_succeeds(new FindbugsAnalysisPublisher.DescriptorImpl());
+    }
+
+    @Test
+    public void maven_build_jar_project_on_master_with_task_scanner_publisher_configured_both_globally_and_on_the_pipeline_succeeds() throws Exception {
+        maven_build_jar_project_on_master_with_publisher_configured_both_globally_and_on_the_pipeline_succeeds(new TasksScannerPublisher.DescriptorImpl());
+    }
+
+    @Test
+    public void maven_build_jar_project_on_master_with_junit_publisher_configured_both_globally_and_on_the_pipeline_succeeds() throws Exception {
+        maven_build_jar_project_on_master_with_publisher_configured_both_globally_and_on_the_pipeline_succeeds(new JunitTestsPublisher.DescriptorImpl());
+    }
+
+    @Test
+    public void maven_build_jar_project_on_master_with_generated_artifacts_publisher_configured_both_globally_and_on_the_pipeline_succeeds() throws Exception {
+        maven_build_jar_project_on_master_with_publisher_configured_both_globally_and_on_the_pipeline_succeeds(new GeneratedArtifactsPublisher.DescriptorImpl());
+    }
+
+    private void maven_build_jar_project_on_master_with_publisher_configured_both_globally_and_on_the_pipeline_succeeds(MavenPublisher.DescriptorImpl descriptor) throws Exception {
+
+        MavenPublisher publisher = descriptor.clazz.newInstance();
+        publisher.setDisabled(true);
+
+        GlobalPipelineMavenConfig globalPipelineMavenConfig = GlobalPipelineMavenConfig.get();
+
+        globalPipelineMavenConfig.setPublisherOptions(publisher);
+        try {
+
+
+            Symbol symbolAnnotation = descriptor.getClass().getAnnotation(Symbol.class);
+            String symbol = symbolAnnotation.value()[0];
+            String displayName = descriptor.getDisplayName();
+
+            loadMavenJarProjectInGitRepo(this.gitRepoRule);
+
+            String pipelineScript = "node('master') {\n" +
+                    "    git($/" + gitRepoRule.toString() + "/$)\n" +
+                    "    withMaven(options:[" + symbol + "(disabled: true)]) {\n" +
+                    "        sh 'mvn package verify'\n" +
+                    "    }\n" +
+                    "}";
+
+            WorkflowJob pipeline = jenkinsRule.createProject(WorkflowJob.class, "build-on-master-" + symbol + "-publisher-defined-globally-and-in-the-pipeline");
+            pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+            WorkflowRun build = jenkinsRule.assertBuildStatus(Result.SUCCESS, pipeline.scheduleBuild2(0));
+
+            jenkinsRule.assertLogContains("[withMaven] WARNING merging publisher configuration defined in the 'Global Tool Configuration' and at the pipeline level is not yet supported. " +
+                    "Use pipeline level configuration for '" + displayName +                     "'", build);
+            jenkinsRule.assertLogContains("[withMaven] Skip '" + displayName + "' disabled by configuration", build);
+        } finally {
+            globalPipelineMavenConfig.setPublisherOptions((List<MavenPublisher>) null);
+        }
+    }
+
+    private void loadMavenJarProjectInGitRepo(GitSampleRepoRule gitRepo) throws Exception {
+        loadSourceCodeInGitRepository(gitRepo, "/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_jar_project/");
+    }
+
+    private void loadSourceCodeInGitRepository(GitSampleRepoRule gitRepo, String name) throws Exception {
+        gitRepo.init();
+        Path mavenProjectRoot = Paths.get(WithMavenStepGlobalConfigurationTest.class.getResource(name).toURI());
+        if (!Files.exists(mavenProjectRoot)) {
+            throw new IllegalStateException("Folder '" + mavenProjectRoot + "' not found");
+        }
+        GitSampleRepoRuleUtils.addFilesAndCommit(mavenProjectRoot, this.gitRepoRule);
+    }
+}


### PR DESCRIPTION
[JENKINS-44384](https://issues.jenkins-ci.org/browse/JENKINS-44384) Support configuration of `withMaven()` publishers in the Jenkins "Global Tools Configuration" section.

ℹ️  If a publisher is configured both in the  Jenkins "Global Tools Configuration" section and in the pipeline (`withMaven(options: [myPublisher(...)]){}`) then the merge of the settings is NOT yet supported, we pick the pipeline configuration and ignore the global configuration.
