### PR TITLE
past tense

### DIFF
--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/trigger/WorkflowJobDependencyTrigger/help.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/trigger/WorkflowJobDependencyTrigger/help.html
@@ -1,8 +1,8 @@
 <div>
-  Trigger the build of this pipeline when a Maven SNAPSHOT dependency is being built by this Jenkins instance.
+  Trigger the build of this pipeline when a Maven SNAPSHOT dependency is built by this Jenkins instance.
 
   Jenkins discovers all the dependencies of the Maven builds of this pipeline invoked in a <code>withMaven(){...}</code> wrapping step and
-  will trigger the build if one of these dependencies is being built (typically a SNAPSHOT version).
+  will trigger the build if one of these dependencies has been built (typically a SNAPSHOT version).
 
   This is convenient for automatically performing continuous integration. Jenkins will check the snapshot dependencies from the <code>&lt;dependency&gt;</code> element in the POM.
 


### PR DESCRIPTION
there is no point in building something if its dependency is being built (you would have to wait until the thing has been built to be able to use it)

So assuming that the plugin does the right thing and triggers after a dependency has been built and updating the text accordingly.

@cyrille-leclerc I assume you know the behaviour and can say if this is correct text or not.