### PR TITLE
[JENKINS-19508] Eliminate some optional deps

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -98,7 +98,7 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-multibranch</artifactId>
       <version>2.14</version>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -110,7 +110,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
       <version>2.0.9</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListener.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListener.java
@@ -6,7 +6,6 @@ import hudson.console.ModelHyperlinkNote;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Item;
-import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
@@ -15,23 +14,17 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
-import jenkins.branch.MultiBranchProject;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
-import jenkins.triggers.Messages;
 import org.acegisecurity.Authentication;
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
 import org.jenkinsci.plugins.pipeline.maven.GlobalPipelineMavenConfig;
 import org.jenkinsci.plugins.pipeline.maven.trigger.WorkflowJobDependencyTrigger;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -124,9 +117,9 @@ public class DownstreamPipelineTriggerRunListener extends RunListener<WorkflowRu
             }
         }
 
-        if (parameterizedJob.getParent() instanceof WorkflowMultiBranchProject) {
+        if (parameterizedJob.getParent() instanceof ComputedFolder) {
             // search for the triggers of MultiBranch pipelines
-            WorkflowMultiBranchProject multiBranchProject = (WorkflowMultiBranchProject) parameterizedJob.getParent();
+            ComputedFolder<?> multiBranchProject = (ComputedFolder) parameterizedJob.getParent();
             for (Trigger trigger : multiBranchProject.getTriggers().values()) {
                 if (trigger instanceof WorkflowJobDependencyTrigger) {
                     return (WorkflowJobDependencyTrigger) trigger;
@@ -135,7 +128,7 @@ public class DownstreamPipelineTriggerRunListener extends RunListener<WorkflowRu
 
             if (multiBranchProject.getParent() instanceof ComputedFolder) {
                 // search for the triggers of GitHubOrg folders / Bitbucket folders
-                ComputedFolder grandParent = (ComputedFolder) multiBranchProject.getParent();
+                ComputedFolder<?> grandParent = (ComputedFolder) multiBranchProject.getParent();
                 Map<TriggerDescriptor, Trigger<?>> grandParentTriggers = grandParent.getTriggers();
                 for (Trigger trigger : grandParentTriggers.values()) {
                     if (trigger instanceof WorkflowJobDependencyTrigger) {


### PR DESCRIPTION
As per [JENKINS-19508](https://issues.jenkins-ci.org/browse/JENKINS-19508), you should avoid `optional` dependencies unless you really know what you are doing, and even then you should avoid them, and if you really need to use them you must take care to test the plugin with the dependencies missing.

In this case if `branch-api` is not present but `pipeline-maven-plugin` is, Jenkins explodes when trying to create a new project (not even Pipeline!):

```
java.lang.NoClassDefFoundError: jenkins/branch/MultiBranchProject
	at org.jenkinsci.plugins.pipeline.maven.trigger.WorkflowJobDependencyTrigger$DescriptorImpl.isApplicable(WorkflowJobDependencyTrigger.java:30)
```

crashes the job configuration screen.

@reviewbybees