### PR TITLE
JENKINS-45555 : Disable spy through environment when running maven-invoker IT tests

### DIFF
--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
@@ -33,6 +33,7 @@ import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.DependencyResolutio
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.DependencyResolutionResultHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.FailsafeTestExecutionHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.InvokerRunExecutionHandler;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.InvokerStartExecutionHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.JarJarExecutionHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.MavenEventHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.MavenExecutionRequestHandler;
@@ -53,6 +54,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.inject.Named;
@@ -117,6 +119,7 @@ public class JenkinsMavenEventSpy extends AbstractEventSpy {
         handlers.add(new SurefireTestExecutionHandler(reporter));
         handlers.add(new JarJarExecutionHandler(reporter));
         handlers.add(new InvokerRunExecutionHandler(reporter));
+        handlers.add(new InvokerStartExecutionHandler(reporter));
         handlers.add(new DefaultSettingsBuildingRequestHandler(reporter));
         handlers.add(new MavenExecutionRequestHandler(reporter));
         handlers.add(new DependencyResolutionRequestHandler(reporter));

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/InvokerStartExecutionHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/InvokerStartExecutionHandler.java
@@ -36,6 +36,16 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * Handler to alter the <code>org.apache.maven.plugins:maven-invoker-plugin:run</code> goal :
+ * it will append the <code>JENKINS_MAVEN_AGENT_DISABLED</code> (set to <code>true</code>) to
+ * the environment.
+ * <p>
+ * Thus our spy will not run during Invoker integration tests, to avoid recording integration
+ * tests artefacts and dependencies.
+ * @author <a href="mailto:benoit.guerin1@free.fr">Benoit Guérin</a>
+ *
+ */
 public class InvokerStartExecutionHandler extends AbstractExecutionHandler {
 
     public InvokerStartExecutionHandler(final MavenEventReporter reporter) {
@@ -64,13 +74,17 @@ public class InvokerStartExecutionHandler extends AbstractExecutionHandler {
     public boolean _handle(final ExecutionEvent executionEvent) {
         final boolean result = super._handle(executionEvent);
 
+        //TODO move from "system.out.println" to a real logger
         System.out.println("[jenkins-maven-event-spy] INFO start of goal " + getSupportedPluginGoal() + ", disabling spy in IT tests.");
 
+        // First retrieve the "environmentVariables" configuration of the captured Mojo
         Xpp3Dom env = executionEvent.getMojoExecution().getConfiguration().getChild("environmentVariables");
         if (env == null) {
+            // if the mojo does not have such a configuration, create an empty one
             env = new Xpp3Dom("environmentVariables");
             executionEvent.getMojoExecution().getConfiguration().addChild(env);
         }
+        // Finally, adding our environment variable to disable our spy during the integration tests runs
         Xpp3Dom disableSpy = new Xpp3Dom(DISABLE_MAVEN_EVENT_SPY_ENVIRONMENT_VARIABLE_NAME);
         disableSpy.setValue("true");
         env.addChild(disableSpy);

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/InvokerStartExecutionHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/InvokerStartExecutionHandler.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.maven.eventspy.handler;
+
+import static org.jenkinsci.plugins.pipeline.maven.eventspy.JenkinsMavenEventSpy.DISABLE_MAVEN_EVENT_SPY_ENVIRONMENT_VARIABLE_NAME;
+
+import org.apache.maven.execution.ExecutionEvent;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class InvokerStartExecutionHandler extends AbstractExecutionHandler {
+
+    public InvokerStartExecutionHandler(final MavenEventReporter reporter) {
+        super(reporter);
+    }
+
+    @Override
+    @Nullable
+    protected ExecutionEvent.Type getSupportedType() {
+        return ExecutionEvent.Type.MojoStarted;
+    }
+
+    @Nullable
+    @Override
+    protected String getSupportedPluginGoal() {
+        return "org.apache.maven.plugins:maven-invoker-plugin:run";
+    }
+
+    @Nonnull
+    @Override
+    protected List<String> getConfigurationParametersToReport(final ExecutionEvent executionEvent) {
+        return new ArrayList<String>();
+    }
+
+    @Override
+    public boolean _handle(final ExecutionEvent executionEvent) {
+        final boolean result = super._handle(executionEvent);
+
+        System.out.println("[jenkins-maven-event-spy] INFO start of goal " + getSupportedPluginGoal() + ", disabling spy in IT tests.");
+
+        Xpp3Dom env = executionEvent.getMojoExecution().getConfiguration().getChild("environmentVariables");
+        if (env == null) {
+            env = new Xpp3Dom("environmentVariables");
+            executionEvent.getMojoExecution().getConfiguration().addChild(env);
+        }
+        Xpp3Dom disableSpy = new Xpp3Dom(DISABLE_MAVEN_EVENT_SPY_ENVIRONMENT_VARIABLE_NAME);
+        disableSpy.setValue("true");
+        env.addChild(disableSpy);
+
+        return result;
+    }
+}

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
@@ -33,11 +33,9 @@ import org.jenkinsci.plugins.pipeline.maven.eventspy.RuntimeIOException;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Date;


### PR DESCRIPTION
By default, IT tests ran by the _maven-invoker-plugin_ will see the `JAVA_TOOL_OPTIONS` environment variable and thus enable the event-spy.

All IT tests runs will be recorded and their artefacts will be archived and fingerprinted as they were from the main project.
But one do not care about that artefacts, they came from test projets.

To avoid this, if we detect the launch of the _maven-invoker-plugin:run_ goal, we append to its configuration the environment variable that will disable the event-spy during IT tests.