### PR TITLE
[JENKINS-45221] Use case insensitive path when computing the workspace relative path

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtils.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtils.java
@@ -222,11 +222,11 @@ public class XmlUtils {
             sanitizedWorkspaceRemote = workspaceRemote;
         }
 
-        if (!sanitizedAbsoluteFilePath.startsWith(sanitizedWorkspaceRemote)) {
+        if (!StringUtils.startsWithIgnoreCase(sanitizedAbsoluteFilePath, sanitizedWorkspaceRemote)) {
             throw new IllegalArgumentException("Cannot relativize '" + absoluteFilePath + "' relatively to '" + workspace.getRemote() + "'");
         }
 
-        String relativePath = StringUtils.substringAfter(sanitizedAbsoluteFilePath, sanitizedWorkspaceRemote);
+        String relativePath = StringUtils.removeStartIgnoreCase(sanitizedAbsoluteFilePath, sanitizedWorkspaceRemote);
         String fileSeparator = windows ? "\\" : "/";
 
         if (relativePath.startsWith(fileSeparator)) {

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
@@ -5,6 +5,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -174,6 +175,17 @@ public class XmlUtilsTest {
         String absolutePath = "C:\\path\\to\\spring-petclinic\\target/abc.xml";
         String actual = XmlUtils.getPathInWorkspace(absolutePath, new FilePath(new File(workspace)));
         String expected = "target\\abc.xml";
+        Assert.assertThat(actual, CoreMatchers.is(expected));
+    }
+
+    @Issue("JENKINS-45221")
+    @Test
+    public void test_getPathInWorkspace_windows_mixed_case_ok_JENKINS_45221() {
+        // lowercase versus uppercase "d:\"
+        String workspace = "d:\\jenkins\\workspace\\d.admin_feature_Jenkinsfile-SCSMHLROYAGBAWY5ZNNG6ALR77MVLEH3F3EFF3O7XN3RO5BL6AMA";
+        String absolutePath = "D:\\jenkins\\workspace\\d.admin_feature_Jenkinsfile-SCSMHLROYAGBAWY5ZNNG6ALR77MVLEH3F3EFF3O7XN3RO5BL6AMA\\admin\\xyz\\target\\pad-admin-xyz-2.4.0-SNAPSHOT-tests.jar";
+        String actual = XmlUtils.getPathInWorkspace(absolutePath, new FilePath(new File(workspace)));
+        String expected = "admin\\xyz\\target\\pad-admin-xyz-2.4.0-SNAPSHOT-tests.jar";
         Assert.assertThat(actual, CoreMatchers.is(expected));
     }
 

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
@@ -3,7 +3,7 @@
 #
 
 # cf. JavaContainer/Dockerfile
-FROM jenkins/java:42a1c8d4b931
+FROM jenkins/java:eed7706a10fb
 
 RUN apt-get update
 RUN apt-get install --no-install-recommends -y git


### PR DESCRIPTION
[JENKINS-45221](https://issues.jenkins-ci.org/browse/JENKINS-45221) Use case insensitive path when computing the workspace relative path.


