### PR TITLE
[JENKINS-44536] Use "WorkspaceList.tempDir()" instead of manually bui…

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -938,8 +938,7 @@ class WithMavenStepExecution extends StepExecution {
      * @return the temporary dir
      */
     private static FilePath tempDir(FilePath ws) {
-        // TODO replace with WorkspaceList.tempDir(ws) after 1.652
-        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
+        return WorkspaceList.tempDir(ws);
     }
 
     /**


### PR DESCRIPTION
[JENKINS-44536](https://issues.jenkins-ci.org/browse/JENKINS-44536) Use "WorkspaceList.tempDir()" instead of manually building the tmp folder path