### PR TITLE
[JENKINS-46511] Option to only trigger downstream pipelines when the generated artifact has been "mvn deploy", not "mvn package" or "mvn install"

### DIFF
--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-jar.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-jar.xml
@@ -1,0 +1,474 @@
+<mavenExecution _time="2017-09-02 15:18:36.786">
+    <context _time="2017-09-02 15:18:36.792">
+        <systemProperties/>
+        <versionProperties/>
+        <workingDirectory/>
+        <userProperties/>
+        <plexus/>
+    </context>
+    <!-- 2017-09-02 15:18:36.793 - new File(.):                                 -->
+    <!-- /path/to/my-jar                       -->
+
+    <DefaultSettingsBuildingRequest class="org.apache.maven.settings.building.DefaultSettingsBuildingRequest" _time="2017-09-02 15:18:36.906">
+        <userSettingsFile>/path/to/home/.m2/settings.xml</userSettingsFile>
+        <globalSettings>/path/to/maven/3.5.0/libexec/conf/settings.xml</globalSettings>
+    </DefaultSettingsBuildingRequest>
+    <MavenExecutionRequest class="org.apache.maven.execution.DefaultMavenExecutionRequest" _time="2017-09-02 15:18:36.94">
+        <pom>/path/to/my-jar/pom.xml</pom>
+        <globalSettingsFile>/path/to/maven/3.5.0/libexec/conf/settings.xml</globalSettingsFile>
+        <userSettingsFile>/path/to/home/.m2/settings.xml</userSettingsFile>
+        <baseDirectory>/path/to/my-jar</baseDirectory>
+    </MavenExecutionRequest>
+    <ExecutionEvent type="ProjectDiscoveryStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:37.243">
+        <project/>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <ExecutionEvent type="SessionStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:37.32">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:37.324">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <DependencyResolutionRequest class="org.apache.maven.project.DefaultDependencyResolutionRequest" _time="2017-09-02 15:18:37.467">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+    </DependencyResolutionRequest>
+    <DependencyResolutionResult class="org.apache.maven.project.DefaultDependencyResolutionResult" _time="2017-09-02 15:18:37.491">
+        <resolvedDependencies>
+            <dependency extension="jar" baseVersion="4.12" groupId="junit" scope="test" name="junit-4.12.jar" classifier="" artifactId="junit" optional="false" id="junit" type="jar" version="4.12" snapshot="false">
+                <file>/path/to/home/.m2/repository/junit/junit/4.12/junit-4.12.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-core-1.3.jar" classifier="" artifactId="hamcrest-core" optional="false" id="hamcrest-core" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar</file>
+            </dependency>
+        </resolvedDependencies>
+    </DependencyResolutionResult>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:37.492">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-resources" goal="resources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.resources}</resources>
+            <session>${session}</session>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>true</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:37.7">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-resources" goal="resources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.resources}</resources>
+            <session>${session}</session>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>true</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:37.702">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-compile" goal="compile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.compileClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <projectArtifact>${project.artifact}</projectArtifact>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skipMain>${maven.main.skip}</skipMain>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:38.124">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-compile" goal="compile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.compileClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <projectArtifact>${project.artifact}</projectArtifact>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skipMain>${maven.main.skip}</skipMain>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:38.125">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-testResources" goal="testResources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.testResources}</resources>
+            <session>${session}</session>
+            <skip>${maven.test.skip}</skip>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>true</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:38.129">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-testResources" goal="testResources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.testResources}</resources>
+            <session>${session}</session>
+            <skip>${maven.test.skip}</skip>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>true</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:38.129">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-testCompile" goal="testCompile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.testClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.testCompileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/test-annotations</generatedTestSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skip>${maven.test.skip}</skip>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <testSource>${maven.compiler.testSource}</testSource>
+            <testTarget>${maven.compiler.testTarget}</testTarget>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:38.137">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-testCompile" goal="testCompile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.testClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.testCompileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/test-annotations</generatedTestSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skip>${maven.test.skip}</skip>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <testSource>${maven.compiler.testSource}</testSource>
+            <testTarget>${maven.compiler.testTarget}</testTarget>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:38.137">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-test" goal="test" groupId="org.apache.maven.plugins" artifactId="maven-surefire-plugin" version="2.12.4">
+            <argLine>${argLine}</argLine>
+            <basedir>${basedir}</basedir>
+            <childDelegation>${childDelegation}</childDelegation>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <debugForkedProcess>${maven.surefire.debug}</debugForkedProcess>
+            <disableXmlReport>${disableXmlReport}</disableXmlReport>
+            <enableAssertions>${enableAssertions}</enableAssertions>
+            <excludedGroups>${excludedGroups}</excludedGroups>
+            <failIfNoSpecifiedTests>${surefire.failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
+            <failIfNoTests>${failIfNoTests}</failIfNoTests>
+            <forkMode>${forkMode}</forkMode>
+            <forkedProcessTimeoutInSeconds>${surefire.timeout}</forkedProcessTimeoutInSeconds>
+            <groups>${groups}</groups>
+            <junitArtifactName>${junitArtifactName}</junitArtifactName>
+            <jvm>${jvm}</jvm>
+            <localRepository>${localRepository}</localRepository>
+            <objectFactory>${objectFactory}</objectFactory>
+            <parallel>${parallel}</parallel>
+            <parallelMavenExecution>${session.parallel}</parallelMavenExecution>
+            <perCoreThreadCount>${perCoreThreadCount}</perCoreThreadCount>
+            <pluginArtifactMap>${plugin.artifactMap}</pluginArtifactMap>
+            <pluginDescriptor>${plugin}</pluginDescriptor>
+            <printSummary>${surefire.printSummary}</printSummary>
+            <projectArtifactMap>${project.artifactMap}</projectArtifactMap>
+            <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
+            <remoteRepositories>${project.pluginArtifactRepositories}</remoteRepositories>
+            <reportFormat>${surefire.reportFormat}</reportFormat>
+            <reportNameSuffix>${surefire.reportNameSuffix}</reportNameSuffix>
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+            <runOrder>filesystem</runOrder>
+            <skip>${maven.test.skip}</skip>
+            <skipExec>${maven.test.skip.exec}</skipExec>
+            <skipTests>${skipTests}</skipTests>
+            <test>${test}</test>
+            <testClassesDirectory>${project.build.testOutputDirectory}</testClassesDirectory>
+            <testFailureIgnore>${maven.test.failure.ignore}</testFailureIgnore>
+            <testNGArtifactName>${testNGArtifactName}</testNGArtifactName>
+            <testSourceDirectory>${project.build.testSourceDirectory}</testSourceDirectory>
+            <threadCount>${threadCount}</threadCount>
+            <trimStackTrace>${trimStackTrace}</trimStackTrace>
+            <useFile>${surefire.useFile}</useFile>
+            <useManifestOnlyJar>${surefire.useManifestOnlyJar}</useManifestOnlyJar>
+            <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
+            <useUnlimitedThreads>${useUnlimitedThreads}</useUnlimitedThreads>
+            <workingDirectory>${basedir}</workingDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:38.822">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-test" goal="test" groupId="org.apache.maven.plugins" artifactId="maven-surefire-plugin" version="2.12.4">
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:38.822">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-jar" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-jar-plugin" version="2.4">
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <defaultManifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</defaultManifestFile>
+            <finalName>${jar.finalName}</finalName>
+            <forceCreation>${jar.forceCreation}</forceCreation>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+            <skipIfEmpty>${jar.skipIfEmpty}</skipIfEmpty>
+            <useDefaultManifestFile>${jar.useDefaultManifestFile}</useDefaultManifestFile>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:39.113">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-jar" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-jar-plugin" version="2.4">
+            <finalName>${jar.finalName}</finalName>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:39.113">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.4">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:39.197">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.4">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:39.197">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-deploy" goal="deploy" groupId="org.apache.maven.plugins" artifactId="maven-deploy-plugin" version="2.8.2">
+            <altDeploymentRepository>${altDeploymentRepository}</altDeploymentRepository>
+            <altReleaseDeploymentRepository>${altReleaseDeploymentRepository}</altReleaseDeploymentRepository>
+            <altSnapshotDeploymentRepository>${altSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <deployAtEnd>${deployAtEnd}</deployAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <retryFailedDeploymentCount>${retryFailedDeploymentCount}</retryFailedDeploymentCount>
+            <skip>${maven.deploy.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:39.76">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <plugin executionId="default-deploy" goal="deploy" groupId="org.apache.maven.plugins" artifactId="maven-deploy-plugin" version="2.8.2">
+            <altDeploymentRepository>${altDeploymentRepository}</altDeploymentRepository>
+            <altReleaseDeploymentRepository>${altReleaseDeploymentRepository}</altReleaseDeploymentRepository>
+            <altSnapshotDeploymentRepository>${altSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <deployAtEnd>${deployAtEnd}</deployAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <retryFailedDeploymentCount>${retryFailedDeploymentCount}</retryFailedDeploymentCount>
+            <skip>${maven.deploy.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:18:39.761">
+        <project baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" version="0.3-SNAPSHOT">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </project>
+        <no-execution-found/>
+        <artifact extension="jar" baseVersion="0.3-SNAPSHOT" groupId="com.example" artifactId="my-jar" id="com.example:my-jar:jar:0.3-SNAPSHOT" type="jar" version="0.3-20170902.221839-9" snapshot="true">
+            <file>/path/to/my-jar/target/my-jar-0.3-SNAPSHOT.jar</file>
+        </artifact>
+        <attachedArtifacts/>
+    </ExecutionEvent>
+    <MavenExecutionResult class="org.apache.maven.execution.DefaultMavenExecutionResult" _time="2017-09-02 15:18:39.887">
+        <buildSummary baseDir="/path/to/my-jar" file="/path/to/my-jar/pom.xml" groupId="com.example" name="my-jar" artifactId="my-jar" time="2436" version="0.3-SNAPSHOT" class="org.apache.maven.execution.BuildSuccess">
+            <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
+        </buildSummary>
+    </MavenExecutionResult>
+    <!-- 2017-09-02 15:18:39.889 - close:                                       -->
+    <!-- ignored:[org.eclipse.aether.RepositoryEvent,                           -->
+    <!-- org.apache.maven.settings.building.DefaultSettingsBuildingResult],     -->
+    <!-- blackListed: []                                                        -->
+
+</mavenExecution>

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-multi-module.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-multi-module.xml
@@ -1,0 +1,3331 @@
+<mavenExecution _time="2017-09-02 15:20:44.046">
+    <context _time="2017-09-02 15:20:44.051">
+        <systemProperties/>
+        <versionProperties/>
+        <workingDirectory/>
+        <userProperties/>
+        <plexus/>
+    </context>
+    <!-- 2017-09-02 15:20:44.053 - new File(.):                                 -->
+    <!-- /path/to/multi-module-maven-project   -->
+
+    <DefaultSettingsBuildingRequest class="org.apache.maven.settings.building.DefaultSettingsBuildingRequest" _time="2017-09-02 15:20:44.173">
+        <userSettingsFile>/path/to/home/.m2/settings.xml</userSettingsFile>
+        <globalSettings>/path/to/maven/3.5.0/libexec/conf/settings.xml</globalSettings>
+    </DefaultSettingsBuildingRequest>
+    <MavenExecutionRequest class="org.apache.maven.execution.DefaultMavenExecutionRequest" _time="2017-09-02 15:20:44.206">
+        <pom>/path/to/multi-module-maven-project/pom.xml</pom>
+        <globalSettingsFile>/path/to/maven/3.5.0/libexec/conf/settings.xml</globalSettingsFile>
+        <userSettingsFile>/path/to/home/.m2/settings.xml</userSettingsFile>
+        <baseDirectory>/path/to/multi-module-maven-project</baseDirectory>
+    </MavenExecutionRequest>
+    <ExecutionEvent type="ProjectDiscoveryStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:44.46">
+        <project/>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <ExecutionEvent type="SessionStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:44.891">
+        <project baseDir="/path/to/multi-module-maven-project" file="/path/to/multi-module-maven-project/pom.xml" groupId="com.example" name="demo-parent" artifactId="demo-parent" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/src/main/java" directory="/path/to/multi-module-maven-project/target"/>
+        </project>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:44.897">
+        <project baseDir="/path/to/multi-module-maven-project" file="/path/to/multi-module-maven-project/pom.xml" groupId="com.example" name="demo-parent" artifactId="demo-parent" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/src/main/java" directory="/path/to/multi-module-maven-project/target"/>
+        </project>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:44.95">
+        <project baseDir="/path/to/multi-module-maven-project" file="/path/to/multi-module-maven-project/pom.xml" groupId="com.example" name="demo-parent" artifactId="demo-parent" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/src/main/java" directory="/path/to/multi-module-maven-project/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.5.2">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <installAtEnd>${installAtEnd}</installAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:45.151">
+        <project baseDir="/path/to/multi-module-maven-project" file="/path/to/multi-module-maven-project/pom.xml" groupId="com.example" name="demo-parent" artifactId="demo-parent" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/src/main/java" directory="/path/to/multi-module-maven-project/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.5.2">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <installAtEnd>${installAtEnd}</installAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:45.151">
+        <project baseDir="/path/to/multi-module-maven-project" file="/path/to/multi-module-maven-project/pom.xml" groupId="com.example" name="demo-parent" artifactId="demo-parent" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/src/main/java" directory="/path/to/multi-module-maven-project/target"/>
+        </project>
+        <plugin executionId="default-deploy" goal="deploy" groupId="org.apache.maven.plugins" artifactId="maven-deploy-plugin" version="2.8.2">
+            <altDeploymentRepository>${altDeploymentRepository}</altDeploymentRepository>
+            <altReleaseDeploymentRepository>${altReleaseDeploymentRepository}</altReleaseDeploymentRepository>
+            <altSnapshotDeploymentRepository>${altSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <deployAtEnd>${deployAtEnd}</deployAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <retryFailedDeploymentCount>${retryFailedDeploymentCount}</retryFailedDeploymentCount>
+            <skip>${maven.deploy.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:45.856">
+        <project baseDir="/path/to/multi-module-maven-project" file="/path/to/multi-module-maven-project/pom.xml" groupId="com.example" name="demo-parent" artifactId="demo-parent" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/src/main/java" directory="/path/to/multi-module-maven-project/target"/>
+        </project>
+        <plugin executionId="default-deploy" goal="deploy" groupId="org.apache.maven.plugins" artifactId="maven-deploy-plugin" version="2.8.2">
+            <altDeploymentRepository>${altDeploymentRepository}</altDeploymentRepository>
+            <altReleaseDeploymentRepository>${altReleaseDeploymentRepository}</altReleaseDeploymentRepository>
+            <altSnapshotDeploymentRepository>${altSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <deployAtEnd>${deployAtEnd}</deployAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <retryFailedDeploymentCount>${retryFailedDeploymentCount}</retryFailedDeploymentCount>
+            <skip>${maven.deploy.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:45.857">
+        <project baseDir="/path/to/multi-module-maven-project" file="/path/to/multi-module-maven-project/pom.xml" groupId="com.example" name="demo-parent" artifactId="demo-parent" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/src/main/java" directory="/path/to/multi-module-maven-project/target"/>
+        </project>
+        <no-execution-found/>
+        <artifact extension="pom" baseVersion="0.0.29-SNAPSHOT" groupId="com.example" artifactId="demo-parent" id="com.example:demo-parent:pom:0.0.29-SNAPSHOT" type="pom" version="0.0.29-20170902.222045-1" snapshot="true">
+            <file/>
+        </artifact>
+        <attachedArtifacts/>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:45.858">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <DependencyResolutionRequest class="org.apache.maven.project.DefaultDependencyResolutionRequest" _time="2017-09-02 15:20:45.924">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+    </DependencyResolutionRequest>
+    <DependencyResolutionResult class="org.apache.maven.project.DefaultDependencyResolutionResult" _time="2017-09-02 15:20:45.93">
+        <resolvedDependencies/>
+    </DependencyResolutionResult>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:45.93">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-resources" goal="resources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.resources}</resources>
+            <session>${session}</session>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.06">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-resources" goal="resources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.resources}</resources>
+            <session>${session}</session>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.061">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-compile" goal="compile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.compileClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <projectArtifact>${project.artifact}</projectArtifact>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skipMain>${maven.main.skip}</skipMain>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.238">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-compile" goal="compile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.compileClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <projectArtifact>${project.artifact}</projectArtifact>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skipMain>${maven.main.skip}</skipMain>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.238">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-testResources" goal="testResources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.testResources}</resources>
+            <session>${session}</session>
+            <skip>${maven.test.skip}</skip>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.241">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-testResources" goal="testResources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.testResources}</resources>
+            <session>${session}</session>
+            <skip>${maven.test.skip}</skip>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.241">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-testCompile" goal="testCompile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.testClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.testCompileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/test-annotations</generatedTestSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skip>${maven.test.skip}</skip>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <testSource>${maven.compiler.testSource}</testSource>
+            <testTarget>${maven.compiler.testTarget}</testTarget>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.244">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-testCompile" goal="testCompile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.testClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.testCompileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/test-annotations</generatedTestSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skip>${maven.test.skip}</skip>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <testSource>${maven.compiler.testSource}</testSource>
+            <testTarget>${maven.compiler.testTarget}</testTarget>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.244">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-test" goal="test" groupId="org.apache.maven.plugins" artifactId="maven-surefire-plugin" version="2.18.1">
+            <additionalClasspathElements>${maven.test.additionalClasspath}</additionalClasspathElements>
+            <argLine>${argLine}</argLine>
+            <basedir>${basedir}</basedir>
+            <childDelegation>${childDelegation}</childDelegation>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <classpathDependencyExcludes>${maven.test.dependency.excludes}</classpathDependencyExcludes>
+            <debugForkedProcess>${maven.surefire.debug}</debugForkedProcess>
+            <dependenciesToScan>${dependenciesToScan}</dependenciesToScan>
+            <disableXmlReport>${disableXmlReport}</disableXmlReport>
+            <enableAssertions>${enableAssertions}</enableAssertions>
+            <excludedGroups>${excludedGroups}</excludedGroups>
+            <excludes>
+                <exclude>**/Abstract*.java</exclude>
+            </excludes>
+            <failIfNoSpecifiedTests>${surefire.failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
+            <failIfNoTests>${failIfNoTests}</failIfNoTests>
+            <forkCount>${forkCount}</forkCount>
+            <forkMode>${forkMode}</forkMode>
+            <forkedProcessTimeoutInSeconds>${surefire.timeout}</forkedProcessTimeoutInSeconds>
+            <groups>${groups}</groups>
+            <includes>
+                <include>**/*Tests.java</include>
+                <include>**/*Test.java</include>
+            </includes>
+            <junitArtifactName>${junitArtifactName}</junitArtifactName>
+            <jvm>${jvm}</jvm>
+            <localRepository>${localRepository}</localRepository>
+            <objectFactory>${objectFactory}</objectFactory>
+            <parallel>${parallel}</parallel>
+            <parallelMavenExecution>${session.parallel}</parallelMavenExecution>
+            <parallelOptimized>${parallelOptimized}</parallelOptimized>
+            <parallelTestsTimeoutForcedInSeconds>${surefire.parallel.forcedTimeout}</parallelTestsTimeoutForcedInSeconds>
+            <parallelTestsTimeoutInSeconds>${surefire.parallel.timeout}</parallelTestsTimeoutInSeconds>
+            <perCoreThreadCount>${perCoreThreadCount}</perCoreThreadCount>
+            <pluginArtifactMap>${plugin.artifactMap}</pluginArtifactMap>
+            <pluginDescriptor>${plugin}</pluginDescriptor>
+            <printSummary>${surefire.printSummary}</printSummary>
+            <projectArtifactMap>${project.artifactMap}</projectArtifactMap>
+            <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
+            <remoteRepositories>${project.pluginArtifactRepositories}</remoteRepositories>
+            <reportFormat>${surefire.reportFormat}</reportFormat>
+            <reportNameSuffix>${surefire.reportNameSuffix}</reportNameSuffix>
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+            <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
+            <reuseForks>${reuseForks}</reuseForks>
+            <runOrder>${surefire.runOrder}</runOrder>
+            <skip>${maven.test.skip}</skip>
+            <skipExec>${maven.test.skip.exec}</skipExec>
+            <skipTests>${skipTests}</skipTests>
+            <suiteXmlFiles>${surefire.suiteXmlFiles}</suiteXmlFiles>
+            <test>${test}</test>
+            <testClassesDirectory>${project.build.testOutputDirectory}</testClassesDirectory>
+            <testFailureIgnore>${maven.test.failure.ignore}</testFailureIgnore>
+            <testNGArtifactName>${testNGArtifactName}</testNGArtifactName>
+            <testSourceDirectory>${project.build.testSourceDirectory}</testSourceDirectory>
+            <threadCount>${threadCount}</threadCount>
+            <threadCountClasses>${threadCountClasses}</threadCountClasses>
+            <threadCountMethods>${threadCountMethods}</threadCountMethods>
+            <threadCountSuites>${threadCountSuites}</threadCountSuites>
+            <trimStackTrace>${trimStackTrace}</trimStackTrace>
+            <useFile>${surefire.useFile}</useFile>
+            <useManifestOnlyJar>${surefire.useManifestOnlyJar}</useManifestOnlyJar>
+            <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
+            <useUnlimitedThreads>${useUnlimitedThreads}</useUnlimitedThreads>
+            <workingDirectory>${basedir}</workingDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.362">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-test" goal="test" groupId="org.apache.maven.plugins" artifactId="maven-surefire-plugin" version="2.18.1">
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.362">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-jar" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-jar-plugin" version="2.6">
+            <archive>
+                <manifest>
+                    <mainClass>${start-class}</mainClass>
+                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                </manifest>
+            </archive>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <classifier>${maven.jar.classifier}</classifier>
+            <defaultManifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</defaultManifestFile>
+            <finalName>${jar.finalName}</finalName>
+            <forceCreation>${jar.forceCreation}</forceCreation>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+            <skipIfEmpty>${jar.skipIfEmpty}</skipIfEmpty>
+            <useDefaultManifestFile>${jar.useDefaultManifestFile}</useDefaultManifestFile>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.608">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-jar" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-jar-plugin" version="2.6">
+            <finalName>${jar.finalName}</finalName>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.608">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkedProjectStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.61">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <DependencyResolutionRequest class="org.apache.maven.project.DefaultDependencyResolutionRequest" _time="2017-09-02 15:20:46.61">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+    </DependencyResolutionRequest>
+    <DependencyResolutionResult class="org.apache.maven.project.DefaultDependencyResolutionResult" _time="2017-09-02 15:20:46.614">
+        <resolvedDependencies/>
+    </DependencyResolutionResult>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:46.614">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="findbugs" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <remoteRepositories>${project.remoteArtifactRepositories}</remoteRepositories>
+            <skip>${findbugs.skip}</skip>
+            <skipEmptyReport>${findbugs.skipEmptyReport}</skipEmptyReport>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <userPrefs>${findbugs.userPrefs}</userPrefs>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:50.788">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="findbugs" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <remoteRepositories>${project.remoteArtifactRepositories}</remoteRepositories>
+            <skip>${findbugs.skip}</skip>
+            <skipEmptyReport>${findbugs.skipEmptyReport}</skipEmptyReport>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <userPrefs>${findbugs.userPrefs}</userPrefs>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkedProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:50.789">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:50.789">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:50.79">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:50.844">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:50.844">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.5.2">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <installAtEnd>${installAtEnd}</installAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:50.857">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.5.2">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <installAtEnd>${installAtEnd}</installAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:50.857">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-deploy" goal="deploy" groupId="org.apache.maven.plugins" artifactId="maven-deploy-plugin" version="2.8.2">
+            <altDeploymentRepository>${altDeploymentRepository}</altDeploymentRepository>
+            <altReleaseDeploymentRepository>${altReleaseDeploymentRepository}</altReleaseDeploymentRepository>
+            <altSnapshotDeploymentRepository>${altSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <deployAtEnd>${deployAtEnd}</deployAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <retryFailedDeploymentCount>${retryFailedDeploymentCount}</retryFailedDeploymentCount>
+            <skip>${maven.deploy.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.072">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <plugin executionId="default-deploy" goal="deploy" groupId="org.apache.maven.plugins" artifactId="maven-deploy-plugin" version="2.8.2">
+            <altDeploymentRepository>${altDeploymentRepository}</altDeploymentRepository>
+            <altReleaseDeploymentRepository>${altReleaseDeploymentRepository}</altReleaseDeploymentRepository>
+            <altSnapshotDeploymentRepository>${altSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <deployAtEnd>${deployAtEnd}</deployAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <retryFailedDeploymentCount>${retryFailedDeploymentCount}</retryFailedDeploymentCount>
+            <skip>${maven.deploy.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.072">
+        <project baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </project>
+        <no-execution-found/>
+        <artifact extension="jar" baseVersion="0.0.29-SNAPSHOT" groupId="com.example.core" artifactId="shared-core" id="com.example.core:shared-core:jar:0.0.29-SNAPSHOT" type="jar" version="0.0.29-20170902.222050-1" snapshot="true">
+            <file>/path/to/multi-module-maven-project/shared-core/target/shared-core-0.0.29-SNAPSHOT.jar</file>
+        </artifact>
+        <attachedArtifacts/>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.073">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <DependencyResolutionRequest class="org.apache.maven.project.DefaultDependencyResolutionRequest" _time="2017-09-02 15:20:51.139">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+    </DependencyResolutionRequest>
+    <DependencyResolutionResult class="org.apache.maven.project.DefaultDependencyResolutionResult" _time="2017-09-02 15:20:51.344">
+        <resolvedDependencies>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-web-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-web" optional="false" id="spring-boot-starter-web" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-web/1.5.4.RELEASE/spring-boot-starter-web-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter" optional="false" id="spring-boot-starter" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter/1.5.4.RELEASE/spring-boot-starter-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot" optional="false" id="spring-boot" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot/1.5.4.RELEASE/spring-boot-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-autoconfigure-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-autoconfigure" optional="false" id="spring-boot-autoconfigure" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-autoconfigure/1.5.4.RELEASE/spring-boot-autoconfigure-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-logging-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-logging" optional="false" id="spring-boot-starter-logging" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-logging/1.5.4.RELEASE/spring-boot-starter-logging-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.11" groupId="ch.qos.logback" scope="compile" name="logback-classic-1.1.11.jar" classifier="" artifactId="logback-classic" optional="false" id="logback-classic" type="jar" version="1.1.11" snapshot="false">
+                <file>/path/to/home/.m2/repository/ch/qos/logback/logback-classic/1.1.11/logback-classic-1.1.11.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.11" groupId="ch.qos.logback" scope="compile" name="logback-core-1.1.11.jar" classifier="" artifactId="logback-core" optional="false" id="logback-core" type="jar" version="1.1.11" snapshot="false">
+                <file>/path/to/home/.m2/repository/ch/qos/logback/logback-core/1.1.11/logback-core-1.1.11.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="jcl-over-slf4j-1.7.25.jar" classifier="" artifactId="jcl-over-slf4j" optional="false" id="jcl-over-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="jul-to-slf4j-1.7.25.jar" classifier="" artifactId="jul-to-slf4j" optional="false" id="jul-to-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="log4j-over-slf4j-1.7.25.jar" classifier="" artifactId="log4j-over-slf4j" optional="false" id="log4j-over-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/log4j-over-slf4j/1.7.25/log4j-over-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-tomcat-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-tomcat" optional="false" id="spring-boot-starter-tomcat" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-tomcat/1.5.4.RELEASE/spring-boot-starter-tomcat-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-core-8.5.15.jar" classifier="" artifactId="tomcat-embed-core" optional="false" id="tomcat-embed-core" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/8.5.15/tomcat-embed-core-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-el-8.5.15.jar" classifier="" artifactId="tomcat-embed-el" optional="false" id="tomcat-embed-el" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-el/8.5.15/tomcat-embed-el-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-websocket-8.5.15.jar" classifier="" artifactId="tomcat-embed-websocket" optional="false" id="tomcat-embed-websocket" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-websocket/8.5.15/tomcat-embed-websocket-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="5.3.5.Final" groupId="org.hibernate" scope="compile" name="hibernate-validator-5.3.5.Final.jar" classifier="" artifactId="hibernate-validator" optional="false" id="hibernate-validator" type="jar" version="5.3.5.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hibernate/hibernate-validator/5.3.5.Final/hibernate-validator-5.3.5.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.0.Final" groupId="javax.validation" scope="compile" name="validation-api-1.1.0.Final.jar" classifier="" artifactId="validation-api" optional="false" id="validation-api" type="jar" version="1.1.0.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="3.3.1.Final" groupId="org.jboss.logging" scope="compile" name="jboss-logging-3.3.1.Final.jar" classifier="" artifactId="jboss-logging" optional="false" id="jboss-logging" type="jar" version="3.3.1.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/jboss/logging/jboss-logging/3.3.1.Final/jboss-logging-3.3.1.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3.3" groupId="com.fasterxml" scope="compile" name="classmate-1.3.3.jar" classifier="" artifactId="classmate" optional="false" id="classmate" type="jar" version="1.3.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/classmate/1.3.3/classmate-1.3.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.8" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-databind-2.8.8.jar" classifier="" artifactId="jackson-databind" optional="false" id="jackson-databind" type="jar" version="2.8.8" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.8.8/jackson-databind-2.8.8.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.0" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-annotations-2.8.0.jar" classifier="" artifactId="jackson-annotations" optional="false" id="jackson-annotations" type="jar" version="2.8.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.8" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-core-2.8.8.jar" classifier="" artifactId="jackson-core" optional="false" id="jackson-core" type="jar" version="2.8.8" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.8.8/jackson-core-2.8.8.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-web-4.3.9.RELEASE.jar" classifier="" artifactId="spring-web" optional="false" id="spring-web" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-web/4.3.9.RELEASE/spring-web-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-aop-4.3.9.RELEASE.jar" classifier="" artifactId="spring-aop" optional="false" id="spring-aop" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-aop/4.3.9.RELEASE/spring-aop-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-beans-4.3.9.RELEASE.jar" classifier="" artifactId="spring-beans" optional="false" id="spring-beans" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-beans/4.3.9.RELEASE/spring-beans-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-context-4.3.9.RELEASE.jar" classifier="" artifactId="spring-context" optional="false" id="spring-context" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-context/4.3.9.RELEASE/spring-context-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-webmvc-4.3.9.RELEASE.jar" classifier="" artifactId="spring-webmvc" optional="false" id="spring-webmvc" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-webmvc/4.3.9.RELEASE/spring-webmvc-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-expression-4.3.9.RELEASE.jar" classifier="" artifactId="spring-expression" optional="false" id="spring-expression" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-expression/4.3.9.RELEASE/spring-expression-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="0.0.29-SNAPSHOT" groupId="com.example.core" scope="compile" name="shared-core-0.0.29-SNAPSHOT.jar" classifier="" artifactId="shared-core" optional="false" id="shared-core" type="jar" version="0.0.29-SNAPSHOT" snapshot="true">
+                <file>/path/to/multi-module-maven-project/shared-core/target/shared-core-0.0.29-SNAPSHOT.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-starter-test-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-test" optional="false" id="spring-boot-starter-test" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-test/1.5.4.RELEASE/spring-boot-starter-test-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-test-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-test" optional="false" id="spring-boot-test" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-test/1.5.4.RELEASE/spring-boot-test-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-test-autoconfigure-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-test-autoconfigure" optional="false" id="spring-boot-test-autoconfigure" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-test-autoconfigure/1.5.4.RELEASE/spring-boot-test-autoconfigure-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.0" groupId="com.jayway.jsonpath" scope="test" name="json-path-2.2.0.jar" classifier="" artifactId="json-path" optional="false" id="json-path" type="jar" version="2.2.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/jayway/jsonpath/json-path/2.2.0/json-path-2.2.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.1" groupId="net.minidev" scope="test" name="json-smart-2.2.1.jar" classifier="" artifactId="json-smart" optional="false" id="json-smart" type="jar" version="2.2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/json-smart/2.2.1/json-smart-2.2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1" groupId="net.minidev" scope="test" name="accessors-smart-1.1.jar" classifier="" artifactId="accessors-smart" optional="false" id="accessors-smart" type="jar" version="1.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/accessors-smart/1.1/accessors-smart-1.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="5.0.3" groupId="org.ow2.asm" scope="test" name="asm-5.0.3.jar" classifier="" artifactId="asm" optional="false" id="asm" type="jar" version="5.0.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/ow2/asm/asm/5.0.3/asm-5.0.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="slf4j-api-1.7.25.jar" classifier="" artifactId="slf4j-api" optional="false" id="slf4j-api" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.12" groupId="junit" scope="test" name="junit-4.12.jar" classifier="" artifactId="junit" optional="false" id="junit" type="jar" version="4.12" snapshot="false">
+                <file>/path/to/home/.m2/repository/junit/junit/4.12/junit-4.12.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.6.0" groupId="org.assertj" scope="test" name="assertj-core-2.6.0.jar" classifier="" artifactId="assertj-core" optional="false" id="assertj-core" type="jar" version="2.6.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/assertj/assertj-core/2.6.0/assertj-core-2.6.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.10.19" groupId="org.mockito" scope="test" name="mockito-core-1.10.19.jar" classifier="" artifactId="mockito-core" optional="false" id="mockito-core" type="jar" version="1.10.19" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/mockito/mockito-core/1.10.19/mockito-core-1.10.19.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.1" groupId="org.objenesis" scope="test" name="objenesis-2.1.jar" classifier="" artifactId="objenesis" optional="false" id="objenesis" type="jar" version="2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/objenesis/objenesis/2.1/objenesis-2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-core-1.3.jar" classifier="" artifactId="hamcrest-core" optional="false" id="hamcrest-core" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-library-1.3.jar" classifier="" artifactId="hamcrest-library" optional="false" id="hamcrest-library" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.4.0" groupId="org.skyscreamer" scope="test" name="jsonassert-1.4.0.jar" classifier="" artifactId="jsonassert" optional="false" id="jsonassert" type="jar" version="1.4.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/skyscreamer/jsonassert/1.4.0/jsonassert-1.4.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="0.0.20131108.vaadin1" groupId="com.vaadin.external.google" scope="test" name="android-json-0.0.20131108.vaadin1.jar" classifier="" artifactId="android-json" optional="false" id="android-json" type="jar" version="0.0.20131108.vaadin1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/vaadin/external/google/android-json/0.0.20131108.vaadin1/android-json-0.0.20131108.vaadin1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-core-4.3.9.RELEASE.jar" classifier="" artifactId="spring-core" optional="false" id="spring-core" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-core/4.3.9.RELEASE/spring-core-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="test" name="spring-test-4.3.9.RELEASE.jar" classifier="" artifactId="spring-test" optional="false" id="spring-test" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-test/4.3.9.RELEASE/spring-test-4.3.9.RELEASE.jar</file>
+            </dependency>
+        </resolvedDependencies>
+    </DependencyResolutionResult>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.348">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-resources" goal="resources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.resources}</resources>
+            <session>${session}</session>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.372">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-resources" goal="resources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.resources}</resources>
+            <session>${session}</session>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.372">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-compile" goal="compile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.compileClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <projectArtifact>${project.artifact}</projectArtifact>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skipMain>${maven.main.skip}</skipMain>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.377">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-compile" goal="compile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.compileClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <projectArtifact>${project.artifact}</projectArtifact>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skipMain>${maven.main.skip}</skipMain>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.377">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-testResources" goal="testResources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.testResources}</resources>
+            <session>${session}</session>
+            <skip>${maven.test.skip}</skip>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.379">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-testResources" goal="testResources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.testResources}</resources>
+            <session>${session}</session>
+            <skip>${maven.test.skip}</skip>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.379">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-testCompile" goal="testCompile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.testClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.testCompileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/test-annotations</generatedTestSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skip>${maven.test.skip}</skip>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <testSource>${maven.compiler.testSource}</testSource>
+            <testTarget>${maven.compiler.testTarget}</testTarget>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.385">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-testCompile" goal="testCompile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.testClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.testCompileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/test-annotations</generatedTestSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skip>${maven.test.skip}</skip>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <testSource>${maven.compiler.testSource}</testSource>
+            <testTarget>${maven.compiler.testTarget}</testTarget>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:20:51.385">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-test" goal="test" groupId="org.apache.maven.plugins" artifactId="maven-surefire-plugin" version="2.18.1">
+            <additionalClasspathElements>${maven.test.additionalClasspath}</additionalClasspathElements>
+            <argLine>${argLine}</argLine>
+            <basedir>${basedir}</basedir>
+            <childDelegation>${childDelegation}</childDelegation>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <classpathDependencyExcludes>${maven.test.dependency.excludes}</classpathDependencyExcludes>
+            <debugForkedProcess>${maven.surefire.debug}</debugForkedProcess>
+            <dependenciesToScan>${dependenciesToScan}</dependenciesToScan>
+            <disableXmlReport>${disableXmlReport}</disableXmlReport>
+            <enableAssertions>${enableAssertions}</enableAssertions>
+            <excludedGroups>${excludedGroups}</excludedGroups>
+            <excludes>
+                <exclude>**/Abstract*.java</exclude>
+            </excludes>
+            <failIfNoSpecifiedTests>${surefire.failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
+            <failIfNoTests>${failIfNoTests}</failIfNoTests>
+            <forkCount>${forkCount}</forkCount>
+            <forkMode>${forkMode}</forkMode>
+            <forkedProcessTimeoutInSeconds>${surefire.timeout}</forkedProcessTimeoutInSeconds>
+            <groups>${groups}</groups>
+            <includes>
+                <include>**/*Tests.java</include>
+                <include>**/*Test.java</include>
+            </includes>
+            <junitArtifactName>${junitArtifactName}</junitArtifactName>
+            <jvm>${jvm}</jvm>
+            <localRepository>${localRepository}</localRepository>
+            <objectFactory>${objectFactory}</objectFactory>
+            <parallel>${parallel}</parallel>
+            <parallelMavenExecution>${session.parallel}</parallelMavenExecution>
+            <parallelOptimized>${parallelOptimized}</parallelOptimized>
+            <parallelTestsTimeoutForcedInSeconds>${surefire.parallel.forcedTimeout}</parallelTestsTimeoutForcedInSeconds>
+            <parallelTestsTimeoutInSeconds>${surefire.parallel.timeout}</parallelTestsTimeoutInSeconds>
+            <perCoreThreadCount>${perCoreThreadCount}</perCoreThreadCount>
+            <pluginArtifactMap>${plugin.artifactMap}</pluginArtifactMap>
+            <pluginDescriptor>${plugin}</pluginDescriptor>
+            <printSummary>${surefire.printSummary}</printSummary>
+            <projectArtifactMap>${project.artifactMap}</projectArtifactMap>
+            <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
+            <remoteRepositories>${project.pluginArtifactRepositories}</remoteRepositories>
+            <reportFormat>${surefire.reportFormat}</reportFormat>
+            <reportNameSuffix>${surefire.reportNameSuffix}</reportNameSuffix>
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+            <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
+            <reuseForks>${reuseForks}</reuseForks>
+            <runOrder>${surefire.runOrder}</runOrder>
+            <skip>${maven.test.skip}</skip>
+            <skipExec>${maven.test.skip.exec}</skipExec>
+            <skipTests>${skipTests}</skipTests>
+            <suiteXmlFiles>${surefire.suiteXmlFiles}</suiteXmlFiles>
+            <test>${test}</test>
+            <testClassesDirectory>${project.build.testOutputDirectory}</testClassesDirectory>
+            <testFailureIgnore>${maven.test.failure.ignore}</testFailureIgnore>
+            <testNGArtifactName>${testNGArtifactName}</testNGArtifactName>
+            <testSourceDirectory>${project.build.testSourceDirectory}</testSourceDirectory>
+            <threadCount>${threadCount}</threadCount>
+            <threadCountClasses>${threadCountClasses}</threadCountClasses>
+            <threadCountMethods>${threadCountMethods}</threadCountMethods>
+            <threadCountSuites>${threadCountSuites}</threadCountSuites>
+            <trimStackTrace>${trimStackTrace}</trimStackTrace>
+            <useFile>${surefire.useFile}</useFile>
+            <useManifestOnlyJar>${surefire.useManifestOnlyJar}</useManifestOnlyJar>
+            <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
+            <useUnlimitedThreads>${useUnlimitedThreads}</useUnlimitedThreads>
+            <workingDirectory>${basedir}</workingDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:04.52">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-test" goal="test" groupId="org.apache.maven.plugins" artifactId="maven-surefire-plugin" version="2.18.1">
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:04.52">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-jar" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-jar-plugin" version="2.6">
+            <archive>
+                <manifest>
+                    <mainClass>${start-class}</mainClass>
+                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                </manifest>
+            </archive>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <classifier>${maven.jar.classifier}</classifier>
+            <defaultManifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</defaultManifestFile>
+            <finalName>${jar.finalName}</finalName>
+            <forceCreation>${jar.forceCreation}</forceCreation>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+            <skipIfEmpty>${jar.skipIfEmpty}</skipIfEmpty>
+            <useDefaultManifestFile>${jar.useDefaultManifestFile}</useDefaultManifestFile>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:04.553">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-jar" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-jar-plugin" version="2.6">
+            <finalName>${jar.finalName}</finalName>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:04.553">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default" goal="repackage" groupId="org.springframework.boot" artifactId="spring-boot-maven-plugin" version="1.5.4.RELEASE">
+            <attach>true</attach>
+            <excludeArtifactIds>${excludeArtifactIds}</excludeArtifactIds>
+            <excludeDevtools>true</excludeDevtools>
+            <excludeGroupIds>${excludeGroupIds}</excludeGroupIds>
+            <executable>false</executable>
+            <finalName>${project.build.finalName}</finalName>
+            <includeSystemScope>false</includeSystemScope>
+            <mainClass>${start-class}</mainClass>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <skip>${skip}</skip>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:05.222">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default" goal="repackage" groupId="org.springframework.boot" artifactId="spring-boot-maven-plugin" version="1.5.4.RELEASE">
+            <attach>true</attach>
+            <excludeArtifactIds>${excludeArtifactIds}</excludeArtifactIds>
+            <excludeDevtools>true</excludeDevtools>
+            <excludeGroupIds>${excludeGroupIds}</excludeGroupIds>
+            <executable>false</executable>
+            <finalName>${project.build.finalName}</finalName>
+            <includeSystemScope>false</includeSystemScope>
+            <mainClass>${start-class}</mainClass>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <skip>${skip}</skip>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:05.222">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkedProjectStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:05.223">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <DependencyResolutionRequest class="org.apache.maven.project.DefaultDependencyResolutionRequest" _time="2017-09-02 15:21:05.223">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+    </DependencyResolutionRequest>
+    <DependencyResolutionResult class="org.apache.maven.project.DefaultDependencyResolutionResult" _time="2017-09-02 15:21:05.248">
+        <resolvedDependencies>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-web-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-web" optional="false" id="spring-boot-starter-web" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-web/1.5.4.RELEASE/spring-boot-starter-web-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter" optional="false" id="spring-boot-starter" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter/1.5.4.RELEASE/spring-boot-starter-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot" optional="false" id="spring-boot" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot/1.5.4.RELEASE/spring-boot-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-autoconfigure-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-autoconfigure" optional="false" id="spring-boot-autoconfigure" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-autoconfigure/1.5.4.RELEASE/spring-boot-autoconfigure-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-logging-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-logging" optional="false" id="spring-boot-starter-logging" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-logging/1.5.4.RELEASE/spring-boot-starter-logging-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.11" groupId="ch.qos.logback" scope="compile" name="logback-classic-1.1.11.jar" classifier="" artifactId="logback-classic" optional="false" id="logback-classic" type="jar" version="1.1.11" snapshot="false">
+                <file>/path/to/home/.m2/repository/ch/qos/logback/logback-classic/1.1.11/logback-classic-1.1.11.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.11" groupId="ch.qos.logback" scope="compile" name="logback-core-1.1.11.jar" classifier="" artifactId="logback-core" optional="false" id="logback-core" type="jar" version="1.1.11" snapshot="false">
+                <file>/path/to/home/.m2/repository/ch/qos/logback/logback-core/1.1.11/logback-core-1.1.11.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="jcl-over-slf4j-1.7.25.jar" classifier="" artifactId="jcl-over-slf4j" optional="false" id="jcl-over-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="jul-to-slf4j-1.7.25.jar" classifier="" artifactId="jul-to-slf4j" optional="false" id="jul-to-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="log4j-over-slf4j-1.7.25.jar" classifier="" artifactId="log4j-over-slf4j" optional="false" id="log4j-over-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/log4j-over-slf4j/1.7.25/log4j-over-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-tomcat-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-tomcat" optional="false" id="spring-boot-starter-tomcat" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-tomcat/1.5.4.RELEASE/spring-boot-starter-tomcat-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-core-8.5.15.jar" classifier="" artifactId="tomcat-embed-core" optional="false" id="tomcat-embed-core" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/8.5.15/tomcat-embed-core-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-el-8.5.15.jar" classifier="" artifactId="tomcat-embed-el" optional="false" id="tomcat-embed-el" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-el/8.5.15/tomcat-embed-el-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-websocket-8.5.15.jar" classifier="" artifactId="tomcat-embed-websocket" optional="false" id="tomcat-embed-websocket" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-websocket/8.5.15/tomcat-embed-websocket-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="5.3.5.Final" groupId="org.hibernate" scope="compile" name="hibernate-validator-5.3.5.Final.jar" classifier="" artifactId="hibernate-validator" optional="false" id="hibernate-validator" type="jar" version="5.3.5.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hibernate/hibernate-validator/5.3.5.Final/hibernate-validator-5.3.5.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.0.Final" groupId="javax.validation" scope="compile" name="validation-api-1.1.0.Final.jar" classifier="" artifactId="validation-api" optional="false" id="validation-api" type="jar" version="1.1.0.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="3.3.1.Final" groupId="org.jboss.logging" scope="compile" name="jboss-logging-3.3.1.Final.jar" classifier="" artifactId="jboss-logging" optional="false" id="jboss-logging" type="jar" version="3.3.1.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/jboss/logging/jboss-logging/3.3.1.Final/jboss-logging-3.3.1.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3.3" groupId="com.fasterxml" scope="compile" name="classmate-1.3.3.jar" classifier="" artifactId="classmate" optional="false" id="classmate" type="jar" version="1.3.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/classmate/1.3.3/classmate-1.3.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.8" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-databind-2.8.8.jar" classifier="" artifactId="jackson-databind" optional="false" id="jackson-databind" type="jar" version="2.8.8" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.8.8/jackson-databind-2.8.8.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.0" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-annotations-2.8.0.jar" classifier="" artifactId="jackson-annotations" optional="false" id="jackson-annotations" type="jar" version="2.8.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.8" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-core-2.8.8.jar" classifier="" artifactId="jackson-core" optional="false" id="jackson-core" type="jar" version="2.8.8" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.8.8/jackson-core-2.8.8.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-web-4.3.9.RELEASE.jar" classifier="" artifactId="spring-web" optional="false" id="spring-web" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-web/4.3.9.RELEASE/spring-web-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-aop-4.3.9.RELEASE.jar" classifier="" artifactId="spring-aop" optional="false" id="spring-aop" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-aop/4.3.9.RELEASE/spring-aop-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-beans-4.3.9.RELEASE.jar" classifier="" artifactId="spring-beans" optional="false" id="spring-beans" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-beans/4.3.9.RELEASE/spring-beans-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-context-4.3.9.RELEASE.jar" classifier="" artifactId="spring-context" optional="false" id="spring-context" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-context/4.3.9.RELEASE/spring-context-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-webmvc-4.3.9.RELEASE.jar" classifier="" artifactId="spring-webmvc" optional="false" id="spring-webmvc" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-webmvc/4.3.9.RELEASE/spring-webmvc-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-expression-4.3.9.RELEASE.jar" classifier="" artifactId="spring-expression" optional="false" id="spring-expression" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-expression/4.3.9.RELEASE/spring-expression-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="0.0.29-SNAPSHOT" groupId="com.example.core" scope="compile" name="shared-core-0.0.29-SNAPSHOT.jar" classifier="" artifactId="shared-core" optional="false" id="shared-core" type="jar" version="0.0.29-SNAPSHOT" snapshot="true">
+                <file>/path/to/multi-module-maven-project/shared-core/target/shared-core-0.0.29-SNAPSHOT.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-starter-test-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-test" optional="false" id="spring-boot-starter-test" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-test/1.5.4.RELEASE/spring-boot-starter-test-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-test-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-test" optional="false" id="spring-boot-test" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-test/1.5.4.RELEASE/spring-boot-test-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-test-autoconfigure-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-test-autoconfigure" optional="false" id="spring-boot-test-autoconfigure" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-test-autoconfigure/1.5.4.RELEASE/spring-boot-test-autoconfigure-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.0" groupId="com.jayway.jsonpath" scope="test" name="json-path-2.2.0.jar" classifier="" artifactId="json-path" optional="false" id="json-path" type="jar" version="2.2.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/jayway/jsonpath/json-path/2.2.0/json-path-2.2.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.1" groupId="net.minidev" scope="test" name="json-smart-2.2.1.jar" classifier="" artifactId="json-smart" optional="false" id="json-smart" type="jar" version="2.2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/json-smart/2.2.1/json-smart-2.2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1" groupId="net.minidev" scope="test" name="accessors-smart-1.1.jar" classifier="" artifactId="accessors-smart" optional="false" id="accessors-smart" type="jar" version="1.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/accessors-smart/1.1/accessors-smart-1.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="5.0.3" groupId="org.ow2.asm" scope="test" name="asm-5.0.3.jar" classifier="" artifactId="asm" optional="false" id="asm" type="jar" version="5.0.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/ow2/asm/asm/5.0.3/asm-5.0.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="slf4j-api-1.7.25.jar" classifier="" artifactId="slf4j-api" optional="false" id="slf4j-api" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.12" groupId="junit" scope="test" name="junit-4.12.jar" classifier="" artifactId="junit" optional="false" id="junit" type="jar" version="4.12" snapshot="false">
+                <file>/path/to/home/.m2/repository/junit/junit/4.12/junit-4.12.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.6.0" groupId="org.assertj" scope="test" name="assertj-core-2.6.0.jar" classifier="" artifactId="assertj-core" optional="false" id="assertj-core" type="jar" version="2.6.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/assertj/assertj-core/2.6.0/assertj-core-2.6.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.10.19" groupId="org.mockito" scope="test" name="mockito-core-1.10.19.jar" classifier="" artifactId="mockito-core" optional="false" id="mockito-core" type="jar" version="1.10.19" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/mockito/mockito-core/1.10.19/mockito-core-1.10.19.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.1" groupId="org.objenesis" scope="test" name="objenesis-2.1.jar" classifier="" artifactId="objenesis" optional="false" id="objenesis" type="jar" version="2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/objenesis/objenesis/2.1/objenesis-2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-core-1.3.jar" classifier="" artifactId="hamcrest-core" optional="false" id="hamcrest-core" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-library-1.3.jar" classifier="" artifactId="hamcrest-library" optional="false" id="hamcrest-library" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.4.0" groupId="org.skyscreamer" scope="test" name="jsonassert-1.4.0.jar" classifier="" artifactId="jsonassert" optional="false" id="jsonassert" type="jar" version="1.4.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/skyscreamer/jsonassert/1.4.0/jsonassert-1.4.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="0.0.20131108.vaadin1" groupId="com.vaadin.external.google" scope="test" name="android-json-0.0.20131108.vaadin1.jar" classifier="" artifactId="android-json" optional="false" id="android-json" type="jar" version="0.0.20131108.vaadin1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/vaadin/external/google/android-json/0.0.20131108.vaadin1/android-json-0.0.20131108.vaadin1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-core-4.3.9.RELEASE.jar" classifier="" artifactId="spring-core" optional="false" id="spring-core" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-core/4.3.9.RELEASE/spring-core-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="test" name="spring-test-4.3.9.RELEASE.jar" classifier="" artifactId="spring-test" optional="false" id="spring-test" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-test/4.3.9.RELEASE/spring-test-4.3.9.RELEASE.jar</file>
+            </dependency>
+        </resolvedDependencies>
+    </DependencyResolutionResult>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:05.251">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="findbugs" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <remoteRepositories>${project.remoteArtifactRepositories}</remoteRepositories>
+            <skip>${findbugs.skip}</skip>
+            <skipEmptyReport>${findbugs.skipEmptyReport}</skipEmptyReport>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <userPrefs>${findbugs.userPrefs}</userPrefs>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:08.112">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="findbugs" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <remoteRepositories>${project.remoteArtifactRepositories}</remoteRepositories>
+            <skip>${findbugs.skip}</skip>
+            <skipEmptyReport>${findbugs.skipEmptyReport}</skipEmptyReport>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <userPrefs>${findbugs.userPrefs}</userPrefs>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkedProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:08.113">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:08.113">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:08.113">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:08.125">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:08.125">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.5.2">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <installAtEnd>${installAtEnd}</installAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:08.189">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.5.2">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <installAtEnd>${installAtEnd}</installAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:08.189">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-deploy" goal="deploy" groupId="org.apache.maven.plugins" artifactId="maven-deploy-plugin" version="2.8.2">
+            <altDeploymentRepository>${altDeploymentRepository}</altDeploymentRepository>
+            <altReleaseDeploymentRepository>${altReleaseDeploymentRepository}</altReleaseDeploymentRepository>
+            <altSnapshotDeploymentRepository>${altSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <deployAtEnd>${deployAtEnd}</deployAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <retryFailedDeploymentCount>${retryFailedDeploymentCount}</retryFailedDeploymentCount>
+            <skip>${maven.deploy.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.033">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <plugin executionId="default-deploy" goal="deploy" groupId="org.apache.maven.plugins" artifactId="maven-deploy-plugin" version="2.8.2">
+            <altDeploymentRepository>${altDeploymentRepository}</altDeploymentRepository>
+            <altReleaseDeploymentRepository>${altReleaseDeploymentRepository}</altReleaseDeploymentRepository>
+            <altSnapshotDeploymentRepository>${altSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <deployAtEnd>${deployAtEnd}</deployAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <retryFailedDeploymentCount>${retryFailedDeploymentCount}</retryFailedDeploymentCount>
+            <skip>${maven.deploy.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.034">
+        <project baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </project>
+        <no-execution-found/>
+        <artifact extension="jar" baseVersion="0.0.29-SNAPSHOT" groupId="com.example.demo1" artifactId="demo-1" id="com.example.demo1:demo-1:jar:0.0.29-SNAPSHOT" type="jar" version="0.0.29-20170902.222108-1" snapshot="true">
+            <file>/path/to/multi-module-maven-project/demo-1/target/demo-1-0.0.29-SNAPSHOT.jar</file>
+        </artifact>
+        <attachedArtifacts/>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.034">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <DependencyResolutionRequest class="org.apache.maven.project.DefaultDependencyResolutionRequest" _time="2017-09-02 15:21:09.036">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+    </DependencyResolutionRequest>
+    <DependencyResolutionResult class="org.apache.maven.project.DefaultDependencyResolutionResult" _time="2017-09-02 15:21:09.058">
+        <resolvedDependencies>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-web-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-web" optional="false" id="spring-boot-starter-web" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-web/1.5.4.RELEASE/spring-boot-starter-web-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter" optional="false" id="spring-boot-starter" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter/1.5.4.RELEASE/spring-boot-starter-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot" optional="false" id="spring-boot" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot/1.5.4.RELEASE/spring-boot-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-autoconfigure-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-autoconfigure" optional="false" id="spring-boot-autoconfigure" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-autoconfigure/1.5.4.RELEASE/spring-boot-autoconfigure-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-logging-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-logging" optional="false" id="spring-boot-starter-logging" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-logging/1.5.4.RELEASE/spring-boot-starter-logging-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.11" groupId="ch.qos.logback" scope="compile" name="logback-classic-1.1.11.jar" classifier="" artifactId="logback-classic" optional="false" id="logback-classic" type="jar" version="1.1.11" snapshot="false">
+                <file>/path/to/home/.m2/repository/ch/qos/logback/logback-classic/1.1.11/logback-classic-1.1.11.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.11" groupId="ch.qos.logback" scope="compile" name="logback-core-1.1.11.jar" classifier="" artifactId="logback-core" optional="false" id="logback-core" type="jar" version="1.1.11" snapshot="false">
+                <file>/path/to/home/.m2/repository/ch/qos/logback/logback-core/1.1.11/logback-core-1.1.11.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="jcl-over-slf4j-1.7.25.jar" classifier="" artifactId="jcl-over-slf4j" optional="false" id="jcl-over-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="jul-to-slf4j-1.7.25.jar" classifier="" artifactId="jul-to-slf4j" optional="false" id="jul-to-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="log4j-over-slf4j-1.7.25.jar" classifier="" artifactId="log4j-over-slf4j" optional="false" id="log4j-over-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/log4j-over-slf4j/1.7.25/log4j-over-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-tomcat-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-tomcat" optional="false" id="spring-boot-starter-tomcat" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-tomcat/1.5.4.RELEASE/spring-boot-starter-tomcat-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-core-8.5.15.jar" classifier="" artifactId="tomcat-embed-core" optional="false" id="tomcat-embed-core" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/8.5.15/tomcat-embed-core-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-el-8.5.15.jar" classifier="" artifactId="tomcat-embed-el" optional="false" id="tomcat-embed-el" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-el/8.5.15/tomcat-embed-el-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-websocket-8.5.15.jar" classifier="" artifactId="tomcat-embed-websocket" optional="false" id="tomcat-embed-websocket" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-websocket/8.5.15/tomcat-embed-websocket-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="5.3.5.Final" groupId="org.hibernate" scope="compile" name="hibernate-validator-5.3.5.Final.jar" classifier="" artifactId="hibernate-validator" optional="false" id="hibernate-validator" type="jar" version="5.3.5.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hibernate/hibernate-validator/5.3.5.Final/hibernate-validator-5.3.5.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.0.Final" groupId="javax.validation" scope="compile" name="validation-api-1.1.0.Final.jar" classifier="" artifactId="validation-api" optional="false" id="validation-api" type="jar" version="1.1.0.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="3.3.1.Final" groupId="org.jboss.logging" scope="compile" name="jboss-logging-3.3.1.Final.jar" classifier="" artifactId="jboss-logging" optional="false" id="jboss-logging" type="jar" version="3.3.1.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/jboss/logging/jboss-logging/3.3.1.Final/jboss-logging-3.3.1.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3.3" groupId="com.fasterxml" scope="compile" name="classmate-1.3.3.jar" classifier="" artifactId="classmate" optional="false" id="classmate" type="jar" version="1.3.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/classmate/1.3.3/classmate-1.3.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.8" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-databind-2.8.8.jar" classifier="" artifactId="jackson-databind" optional="false" id="jackson-databind" type="jar" version="2.8.8" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.8.8/jackson-databind-2.8.8.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.0" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-annotations-2.8.0.jar" classifier="" artifactId="jackson-annotations" optional="false" id="jackson-annotations" type="jar" version="2.8.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.8" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-core-2.8.8.jar" classifier="" artifactId="jackson-core" optional="false" id="jackson-core" type="jar" version="2.8.8" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.8.8/jackson-core-2.8.8.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-web-4.3.9.RELEASE.jar" classifier="" artifactId="spring-web" optional="false" id="spring-web" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-web/4.3.9.RELEASE/spring-web-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-aop-4.3.9.RELEASE.jar" classifier="" artifactId="spring-aop" optional="false" id="spring-aop" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-aop/4.3.9.RELEASE/spring-aop-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-beans-4.3.9.RELEASE.jar" classifier="" artifactId="spring-beans" optional="false" id="spring-beans" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-beans/4.3.9.RELEASE/spring-beans-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-context-4.3.9.RELEASE.jar" classifier="" artifactId="spring-context" optional="false" id="spring-context" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-context/4.3.9.RELEASE/spring-context-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-webmvc-4.3.9.RELEASE.jar" classifier="" artifactId="spring-webmvc" optional="false" id="spring-webmvc" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-webmvc/4.3.9.RELEASE/spring-webmvc-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-expression-4.3.9.RELEASE.jar" classifier="" artifactId="spring-expression" optional="false" id="spring-expression" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-expression/4.3.9.RELEASE/spring-expression-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="0.0.29-SNAPSHOT" groupId="com.example.core" scope="compile" name="shared-core-0.0.29-SNAPSHOT.jar" classifier="" artifactId="shared-core" optional="false" id="shared-core" type="jar" version="0.0.29-SNAPSHOT" snapshot="true">
+                <file>/path/to/multi-module-maven-project/shared-core/target/shared-core-0.0.29-SNAPSHOT.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-starter-test-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-test" optional="false" id="spring-boot-starter-test" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-test/1.5.4.RELEASE/spring-boot-starter-test-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-test-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-test" optional="false" id="spring-boot-test" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-test/1.5.4.RELEASE/spring-boot-test-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-test-autoconfigure-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-test-autoconfigure" optional="false" id="spring-boot-test-autoconfigure" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-test-autoconfigure/1.5.4.RELEASE/spring-boot-test-autoconfigure-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.0" groupId="com.jayway.jsonpath" scope="test" name="json-path-2.2.0.jar" classifier="" artifactId="json-path" optional="false" id="json-path" type="jar" version="2.2.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/jayway/jsonpath/json-path/2.2.0/json-path-2.2.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.1" groupId="net.minidev" scope="test" name="json-smart-2.2.1.jar" classifier="" artifactId="json-smart" optional="false" id="json-smart" type="jar" version="2.2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/json-smart/2.2.1/json-smart-2.2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1" groupId="net.minidev" scope="test" name="accessors-smart-1.1.jar" classifier="" artifactId="accessors-smart" optional="false" id="accessors-smart" type="jar" version="1.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/accessors-smart/1.1/accessors-smart-1.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="5.0.3" groupId="org.ow2.asm" scope="test" name="asm-5.0.3.jar" classifier="" artifactId="asm" optional="false" id="asm" type="jar" version="5.0.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/ow2/asm/asm/5.0.3/asm-5.0.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="slf4j-api-1.7.25.jar" classifier="" artifactId="slf4j-api" optional="false" id="slf4j-api" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.12" groupId="junit" scope="test" name="junit-4.12.jar" classifier="" artifactId="junit" optional="false" id="junit" type="jar" version="4.12" snapshot="false">
+                <file>/path/to/home/.m2/repository/junit/junit/4.12/junit-4.12.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.6.0" groupId="org.assertj" scope="test" name="assertj-core-2.6.0.jar" classifier="" artifactId="assertj-core" optional="false" id="assertj-core" type="jar" version="2.6.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/assertj/assertj-core/2.6.0/assertj-core-2.6.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.10.19" groupId="org.mockito" scope="test" name="mockito-core-1.10.19.jar" classifier="" artifactId="mockito-core" optional="false" id="mockito-core" type="jar" version="1.10.19" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/mockito/mockito-core/1.10.19/mockito-core-1.10.19.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.1" groupId="org.objenesis" scope="test" name="objenesis-2.1.jar" classifier="" artifactId="objenesis" optional="false" id="objenesis" type="jar" version="2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/objenesis/objenesis/2.1/objenesis-2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-core-1.3.jar" classifier="" artifactId="hamcrest-core" optional="false" id="hamcrest-core" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-library-1.3.jar" classifier="" artifactId="hamcrest-library" optional="false" id="hamcrest-library" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.4.0" groupId="org.skyscreamer" scope="test" name="jsonassert-1.4.0.jar" classifier="" artifactId="jsonassert" optional="false" id="jsonassert" type="jar" version="1.4.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/skyscreamer/jsonassert/1.4.0/jsonassert-1.4.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="0.0.20131108.vaadin1" groupId="com.vaadin.external.google" scope="test" name="android-json-0.0.20131108.vaadin1.jar" classifier="" artifactId="android-json" optional="false" id="android-json" type="jar" version="0.0.20131108.vaadin1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/vaadin/external/google/android-json/0.0.20131108.vaadin1/android-json-0.0.20131108.vaadin1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-core-4.3.9.RELEASE.jar" classifier="" artifactId="spring-core" optional="false" id="spring-core" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-core/4.3.9.RELEASE/spring-core-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="test" name="spring-test-4.3.9.RELEASE.jar" classifier="" artifactId="spring-test" optional="false" id="spring-test" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-test/4.3.9.RELEASE/spring-test-4.3.9.RELEASE.jar</file>
+            </dependency>
+        </resolvedDependencies>
+    </DependencyResolutionResult>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.061">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-resources" goal="resources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.resources}</resources>
+            <session>${session}</session>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.067">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-resources" goal="resources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.resources}</resources>
+            <session>${session}</session>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.067">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-compile" goal="compile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.compileClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <projectArtifact>${project.artifact}</projectArtifact>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skipMain>${maven.main.skip}</skipMain>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.076">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-compile" goal="compile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.compileClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <projectArtifact>${project.artifact}</projectArtifact>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skipMain>${maven.main.skip}</skipMain>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.076">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-testResources" goal="testResources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.testResources}</resources>
+            <session>${session}</session>
+            <skip>${maven.test.skip}</skip>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.089">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-testResources" goal="testResources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <delimiters>
+                <delimiter>@</delimiter>
+            </delimiters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.testResources}</resources>
+            <session>${session}</session>
+            <skip>${maven.test.skip}</skip>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>false</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.09">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-testCompile" goal="testCompile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.testClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.testCompileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/test-annotations</generatedTestSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skip>${maven.test.skip}</skip>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <testSource>${maven.compiler.testSource}</testSource>
+            <testTarget>${maven.compiler.testTarget}</testTarget>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.101">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-testCompile" goal="testCompile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <classpathElements>${project.testClasspathElements}</classpathElements>
+            <compileSourceRoots>${project.testCompileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/test-annotations</generatedTestSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skip>${maven.test.skip}</skip>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>${maven.compiler.source}</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>${maven.compiler.target}</target>
+            <testSource>${maven.compiler.testSource}</testSource>
+            <testTarget>${maven.compiler.testTarget}</testTarget>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+            <mavenSession>${session}</mavenSession>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:09.102">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-test" goal="test" groupId="org.apache.maven.plugins" artifactId="maven-surefire-plugin" version="2.18.1">
+            <additionalClasspathElements>${maven.test.additionalClasspath}</additionalClasspathElements>
+            <argLine>${argLine}</argLine>
+            <basedir>${basedir}</basedir>
+            <childDelegation>${childDelegation}</childDelegation>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <classpathDependencyExcludes>${maven.test.dependency.excludes}</classpathDependencyExcludes>
+            <debugForkedProcess>${maven.surefire.debug}</debugForkedProcess>
+            <dependenciesToScan>${dependenciesToScan}</dependenciesToScan>
+            <disableXmlReport>${disableXmlReport}</disableXmlReport>
+            <enableAssertions>${enableAssertions}</enableAssertions>
+            <excludedGroups>${excludedGroups}</excludedGroups>
+            <excludes>
+                <exclude>**/Abstract*.java</exclude>
+            </excludes>
+            <failIfNoSpecifiedTests>${surefire.failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
+            <failIfNoTests>${failIfNoTests}</failIfNoTests>
+            <forkCount>${forkCount}</forkCount>
+            <forkMode>${forkMode}</forkMode>
+            <forkedProcessTimeoutInSeconds>${surefire.timeout}</forkedProcessTimeoutInSeconds>
+            <groups>${groups}</groups>
+            <includes>
+                <include>**/*Tests.java</include>
+                <include>**/*Test.java</include>
+            </includes>
+            <junitArtifactName>${junitArtifactName}</junitArtifactName>
+            <jvm>${jvm}</jvm>
+            <localRepository>${localRepository}</localRepository>
+            <objectFactory>${objectFactory}</objectFactory>
+            <parallel>${parallel}</parallel>
+            <parallelMavenExecution>${session.parallel}</parallelMavenExecution>
+            <parallelOptimized>${parallelOptimized}</parallelOptimized>
+            <parallelTestsTimeoutForcedInSeconds>${surefire.parallel.forcedTimeout}</parallelTestsTimeoutForcedInSeconds>
+            <parallelTestsTimeoutInSeconds>${surefire.parallel.timeout}</parallelTestsTimeoutInSeconds>
+            <perCoreThreadCount>${perCoreThreadCount}</perCoreThreadCount>
+            <pluginArtifactMap>${plugin.artifactMap}</pluginArtifactMap>
+            <pluginDescriptor>${plugin}</pluginDescriptor>
+            <printSummary>${surefire.printSummary}</printSummary>
+            <projectArtifactMap>${project.artifactMap}</projectArtifactMap>
+            <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
+            <remoteRepositories>${project.pluginArtifactRepositories}</remoteRepositories>
+            <reportFormat>${surefire.reportFormat}</reportFormat>
+            <reportNameSuffix>${surefire.reportNameSuffix}</reportNameSuffix>
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+            <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
+            <reuseForks>${reuseForks}</reuseForks>
+            <runOrder>${surefire.runOrder}</runOrder>
+            <skip>${maven.test.skip}</skip>
+            <skipExec>${maven.test.skip.exec}</skipExec>
+            <skipTests>${skipTests}</skipTests>
+            <suiteXmlFiles>${surefire.suiteXmlFiles}</suiteXmlFiles>
+            <test>${test}</test>
+            <testClassesDirectory>${project.build.testOutputDirectory}</testClassesDirectory>
+            <testFailureIgnore>${maven.test.failure.ignore}</testFailureIgnore>
+            <testNGArtifactName>${testNGArtifactName}</testNGArtifactName>
+            <testSourceDirectory>${project.build.testSourceDirectory}</testSourceDirectory>
+            <threadCount>${threadCount}</threadCount>
+            <threadCountClasses>${threadCountClasses}</threadCountClasses>
+            <threadCountMethods>${threadCountMethods}</threadCountMethods>
+            <threadCountSuites>${threadCountSuites}</threadCountSuites>
+            <trimStackTrace>${trimStackTrace}</trimStackTrace>
+            <useFile>${surefire.useFile}</useFile>
+            <useManifestOnlyJar>${surefire.useManifestOnlyJar}</useManifestOnlyJar>
+            <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
+            <useUnlimitedThreads>${useUnlimitedThreads}</useUnlimitedThreads>
+            <workingDirectory>${basedir}</workingDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:21.956">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-test" goal="test" groupId="org.apache.maven.plugins" artifactId="maven-surefire-plugin" version="2.18.1">
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:21.956">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-jar" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-jar-plugin" version="2.6">
+            <archive>
+                <manifest>
+                    <mainClass>${start-class}</mainClass>
+                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                </manifest>
+            </archive>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <classifier>${maven.jar.classifier}</classifier>
+            <defaultManifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</defaultManifestFile>
+            <finalName>${jar.finalName}</finalName>
+            <forceCreation>${jar.forceCreation}</forceCreation>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+            <skipIfEmpty>${jar.skipIfEmpty}</skipIfEmpty>
+            <useDefaultManifestFile>${jar.useDefaultManifestFile}</useDefaultManifestFile>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:21.968">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-jar" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-jar-plugin" version="2.6">
+            <finalName>${jar.finalName}</finalName>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:21.968">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default" goal="repackage" groupId="org.springframework.boot" artifactId="spring-boot-maven-plugin" version="1.5.4.RELEASE">
+            <attach>true</attach>
+            <excludeArtifactIds>${excludeArtifactIds}</excludeArtifactIds>
+            <excludeDevtools>true</excludeDevtools>
+            <excludeGroupIds>${excludeGroupIds}</excludeGroupIds>
+            <executable>false</executable>
+            <finalName>${project.build.finalName}</finalName>
+            <includeSystemScope>false</includeSystemScope>
+            <mainClass>${start-class}</mainClass>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <skip>${skip}</skip>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:22.054">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default" goal="repackage" groupId="org.springframework.boot" artifactId="spring-boot-maven-plugin" version="1.5.4.RELEASE">
+            <attach>true</attach>
+            <excludeArtifactIds>${excludeArtifactIds}</excludeArtifactIds>
+            <excludeDevtools>true</excludeDevtools>
+            <excludeGroupIds>${excludeGroupIds}</excludeGroupIds>
+            <executable>false</executable>
+            <finalName>${project.build.finalName}</finalName>
+            <includeSystemScope>false</includeSystemScope>
+            <mainClass>${start-class}</mainClass>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <skip>${skip}</skip>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:22.054">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkedProjectStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:22.055">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <DependencyResolutionRequest class="org.apache.maven.project.DefaultDependencyResolutionRequest" _time="2017-09-02 15:21:22.055">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+    </DependencyResolutionRequest>
+    <DependencyResolutionResult class="org.apache.maven.project.DefaultDependencyResolutionResult" _time="2017-09-02 15:21:22.077">
+        <resolvedDependencies>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-web-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-web" optional="false" id="spring-boot-starter-web" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-web/1.5.4.RELEASE/spring-boot-starter-web-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter" optional="false" id="spring-boot-starter" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter/1.5.4.RELEASE/spring-boot-starter-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot" optional="false" id="spring-boot" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot/1.5.4.RELEASE/spring-boot-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-autoconfigure-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-autoconfigure" optional="false" id="spring-boot-autoconfigure" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-autoconfigure/1.5.4.RELEASE/spring-boot-autoconfigure-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-logging-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-logging" optional="false" id="spring-boot-starter-logging" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-logging/1.5.4.RELEASE/spring-boot-starter-logging-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.11" groupId="ch.qos.logback" scope="compile" name="logback-classic-1.1.11.jar" classifier="" artifactId="logback-classic" optional="false" id="logback-classic" type="jar" version="1.1.11" snapshot="false">
+                <file>/path/to/home/.m2/repository/ch/qos/logback/logback-classic/1.1.11/logback-classic-1.1.11.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.11" groupId="ch.qos.logback" scope="compile" name="logback-core-1.1.11.jar" classifier="" artifactId="logback-core" optional="false" id="logback-core" type="jar" version="1.1.11" snapshot="false">
+                <file>/path/to/home/.m2/repository/ch/qos/logback/logback-core/1.1.11/logback-core-1.1.11.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="jcl-over-slf4j-1.7.25.jar" classifier="" artifactId="jcl-over-slf4j" optional="false" id="jcl-over-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="jul-to-slf4j-1.7.25.jar" classifier="" artifactId="jul-to-slf4j" optional="false" id="jul-to-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="log4j-over-slf4j-1.7.25.jar" classifier="" artifactId="log4j-over-slf4j" optional="false" id="log4j-over-slf4j" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/log4j-over-slf4j/1.7.25/log4j-over-slf4j-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="compile" name="spring-boot-starter-tomcat-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-tomcat" optional="false" id="spring-boot-starter-tomcat" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-tomcat/1.5.4.RELEASE/spring-boot-starter-tomcat-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-core-8.5.15.jar" classifier="" artifactId="tomcat-embed-core" optional="false" id="tomcat-embed-core" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/8.5.15/tomcat-embed-core-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-el-8.5.15.jar" classifier="" artifactId="tomcat-embed-el" optional="false" id="tomcat-embed-el" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-el/8.5.15/tomcat-embed-el-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="8.5.15" groupId="org.apache.tomcat.embed" scope="compile" name="tomcat-embed-websocket-8.5.15.jar" classifier="" artifactId="tomcat-embed-websocket" optional="false" id="tomcat-embed-websocket" type="jar" version="8.5.15" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/tomcat/embed/tomcat-embed-websocket/8.5.15/tomcat-embed-websocket-8.5.15.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="5.3.5.Final" groupId="org.hibernate" scope="compile" name="hibernate-validator-5.3.5.Final.jar" classifier="" artifactId="hibernate-validator" optional="false" id="hibernate-validator" type="jar" version="5.3.5.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hibernate/hibernate-validator/5.3.5.Final/hibernate-validator-5.3.5.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1.0.Final" groupId="javax.validation" scope="compile" name="validation-api-1.1.0.Final.jar" classifier="" artifactId="validation-api" optional="false" id="validation-api" type="jar" version="1.1.0.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="3.3.1.Final" groupId="org.jboss.logging" scope="compile" name="jboss-logging-3.3.1.Final.jar" classifier="" artifactId="jboss-logging" optional="false" id="jboss-logging" type="jar" version="3.3.1.Final" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/jboss/logging/jboss-logging/3.3.1.Final/jboss-logging-3.3.1.Final.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3.3" groupId="com.fasterxml" scope="compile" name="classmate-1.3.3.jar" classifier="" artifactId="classmate" optional="false" id="classmate" type="jar" version="1.3.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/classmate/1.3.3/classmate-1.3.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.8" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-databind-2.8.8.jar" classifier="" artifactId="jackson-databind" optional="false" id="jackson-databind" type="jar" version="2.8.8" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.8.8/jackson-databind-2.8.8.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.0" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-annotations-2.8.0.jar" classifier="" artifactId="jackson-annotations" optional="false" id="jackson-annotations" type="jar" version="2.8.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.8.0/jackson-annotations-2.8.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.8.8" groupId="com.fasterxml.jackson.core" scope="compile" name="jackson-core-2.8.8.jar" classifier="" artifactId="jackson-core" optional="false" id="jackson-core" type="jar" version="2.8.8" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.8.8/jackson-core-2.8.8.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-web-4.3.9.RELEASE.jar" classifier="" artifactId="spring-web" optional="false" id="spring-web" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-web/4.3.9.RELEASE/spring-web-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-aop-4.3.9.RELEASE.jar" classifier="" artifactId="spring-aop" optional="false" id="spring-aop" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-aop/4.3.9.RELEASE/spring-aop-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-beans-4.3.9.RELEASE.jar" classifier="" artifactId="spring-beans" optional="false" id="spring-beans" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-beans/4.3.9.RELEASE/spring-beans-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-context-4.3.9.RELEASE.jar" classifier="" artifactId="spring-context" optional="false" id="spring-context" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-context/4.3.9.RELEASE/spring-context-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-webmvc-4.3.9.RELEASE.jar" classifier="" artifactId="spring-webmvc" optional="false" id="spring-webmvc" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-webmvc/4.3.9.RELEASE/spring-webmvc-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-expression-4.3.9.RELEASE.jar" classifier="" artifactId="spring-expression" optional="false" id="spring-expression" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-expression/4.3.9.RELEASE/spring-expression-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="0.0.29-SNAPSHOT" groupId="com.example.core" scope="compile" name="shared-core-0.0.29-SNAPSHOT.jar" classifier="" artifactId="shared-core" optional="false" id="shared-core" type="jar" version="0.0.29-SNAPSHOT" snapshot="true">
+                <file>/path/to/multi-module-maven-project/shared-core/target/shared-core-0.0.29-SNAPSHOT.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-starter-test-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-starter-test" optional="false" id="spring-boot-starter-test" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-starter-test/1.5.4.RELEASE/spring-boot-starter-test-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-test-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-test" optional="false" id="spring-boot-test" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-test/1.5.4.RELEASE/spring-boot-test-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.5.4.RELEASE" groupId="org.springframework.boot" scope="test" name="spring-boot-test-autoconfigure-1.5.4.RELEASE.jar" classifier="" artifactId="spring-boot-test-autoconfigure" optional="false" id="spring-boot-test-autoconfigure" type="jar" version="1.5.4.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/boot/spring-boot-test-autoconfigure/1.5.4.RELEASE/spring-boot-test-autoconfigure-1.5.4.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.0" groupId="com.jayway.jsonpath" scope="test" name="json-path-2.2.0.jar" classifier="" artifactId="json-path" optional="false" id="json-path" type="jar" version="2.2.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/jayway/jsonpath/json-path/2.2.0/json-path-2.2.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.1" groupId="net.minidev" scope="test" name="json-smart-2.2.1.jar" classifier="" artifactId="json-smart" optional="false" id="json-smart" type="jar" version="2.2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/json-smart/2.2.1/json-smart-2.2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1" groupId="net.minidev" scope="test" name="accessors-smart-1.1.jar" classifier="" artifactId="accessors-smart" optional="false" id="accessors-smart" type="jar" version="1.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/accessors-smart/1.1/accessors-smart-1.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="5.0.3" groupId="org.ow2.asm" scope="test" name="asm-5.0.3.jar" classifier="" artifactId="asm" optional="false" id="asm" type="jar" version="5.0.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/ow2/asm/asm/5.0.3/asm-5.0.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.25" groupId="org.slf4j" scope="compile" name="slf4j-api-1.7.25.jar" classifier="" artifactId="slf4j-api" optional="false" id="slf4j-api" type="jar" version="1.7.25" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.12" groupId="junit" scope="test" name="junit-4.12.jar" classifier="" artifactId="junit" optional="false" id="junit" type="jar" version="4.12" snapshot="false">
+                <file>/path/to/home/.m2/repository/junit/junit/4.12/junit-4.12.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.6.0" groupId="org.assertj" scope="test" name="assertj-core-2.6.0.jar" classifier="" artifactId="assertj-core" optional="false" id="assertj-core" type="jar" version="2.6.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/assertj/assertj-core/2.6.0/assertj-core-2.6.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.10.19" groupId="org.mockito" scope="test" name="mockito-core-1.10.19.jar" classifier="" artifactId="mockito-core" optional="false" id="mockito-core" type="jar" version="1.10.19" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/mockito/mockito-core/1.10.19/mockito-core-1.10.19.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.1" groupId="org.objenesis" scope="test" name="objenesis-2.1.jar" classifier="" artifactId="objenesis" optional="false" id="objenesis" type="jar" version="2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/objenesis/objenesis/2.1/objenesis-2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-core-1.3.jar" classifier="" artifactId="hamcrest-core" optional="false" id="hamcrest-core" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-library-1.3.jar" classifier="" artifactId="hamcrest-library" optional="false" id="hamcrest-library" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.4.0" groupId="org.skyscreamer" scope="test" name="jsonassert-1.4.0.jar" classifier="" artifactId="jsonassert" optional="false" id="jsonassert" type="jar" version="1.4.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/skyscreamer/jsonassert/1.4.0/jsonassert-1.4.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="0.0.20131108.vaadin1" groupId="com.vaadin.external.google" scope="test" name="android-json-0.0.20131108.vaadin1.jar" classifier="" artifactId="android-json" optional="false" id="android-json" type="jar" version="0.0.20131108.vaadin1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/vaadin/external/google/android-json/0.0.20131108.vaadin1/android-json-0.0.20131108.vaadin1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="compile" name="spring-core-4.3.9.RELEASE.jar" classifier="" artifactId="spring-core" optional="false" id="spring-core" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-core/4.3.9.RELEASE/spring-core-4.3.9.RELEASE.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.3.9.RELEASE" groupId="org.springframework" scope="test" name="spring-test-4.3.9.RELEASE.jar" classifier="" artifactId="spring-test" optional="false" id="spring-test" type="jar" version="4.3.9.RELEASE" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/springframework/spring-test/4.3.9.RELEASE/spring-test-4.3.9.RELEASE.jar</file>
+            </dependency>
+        </resolvedDependencies>
+    </DependencyResolutionResult>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:22.079">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="findbugs" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <remoteRepositories>${project.remoteArtifactRepositories}</remoteRepositories>
+            <skip>${findbugs.skip}</skip>
+            <skipEmptyReport>${findbugs.skipEmptyReport}</skipEmptyReport>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <userPrefs>${findbugs.userPrefs}</userPrefs>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:24.779">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="findbugs" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <remoteRepositories>${project.remoteArtifactRepositories}</remoteRepositories>
+            <skip>${findbugs.skip}</skip>
+            <skipEmptyReport>${findbugs.skipEmptyReport}</skipEmptyReport>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <userPrefs>${findbugs.userPrefs}</userPrefs>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkedProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:24.779">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:24.779">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:24.78">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:24.792">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:24.792">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.5.2">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <installAtEnd>${installAtEnd}</installAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:24.846">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.5.2">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <installAtEnd>${installAtEnd}</installAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:24.846">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-deploy" goal="deploy" groupId="org.apache.maven.plugins" artifactId="maven-deploy-plugin" version="2.8.2">
+            <altDeploymentRepository>${altDeploymentRepository}</altDeploymentRepository>
+            <altReleaseDeploymentRepository>${altReleaseDeploymentRepository}</altReleaseDeploymentRepository>
+            <altSnapshotDeploymentRepository>${altSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <deployAtEnd>${deployAtEnd}</deployAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <retryFailedDeploymentCount>${retryFailedDeploymentCount}</retryFailedDeploymentCount>
+            <skip>${maven.deploy.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:25.577">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <plugin executionId="default-deploy" goal="deploy" groupId="org.apache.maven.plugins" artifactId="maven-deploy-plugin" version="2.8.2">
+            <altDeploymentRepository>${altDeploymentRepository}</altDeploymentRepository>
+            <altReleaseDeploymentRepository>${altReleaseDeploymentRepository}</altReleaseDeploymentRepository>
+            <altSnapshotDeploymentRepository>${altSnapshotDeploymentRepository}</altSnapshotDeploymentRepository>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <deployAtEnd>${deployAtEnd}</deployAtEnd>
+            <localRepository>${localRepository}</localRepository>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <retryFailedDeploymentCount>${retryFailedDeploymentCount}</retryFailedDeploymentCount>
+            <skip>${maven.deploy.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-02 15:21:25.578">
+        <project baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" version="0.0.29-SNAPSHOT">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </project>
+        <no-execution-found/>
+        <artifact extension="jar" baseVersion="0.0.29-SNAPSHOT" groupId="com.example.demo2" artifactId="demo-2" id="com.example.demo2:demo-2:jar:0.0.29-SNAPSHOT" type="jar" version="0.0.29-20170902.222124-1" snapshot="true">
+            <file>/path/to/multi-module-maven-project/demo-2/target/demo-2-0.0.29-SNAPSHOT.jar</file>
+        </artifact>
+        <attachedArtifacts/>
+    </ExecutionEvent>
+    <MavenExecutionResult class="org.apache.maven.execution.DefaultMavenExecutionResult" _time="2017-09-02 15:21:25.814">
+        <buildSummary baseDir="/path/to/multi-module-maven-project" file="/path/to/multi-module-maven-project/pom.xml" groupId="com.example" name="demo-parent" artifactId="demo-parent" time="960" version="0.0.29-SNAPSHOT" class="org.apache.maven.execution.BuildSuccess">
+            <build sourceDirectory="/path/to/multi-module-maven-project/src/main/java" directory="/path/to/multi-module-maven-project/target"/>
+        </buildSummary>
+        <buildSummary baseDir="/path/to/multi-module-maven-project/shared-core" file="/path/to/multi-module-maven-project/shared-core/pom.xml" groupId="com.example.core" name="shared-core" artifactId="shared-core" time="5215" version="0.0.29-SNAPSHOT" class="org.apache.maven.execution.BuildSuccess">
+            <build sourceDirectory="/path/to/multi-module-maven-project/shared-core/src/main/java" directory="/path/to/multi-module-maven-project/shared-core/target"/>
+        </buildSummary>
+        <buildSummary baseDir="/path/to/multi-module-maven-project/demo-1" file="/path/to/multi-module-maven-project/demo-1/pom.xml" groupId="com.example.demo1" name="demo-1" artifactId="demo-1" time="17962" version="0.0.29-SNAPSHOT" class="org.apache.maven.execution.BuildSuccess">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-1/src/main/java" directory="/path/to/multi-module-maven-project/demo-1/target"/>
+        </buildSummary>
+        <buildSummary baseDir="/path/to/multi-module-maven-project/demo-2" file="/path/to/multi-module-maven-project/demo-2/pom.xml" groupId="com.example.demo2" name="demo-2" artifactId="demo-2" time="16544" version="0.0.29-SNAPSHOT" class="org.apache.maven.execution.BuildSuccess">
+            <build sourceDirectory="/path/to/multi-module-maven-project/demo-2/src/main/java" directory="/path/to/multi-module-maven-project/demo-2/target"/>
+        </buildSummary>
+    </MavenExecutionResult>
+    <!-- 2017-09-02 15:21:25.814 - close:                                       -->
+    <!-- ignored:[org.eclipse.aether.RepositoryEvent,                           -->
+    <!-- org.apache.maven.settings.building.DefaultSettingsBuildingResult],     -->
+    <!-- blackListed: []                                                        -->
+
+</mavenExecution>

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-nexus-deploy-release.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-nexus-deploy-release.xml
@@ -1,0 +1,1607 @@
+<mavenExecution _time="2017-09-01 15:41:01.777">
+    <context _time="2017-09-01 15:41:01.784">
+        <systemProperties/>
+        <versionProperties/>
+        <workingDirectory/>
+        <userProperties/>
+        <plexus/>
+    </context>
+    <!-- 2017-09-01 15:41:01.788 - new File(.):                                 -->
+    <!-- /path/to/jmxtrans-agent/target/checkout      -->
+
+    <DefaultSettingsBuildingRequest class="org.apache.maven.settings.building.DefaultSettingsBuildingRequest" _time="2017-09-01 15:41:01.926">
+        <userSettingsFile>/private/var/folders/lq/50t8n2nx7l316pwm8gc_2rt40000gn/T/release-settings1997633273122836122.xml</userSettingsFile>
+        <globalSettings>/path/to/maven/3.5.0/libexec/conf/settings.xml</globalSettings>
+    </DefaultSettingsBuildingRequest>
+    <MavenExecutionRequest class="org.apache.maven.execution.DefaultMavenExecutionRequest" _time="2017-09-01 15:41:01.964">
+        <pom>/path/to/jmxtrans-agent/target/checkout/pom.xml</pom>
+        <globalSettingsFile>/path/to/maven/3.5.0/libexec/conf/settings.xml</globalSettingsFile>
+        <userSettingsFile>/private/var/folders/lq/50t8n2nx7l316pwm8gc_2rt40000gn/T/release-settings1997633273122836122.xml</userSettingsFile>
+        <baseDirectory>/path/to/jmxtrans-agent/target/checkout</baseDirectory>
+    </MavenExecutionRequest>
+    <ExecutionEvent type="ProjectDiscoveryStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:02.186">
+        <project/>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <ExecutionEvent type="SessionStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:03.084">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:03.095">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <no-execution-found/>
+    </ExecutionEvent>
+    <DependencyResolutionRequest class="org.apache.maven.project.DefaultDependencyResolutionRequest" _time="2017-09-01 15:41:03.316">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+    </DependencyResolutionRequest>
+    <DependencyResolutionResult class="org.apache.maven.project.DefaultDependencyResolutionResult" _time="2017-09-01 15:41:03.577">
+        <resolvedDependencies>
+            <dependency extension="jar" baseVersion="2.0.1" groupId="com.google.code.findbugs" scope="compile" name="jsr305-2.0.1.jar" classifier="" artifactId="jsr305" optional="true" id="jsr305" type="jar" version="2.0.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="3.0.0" groupId="com.google.code.findbugs" scope="compile" name="annotations-3.0.0.jar" classifier="" artifactId="annotations" optional="true" id="annotations" type="jar" version="3.0.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/google/code/findbugs/annotations/3.0.0/annotations-3.0.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2" groupId="joda-time" scope="test" name="joda-time-2.2.jar" classifier="" artifactId="joda-time" optional="false" id="joda-time" type="jar" version="2.2" snapshot="false">
+                <file>/path/to/home/.m2/repository/joda-time/joda-time/2.2/joda-time-2.2.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.12" groupId="junit" scope="test" name="junit-4.12.jar" classifier="" artifactId="junit" optional="false" id="junit" type="jar" version="4.12" snapshot="false">
+                <file>/path/to/home/.m2/repository/junit/junit/4.12/junit-4.12.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-core-1.3.jar" classifier="" artifactId="hamcrest-core" optional="false" id="hamcrest-core" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-all-1.3.jar" classifier="" artifactId="hamcrest-all" optional="false" id="hamcrest-all" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.2.3" groupId="org.skyscreamer" scope="test" name="jsonassert-1.2.3.jar" classifier="" artifactId="jsonassert" optional="false" id="jsonassert" type="jar" version="1.2.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/skyscreamer/jsonassert/1.2.3/jsonassert-1.2.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="20090211" groupId="org.json" scope="test" name="json-20090211.jar" classifier="" artifactId="json" optional="false" id="json" type="jar" version="20090211" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/json/json/20090211/json-20090211.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.5.1" groupId="com.github.tomakehurst" scope="test" name="wiremock-2.5.1.jar" classifier="" artifactId="wiremock" optional="false" id="wiremock" type="jar" version="2.5.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/github/tomakehurst/wiremock/2.5.1/wiremock-2.5.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-server-9.2.13.v20150730.jar" classifier="" artifactId="jetty-server" optional="false" id="jetty-server" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-server/9.2.13.v20150730/jetty-server-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="3.1.0" groupId="javax.servlet" scope="test" name="javax.servlet-api-3.1.0.jar" classifier="" artifactId="javax.servlet-api" optional="false" id="javax.servlet-api" type="jar" version="3.1.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-http-9.2.13.v20150730.jar" classifier="" artifactId="jetty-http" optional="false" id="jetty-http" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-http/9.2.13.v20150730/jetty-http-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-io-9.2.13.v20150730.jar" classifier="" artifactId="jetty-io" optional="false" id="jetty-io" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-io/9.2.13.v20150730/jetty-io-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-servlet-9.2.13.v20150730.jar" classifier="" artifactId="jetty-servlet" optional="false" id="jetty-servlet" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-servlet/9.2.13.v20150730/jetty-servlet-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-security-9.2.13.v20150730.jar" classifier="" artifactId="jetty-security" optional="false" id="jetty-security" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-security/9.2.13.v20150730/jetty-security-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-servlets-9.2.13.v20150730.jar" classifier="" artifactId="jetty-servlets" optional="false" id="jetty-servlets" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-servlets/9.2.13.v20150730/jetty-servlets-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-continuation-9.2.13.v20150730.jar" classifier="" artifactId="jetty-continuation" optional="false" id="jetty-continuation" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-continuation/9.2.13.v20150730/jetty-continuation-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-util-9.2.13.v20150730.jar" classifier="" artifactId="jetty-util" optional="false" id="jetty-util" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-util/9.2.13.v20150730/jetty-util-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-webapp-9.2.13.v20150730.jar" classifier="" artifactId="jetty-webapp" optional="false" id="jetty-webapp" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-webapp/9.2.13.v20150730/jetty-webapp-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-xml-9.2.13.v20150730.jar" classifier="" artifactId="jetty-xml" optional="false" id="jetty-xml" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-xml/9.2.13.v20150730/jetty-xml-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="18.0" groupId="com.google.guava" scope="test" name="guava-18.0.jar" classifier="" artifactId="guava" optional="false" id="guava" type="jar" version="18.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/google/guava/guava/18.0/guava-18.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.6.1" groupId="com.fasterxml.jackson.core" scope="test" name="jackson-core-2.6.1.jar" classifier="" artifactId="jackson-core" optional="false" id="jackson-core" type="jar" version="2.6.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.6.1/jackson-core-2.6.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.6.1" groupId="com.fasterxml.jackson.core" scope="test" name="jackson-annotations-2.6.1.jar" classifier="" artifactId="jackson-annotations" optional="false" id="jackson-annotations" type="jar" version="2.6.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.6.1/jackson-annotations-2.6.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.6.1" groupId="com.fasterxml.jackson.core" scope="test" name="jackson-databind-2.6.1.jar" classifier="" artifactId="jackson-databind" optional="false" id="jackson-databind" type="jar" version="2.6.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.6.1/jackson-databind-2.6.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.5.1" groupId="org.apache.httpcomponents" scope="test" name="httpclient-4.5.1.jar" classifier="" artifactId="httpclient" optional="false" id="httpclient" type="jar" version="4.5.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/httpcomponents/httpclient/4.5.1/httpclient-4.5.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.4.3" groupId="org.apache.httpcomponents" scope="test" name="httpcore-4.4.3.jar" classifier="" artifactId="httpcore" optional="false" id="httpcore" type="jar" version="4.4.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/httpcomponents/httpcore/4.4.3/httpcore-4.4.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.2" groupId="commons-logging" scope="test" name="commons-logging-1.2.jar" classifier="" artifactId="commons-logging" optional="false" id="commons-logging" type="jar" version="1.2" snapshot="false">
+                <file>/path/to/home/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.9" groupId="commons-codec" scope="test" name="commons-codec-1.9.jar" classifier="" artifactId="commons-codec" optional="false" id="commons-codec" type="jar" version="1.9" snapshot="false">
+                <file>/path/to/home/.m2/repository/commons-codec/commons-codec/1.9/commons-codec-1.9.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.3.0" groupId="org.xmlunit" scope="test" name="xmlunit-core-2.3.0.jar" classifier="" artifactId="xmlunit-core" optional="false" id="xmlunit-core" type="jar" version="2.3.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/xmlunit/xmlunit-core/2.3.0/xmlunit-core-2.3.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.3.0" groupId="org.xmlunit" scope="test" name="xmlunit-legacy-2.3.0.jar" classifier="" artifactId="xmlunit-legacy" optional="false" id="xmlunit-legacy" type="jar" version="2.3.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/xmlunit/xmlunit-legacy/2.3.0/xmlunit-legacy-2.3.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.0" groupId="com.jayway.jsonpath" scope="test" name="json-path-2.2.0.jar" classifier="" artifactId="json-path" optional="false" id="json-path" type="jar" version="2.2.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/jayway/jsonpath/json-path/2.2.0/json-path-2.2.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.1" groupId="net.minidev" scope="test" name="json-smart-2.2.1.jar" classifier="" artifactId="json-smart" optional="false" id="json-smart" type="jar" version="2.2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/json-smart/2.2.1/json-smart-2.2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1" groupId="net.minidev" scope="test" name="accessors-smart-1.1.jar" classifier="" artifactId="accessors-smart" optional="false" id="accessors-smart" type="jar" version="1.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/accessors-smart/1.1/accessors-smart-1.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="5.0.3" groupId="org.ow2.asm" scope="test" name="asm-5.0.3.jar" classifier="" artifactId="asm" optional="false" id="asm" type="jar" version="5.0.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/ow2/asm/asm/5.0.3/asm-5.0.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.12" groupId="org.slf4j" scope="test" name="slf4j-api-1.7.12.jar" classifier="" artifactId="slf4j-api" optional="false" id="slf4j-api" type="jar" version="1.7.12" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/slf4j-api/1.7.12/slf4j-api-1.7.12.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.9" groupId="net.sf.jopt-simple" scope="test" name="jopt-simple-4.9.jar" classifier="" artifactId="jopt-simple" optional="false" id="jopt-simple" type="jar" version="4.9" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/sf/jopt-simple/jopt-simple/4.9/jopt-simple-4.9.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="3.4" groupId="org.apache.commons" scope="test" name="commons-lang3-3.4.jar" classifier="" artifactId="commons-lang3" optional="false" id="commons-lang3" type="jar" version="3.4" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="0.2.1" groupId="com.flipkart.zjsonpatch" scope="test" name="zjsonpatch-0.2.1.jar" classifier="" artifactId="zjsonpatch" optional="false" id="zjsonpatch" type="jar" version="0.2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/flipkart/zjsonpatch/zjsonpatch/0.2.1/zjsonpatch-0.2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.0" groupId="org.apache.commons" scope="test" name="commons-collections4-4.0.jar" classifier="" artifactId="commons-collections4" optional="false" id="commons-collections4" type="jar" version="4.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/commons/commons-collections4/4.0/commons-collections4-4.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.0.6" groupId="com.github.jknack" scope="test" name="handlebars-4.0.6.jar" classifier="" artifactId="handlebars" optional="false" id="handlebars" type="jar" version="4.0.6" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/github/jknack/handlebars/4.0.6/handlebars-4.0.6.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.5.1-1" groupId="org.antlr" scope="test" name="antlr4-runtime-4.5.1-1.jar" classifier="" artifactId="antlr4-runtime" optional="false" id="antlr4-runtime" type="jar" version="4.5.1-1" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/antlr/antlr4-runtime/4.5.1-1/antlr4-runtime-4.5.1-1.jar</file>
+            </dependency>
+        </resolvedDependencies>
+    </DependencyResolutionResult>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:03.584">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="enforce-maven" goal="enforce" groupId="org.apache.maven.plugins" artifactId="maven-enforcer-plugin" version="1.4.1">
+            <fail>${enforcer.fail}</fail>
+            <failFast>${enforcer.failFast}</failFast>
+            <ignoreCache>${enforcer.ignoreCache}</ignoreCache>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <project>${project}</project>
+            <rules>
+                <requireMavenVersion>
+                    <version>3.3</version>
+                    <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.</message>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                    <version>1.7</version>
+                </requireJavaVersion>
+            </rules>
+            <session>${session}</session>
+            <skip>${enforcer.skip}</skip>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:04.044">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="enforce-maven" goal="enforce" groupId="org.apache.maven.plugins" artifactId="maven-enforcer-plugin" version="1.4.1">
+            <fail>${enforcer.fail}</fail>
+            <failFast>${enforcer.failFast}</failFast>
+            <ignoreCache>${enforcer.ignoreCache}</ignoreCache>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <project>${project}</project>
+            <rules>
+                <requireMavenVersion>
+                    <version>3.3</version>
+                    <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.</message>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                    <version>1.7</version>
+                </requireJavaVersion>
+            </rules>
+            <session>${session}</session>
+            <skip>${enforcer.skip}</skip>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:04.045">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-resources" goal="resources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.resources}</resources>
+            <session>${session}</session>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>true</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:04.189">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-resources" goal="resources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.resources}</resources>
+            <session>${session}</session>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>true</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:04.189">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-compile" goal="compile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.6.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <compilePath>${project.compileClasspathElements}</compilePath>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <failOnWarning>${maven.compiler.failOnWarning}</failOnWarning>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <project>${project}</project>
+            <projectArtifact>${project.artifact}</projectArtifact>
+            <release>${maven.compiler.release}</release>
+            <session>${session}</session>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skipMain>${maven.main.skip}</skipMain>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>1.7</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>1.7</target>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:06.444">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-compile" goal="compile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.6.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <compilePath>${project.compileClasspathElements}</compilePath>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <failOnWarning>${maven.compiler.failOnWarning}</failOnWarning>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources/annotations</generatedSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            <project>${project}</project>
+            <projectArtifact>${project.artifact}</projectArtifact>
+            <release>${maven.compiler.release}</release>
+            <session>${session}</session>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skipMain>${maven.main.skip}</skipMain>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>1.7</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>1.7</target>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:06.445">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-testResources" goal="testResources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.testResources}</resources>
+            <session>${session}</session>
+            <skip>${maven.test.skip}</skip>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>true</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:06.477">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-testResources" goal="testResources" groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin" version="2.6">
+            <buildFilters>${project.build.filters}</buildFilters>
+            <encoding>${encoding}</encoding>
+            <escapeString>${maven.resources.escapeString}</escapeString>
+            <escapeWindowsPaths>${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
+            <includeEmptyDirs>${maven.resources.includeEmptyDirs}</includeEmptyDirs>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <overwrite>${maven.resources.overwrite}</overwrite>
+            <project>${project}</project>
+            <resources>${project.testResources}</resources>
+            <session>${session}</session>
+            <skip>${maven.test.skip}</skip>
+            <supportMultiLineFiltering>${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
+            <useBuildFilters>true</useBuildFilters>
+            <useDefaultDelimiters>true</useDefaultDelimiters>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:06.478">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-testCompile" goal="testCompile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.6.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <compilePath>${project.compileClasspathElements}</compilePath>
+            <compileSourceRoots>${project.testCompileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <failOnWarning>${maven.compiler.failOnWarning}</failOnWarning>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/test-annotations</generatedTestSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <project>${project}</project>
+            <release>${maven.compiler.release}</release>
+            <session>${session}</session>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skip>${maven.test.skip}</skip>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>1.7</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>1.7</target>
+            <testPath>${project.testClasspathElements}</testPath>
+            <testRelease>${maven.compiler.testRelease}</testRelease>
+            <testSource>${maven.compiler.testSource}</testSource>
+            <testTarget>${maven.compiler.testTarget}</testTarget>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:07.037">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-testCompile" goal="testCompile" groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" version="3.6.1">
+            <basedir>${basedir}</basedir>
+            <buildDirectory>${project.build.directory}</buildDirectory>
+            <compilePath>${project.compileClasspathElements}</compilePath>
+            <compileSourceRoots>${project.testCompileSourceRoots}</compileSourceRoots>
+            <compilerId>${maven.compiler.compilerId}</compilerId>
+            <compilerReuseStrategy>${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
+            <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
+            <debug>${maven.compiler.debug}</debug>
+            <debuglevel>${maven.compiler.debuglevel}</debuglevel>
+            <encoding>${encoding}</encoding>
+            <executable>${maven.compiler.executable}</executable>
+            <failOnError>${maven.compiler.failOnError}</failOnError>
+            <failOnWarning>${maven.compiler.failOnWarning}</failOnWarning>
+            <forceJavacCompilerUse>${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
+            <fork>${maven.compiler.fork}</fork>
+            <generatedTestSourcesDirectory>${project.build.directory}/generated-test-sources/test-annotations</generatedTestSourcesDirectory>
+            <maxmem>${maven.compiler.maxmem}</maxmem>
+            <meminitial>${maven.compiler.meminitial}</meminitial>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <optimize>${maven.compiler.optimize}</optimize>
+            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+            <project>${project}</project>
+            <release>${maven.compiler.release}</release>
+            <session>${session}</session>
+            <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>
+            <showWarnings>${maven.compiler.showWarnings}</showWarnings>
+            <skip>${maven.test.skip}</skip>
+            <skipMultiThreadWarning>${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
+            <source>1.7</source>
+            <staleMillis>${lastModGranularityMs}</staleMillis>
+            <target>1.7</target>
+            <testPath>${project.testClasspathElements}</testPath>
+            <testRelease>${maven.compiler.testRelease}</testRelease>
+            <testSource>${maven.compiler.testSource}</testSource>
+            <testTarget>${maven.compiler.testTarget}</testTarget>
+            <useIncrementalCompilation>${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
+            <verbose>${maven.compiler.verbose}</verbose>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:41:07.038">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-test" goal="test" groupId="org.apache.maven.plugins" artifactId="maven-surefire-plugin" version="2.19.1">
+            <additionalClasspathElements>${maven.test.additionalClasspath}</additionalClasspathElements>
+            <argLine>${argLine}</argLine>
+            <basedir>${basedir}</basedir>
+            <childDelegation>${childDelegation}</childDelegation>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <classpathDependencyExcludes>${maven.test.dependency.excludes}</classpathDependencyExcludes>
+            <debugForkedProcess>${maven.surefire.debug}</debugForkedProcess>
+            <dependenciesToScan>${dependenciesToScan}</dependenciesToScan>
+            <disableXmlReport>${disableXmlReport}</disableXmlReport>
+            <enableAssertions>${enableAssertions}</enableAssertions>
+            <excludedGroups>org.jmxtrans.agent.IntegrationTest</excludedGroups>
+            <excludesFile>${surefire.excludesFile}</excludesFile>
+            <failIfNoSpecifiedTests>${surefire.failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
+            <failIfNoTests>${failIfNoTests}</failIfNoTests>
+            <forkCount>${forkCount}</forkCount>
+            <forkMode>${forkMode}</forkMode>
+            <forkedProcessTimeoutInSeconds>${surefire.timeout}</forkedProcessTimeoutInSeconds>
+            <groups>${groups}</groups>
+            <includesFile>${surefire.includesFile}</includesFile>
+            <junitArtifactName>${junitArtifactName}</junitArtifactName>
+            <jvm>${jvm}</jvm>
+            <localRepository>${localRepository}</localRepository>
+            <objectFactory>${objectFactory}</objectFactory>
+            <parallel>${parallel}</parallel>
+            <parallelMavenExecution>${session.parallel}</parallelMavenExecution>
+            <parallelOptimized>${parallelOptimized}</parallelOptimized>
+            <parallelTestsTimeoutForcedInSeconds>${surefire.parallel.forcedTimeout}</parallelTestsTimeoutForcedInSeconds>
+            <parallelTestsTimeoutInSeconds>${surefire.parallel.timeout}</parallelTestsTimeoutInSeconds>
+            <perCoreThreadCount>${perCoreThreadCount}</perCoreThreadCount>
+            <pluginArtifactMap>${plugin.artifactMap}</pluginArtifactMap>
+            <pluginDescriptor>${plugin}</pluginDescriptor>
+            <printSummary>${surefire.printSummary}</printSummary>
+            <projectArtifactMap>${project.artifactMap}</projectArtifactMap>
+            <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
+            <remoteRepositories>${project.pluginArtifactRepositories}</remoteRepositories>
+            <reportFormat>${surefire.reportFormat}</reportFormat>
+            <reportNameSuffix>${surefire.reportNameSuffix}</reportNameSuffix>
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+            <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
+            <reuseForks>${reuseForks}</reuseForks>
+            <runOrder>${surefire.runOrder}</runOrder>
+            <shutdown>${surefire.shutdown}</shutdown>
+            <skip>${maven.test.skip}</skip>
+            <skipAfterFailureCount>${surefire.skipAfterFailureCount}</skipAfterFailureCount>
+            <skipExec>${maven.test.skip.exec}</skipExec>
+            <skipTests>${skipTests}</skipTests>
+            <suiteXmlFiles>${surefire.suiteXmlFiles}</suiteXmlFiles>
+            <test>${test}</test>
+            <testClassesDirectory>${project.build.testOutputDirectory}</testClassesDirectory>
+            <testFailureIgnore>${maven.test.failure.ignore}</testFailureIgnore>
+            <testNGArtifactName>${testNGArtifactName}</testNGArtifactName>
+            <testSourceDirectory>${project.build.testSourceDirectory}</testSourceDirectory>
+            <threadCount>${threadCount}</threadCount>
+            <threadCountClasses>${threadCountClasses}</threadCountClasses>
+            <threadCountMethods>${threadCountMethods}</threadCountMethods>
+            <threadCountSuites>${threadCountSuites}</threadCountSuites>
+            <trimStackTrace>${trimStackTrace}</trimStackTrace>
+            <useFile>${surefire.useFile}</useFile>
+            <useManifestOnlyJar>${surefire.useManifestOnlyJar}</useManifestOnlyJar>
+            <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
+            <useUnlimitedThreads>${useUnlimitedThreads}</useUnlimitedThreads>
+            <workingDirectory>${basedir}</workingDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:44:54.048">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-test" goal="test" groupId="org.apache.maven.plugins" artifactId="maven-surefire-plugin" version="2.19.1">
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:44:54.049">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-jar" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-jar-plugin" version="3.0.2">
+            <archive>
+                <manifest>
+                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                </manifest>
+                <manifestEntries>
+                    <Main-Class>org.jmxtrans.agent.JmxTransAgent</Main-Class>
+                    <Premain-Class>org.jmxtrans.agent.JmxTransAgent</Premain-Class>
+                    <Agent-Class>org.jmxtrans.agent.JmxTransAgent</Agent-Class>
+                </manifestEntries>
+            </archive>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <finalName>${project.build.finalName}</finalName>
+            <forceCreation>${maven.jar.forceCreation}</forceCreation>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+            <skipIfEmpty>false</skipIfEmpty>
+            <useDefaultManifestFile>${jar.useDefaultManifestFile}</useDefaultManifestFile>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:44:54.661">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-jar" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-jar-plugin" version="3.0.2">
+            <finalName>${project.build.finalName}</finalName>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:44:54.662">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="attach-sources" goal="jar-no-fork" groupId="org.apache.maven.plugins" artifactId="maven-source-plugin" version="2.1.2">
+            <attach>${attach}</attach>
+            <defaultManifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</defaultManifestFile>
+            <excludeResources>${source.excludeResources}</excludeResources>
+            <finalName>${project.build.finalName}</finalName>
+            <forceCreation>${source.forceCreation}</forceCreation>
+            <includePom>${source.includePom}</includePom>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <useDefaultManifestFile>false</useDefaultManifestFile>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:44:55.499">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="attach-sources" goal="jar-no-fork" groupId="org.apache.maven.plugins" artifactId="maven-source-plugin" version="2.1.2">
+            <attach>${attach}</attach>
+            <defaultManifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</defaultManifestFile>
+            <excludeResources>${source.excludeResources}</excludeResources>
+            <finalName>${project.build.finalName}</finalName>
+            <forceCreation>${source.forceCreation}</forceCreation>
+            <includePom>${source.includePom}</includePom>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+            <project>${project}</project>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <useDefaultManifestFile>false</useDefaultManifestFile>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:44:55.5">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="attach-javadocs" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-javadoc-plugin" version="2.7">
+            <additionalJOption>${additionalJOption}</additionalJOption>
+            <additionalparam>${additionalparam}</additionalparam>
+            <aggregate>${aggregate}</aggregate>
+            <attach>${attach}</attach>
+            <author>${author}</author>
+            <bootclasspath>${bootclasspath}</bootclasspath>
+            <bootclasspathArtifacts>${bootclasspathArtifacts}</bootclasspathArtifacts>
+            <bottom>${bottom}</bottom>
+            <breakiterator>${breakiterator}</breakiterator>
+            <charset>${charset}</charset>
+            <debug>${debug}</debug>
+            <defaultManifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</defaultManifestFile>
+            <destDir>${destDir}</destDir>
+            <detectJavaApiLink>${detectJavaApiLink}</detectJavaApiLink>
+            <detectLinks>${detectLinks}</detectLinks>
+            <detectOfflineLinks>${detectOfflineLinks}</detectOfflineLinks>
+            <docencoding>${docencoding}</docencoding>
+            <docfilessubdirs>${docfilessubdirs}</docfilessubdirs>
+            <doclet>${doclet}</doclet>
+            <docletArtifact>${docletArtifact}</docletArtifact>
+            <docletArtifacts>${docletArtifacts}</docletArtifacts>
+            <docletPath>${docletPath}</docletPath>
+            <doctitle>${doctitle}</doctitle>
+            <encoding>${encoding}</encoding>
+            <excludePackageNames>${excludePackageNames}</excludePackageNames>
+            <excludedocfilessubdir>${excludedocfilessubdir}</excludedocfilessubdir>
+            <extdirs>${extdirs}</extdirs>
+            <failOnError>${maven.javadoc.failOnError}</failOnError>
+            <finalName>${project.build.finalName}</finalName>
+            <footer>${footer}</footer>
+            <groups>${groups}</groups>
+            <header>${header}</header>
+            <helpfile>${helpfile}</helpfile>
+            <includeDependencySources>false</includeDependencySources>
+            <includeTransitiveDependencySources>false</includeTransitiveDependencySources>
+            <isOffline>${settings.offline}</isOffline>
+            <jarOutputDirectory>${project.build.directory}</jarOutputDirectory>
+            <javaApiLinks>${javaApiLinks}</javaApiLinks>
+            <javadocDirectory>${basedir}/src/main/javadoc</javadocDirectory>
+            <javadocExecutable>${javadocExecutable}</javadocExecutable>
+            <javadocOptionsDir>${project.build.directory}/javadoc-bundle-options</javadocOptionsDir>
+            <javadocVersion>${javadocVersion}</javadocVersion>
+            <keywords>${keywords}</keywords>
+            <links>${links}</links>
+            <linksource>${linksource}</linksource>
+            <localRepository>${localRepository}</localRepository>
+            <locale>${locale}</locale>
+            <maxmemory>${maxmemory}</maxmemory>
+            <minmemory>${minmemory}</minmemory>
+            <nocomment>${nocomment}</nocomment>
+            <nodeprecated>${nodeprecated}</nodeprecated>
+            <nodeprecatedlist>${nodeprecatedlist}</nodeprecatedlist>
+            <nohelp>${nohelp}</nohelp>
+            <noindex>${noindex}</noindex>
+            <nonavbar>${nonavbar}</nonavbar>
+            <nooverview>${nooverview}</nooverview>
+            <noqualifier>${noqualifier}</noqualifier>
+            <nosince>${nosince}</nosince>
+            <notimestamp>${notimestamp}</notimestamp>
+            <notree>${notree}</notree>
+            <offlineLinks>${offlineLinks}</offlineLinks>
+            <old>${old}</old>
+            <outputDirectory>${destDir}</outputDirectory>
+            <overview>${overview}</overview>
+            <packagesheader>${packagesheader}</packagesheader>
+            <project>${project}</project>
+            <proxyHost>${proxyHost}</proxyHost>
+            <proxyPort>${proxyPort}</proxyPort>
+            <quiet>${quiet}</quiet>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <remoteRepositories>${project.remoteArtifactRepositories}</remoteRepositories>
+            <resourcesArtifacts>${resourcesArtifacts}</resourcesArtifacts>
+            <serialwarn>${serialwarn}</serialwarn>
+            <session>${session}</session>
+            <settings>${settings}</settings>
+            <show>${show}</show>
+            <skip>${maven.javadoc.skip}</skip>
+            <source>${source}</source>
+            <sourceDependencyCacheDir>${project.build.directory}/distro-javadoc-sources</sourceDependencyCacheDir>
+            <sourcepath>${sourcepath}</sourcepath>
+            <sourcetab>${sourcetab}</sourcetab>
+            <splitindex>${splitindex}</splitindex>
+            <stylesheet>${stylesheet}</stylesheet>
+            <stylesheetfile>${stylesheetfile}</stylesheetfile>
+            <subpackages>${subpackages}</subpackages>
+            <taglet>${taglet}</taglet>
+            <tagletArtifact>${tagletArtifact}</tagletArtifact>
+            <tagletArtifacts>${tagletArtifacts}</tagletArtifacts>
+            <tagletpath>${tagletpath}</tagletpath>
+            <taglets>${taglets}</taglets>
+            <tags>${tags}</tags>
+            <top>${top}</top>
+            <use>${use}</use>
+            <useDefaultManifestFile>false</useDefaultManifestFile>
+            <useStandardDocletOptions>${useStandardDocletOptions}</useStandardDocletOptions>
+            <verbose>${verbose}</verbose>
+            <version>${version}</version>
+            <windowtitle>${windowtitle}</windowtitle>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:03.214">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="attach-javadocs" goal="jar" groupId="org.apache.maven.plugins" artifactId="maven-javadoc-plugin" version="2.7">
+            <additionalJOption>${additionalJOption}</additionalJOption>
+            <additionalparam>${additionalparam}</additionalparam>
+            <aggregate>${aggregate}</aggregate>
+            <attach>${attach}</attach>
+            <author>${author}</author>
+            <bootclasspath>${bootclasspath}</bootclasspath>
+            <bootclasspathArtifacts>${bootclasspathArtifacts}</bootclasspathArtifacts>
+            <bottom>${bottom}</bottom>
+            <breakiterator>${breakiterator}</breakiterator>
+            <charset>${charset}</charset>
+            <debug>${debug}</debug>
+            <defaultManifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</defaultManifestFile>
+            <destDir>${destDir}</destDir>
+            <detectJavaApiLink>${detectJavaApiLink}</detectJavaApiLink>
+            <detectLinks>${detectLinks}</detectLinks>
+            <detectOfflineLinks>${detectOfflineLinks}</detectOfflineLinks>
+            <docencoding>${docencoding}</docencoding>
+            <docfilessubdirs>${docfilessubdirs}</docfilessubdirs>
+            <doclet>${doclet}</doclet>
+            <docletArtifact>${docletArtifact}</docletArtifact>
+            <docletArtifacts>${docletArtifacts}</docletArtifacts>
+            <docletPath>${docletPath}</docletPath>
+            <doctitle>${doctitle}</doctitle>
+            <encoding>${encoding}</encoding>
+            <excludePackageNames>${excludePackageNames}</excludePackageNames>
+            <excludedocfilessubdir>${excludedocfilessubdir}</excludedocfilessubdir>
+            <extdirs>${extdirs}</extdirs>
+            <failOnError>${maven.javadoc.failOnError}</failOnError>
+            <finalName>${project.build.finalName}</finalName>
+            <footer>${footer}</footer>
+            <groups>${groups}</groups>
+            <header>${header}</header>
+            <helpfile>${helpfile}</helpfile>
+            <includeDependencySources>false</includeDependencySources>
+            <includeTransitiveDependencySources>false</includeTransitiveDependencySources>
+            <isOffline>${settings.offline}</isOffline>
+            <jarOutputDirectory>${project.build.directory}</jarOutputDirectory>
+            <javaApiLinks>${javaApiLinks}</javaApiLinks>
+            <javadocDirectory>${basedir}/src/main/javadoc</javadocDirectory>
+            <javadocExecutable>${javadocExecutable}</javadocExecutable>
+            <javadocOptionsDir>${project.build.directory}/javadoc-bundle-options</javadocOptionsDir>
+            <javadocVersion>${javadocVersion}</javadocVersion>
+            <keywords>${keywords}</keywords>
+            <links>${links}</links>
+            <linksource>${linksource}</linksource>
+            <localRepository>${localRepository}</localRepository>
+            <locale>${locale}</locale>
+            <maxmemory>${maxmemory}</maxmemory>
+            <minmemory>${minmemory}</minmemory>
+            <nocomment>${nocomment}</nocomment>
+            <nodeprecated>${nodeprecated}</nodeprecated>
+            <nodeprecatedlist>${nodeprecatedlist}</nodeprecatedlist>
+            <nohelp>${nohelp}</nohelp>
+            <noindex>${noindex}</noindex>
+            <nonavbar>${nonavbar}</nonavbar>
+            <nooverview>${nooverview}</nooverview>
+            <noqualifier>${noqualifier}</noqualifier>
+            <nosince>${nosince}</nosince>
+            <notimestamp>${notimestamp}</notimestamp>
+            <notree>${notree}</notree>
+            <offlineLinks>${offlineLinks}</offlineLinks>
+            <old>${old}</old>
+            <outputDirectory>${destDir}</outputDirectory>
+            <overview>${overview}</overview>
+            <packagesheader>${packagesheader}</packagesheader>
+            <project>${project}</project>
+            <proxyHost>${proxyHost}</proxyHost>
+            <proxyPort>${proxyPort}</proxyPort>
+            <quiet>${quiet}</quiet>
+            <reactorProjects>${reactorProjects}</reactorProjects>
+            <remoteRepositories>${project.remoteArtifactRepositories}</remoteRepositories>
+            <resourcesArtifacts>${resourcesArtifacts}</resourcesArtifacts>
+            <serialwarn>${serialwarn}</serialwarn>
+            <session>${session}</session>
+            <settings>${settings}</settings>
+            <show>${show}</show>
+            <skip>${maven.javadoc.skip}</skip>
+            <source>${source}</source>
+            <sourceDependencyCacheDir>${project.build.directory}/distro-javadoc-sources</sourceDependencyCacheDir>
+            <sourcepath>${sourcepath}</sourcepath>
+            <sourcetab>${sourcetab}</sourcetab>
+            <splitindex>${splitindex}</splitindex>
+            <stylesheet>${stylesheet}</stylesheet>
+            <stylesheetfile>${stylesheetfile}</stylesheetfile>
+            <subpackages>${subpackages}</subpackages>
+            <taglet>${taglet}</taglet>
+            <tagletArtifact>${tagletArtifact}</tagletArtifact>
+            <tagletArtifacts>${tagletArtifacts}</tagletArtifacts>
+            <tagletpath>${tagletpath}</tagletpath>
+            <taglets>${taglets}</taglets>
+            <tags>${tags}</tags>
+            <top>${top}</top>
+            <use>${use}</use>
+            <useDefaultManifestFile>false</useDefaultManifestFile>
+            <useStandardDocletOptions>${useStandardDocletOptions}</useStandardDocletOptions>
+            <verbose>${verbose}</verbose>
+            <version>${version}</version>
+            <windowtitle>${windowtitle}</windowtitle>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:03.214">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default" goal="integration-test" groupId="org.apache.maven.plugins" artifactId="maven-failsafe-plugin" version="2.19.1">
+            <additionalClasspathElements>${maven.test.additionalClasspath}</additionalClasspathElements>
+            <argLine>${argLine}</argLine>
+            <basedir>${basedir}</basedir>
+            <childDelegation>${childDelegation}</childDelegation>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <classpathDependencyExcludes>${maven.test.dependency.excludes}</classpathDependencyExcludes>
+            <debugForkedProcess>${maven.failsafe.debug}</debugForkedProcess>
+            <dependenciesToScan>${dependenciesToScan}</dependenciesToScan>
+            <disableXmlReport>${disableXmlReport}</disableXmlReport>
+            <enableAssertions>${enableAssertions}</enableAssertions>
+            <encoding>${encoding}</encoding>
+            <excludedGroups>${excludedGroups}</excludedGroups>
+            <excludesFile>${failsafe.excludesFile}</excludesFile>
+            <failIfNoSpecifiedTests>${it.failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
+            <failIfNoTests>${failIfNoTests}</failIfNoTests>
+            <forkCount>${forkCount}</forkCount>
+            <forkMode>${forkMode}</forkMode>
+            <forkedProcessTimeoutInSeconds>${failsafe.timeout}</forkedProcessTimeoutInSeconds>
+            <groups>org.jmxtrans.agent.IntegrationTest</groups>
+            <includes>
+                <include>**/*.java</include>
+            </includes>
+            <includesFile>${failsafe.includesFile}</includesFile>
+            <junitArtifactName>${junitArtifactName}</junitArtifactName>
+            <jvm>${jvm}</jvm>
+            <localRepository>${localRepository}</localRepository>
+            <objectFactory>${objectFactory}</objectFactory>
+            <parallel>${parallel}</parallel>
+            <parallelMavenExecution>${session.parallel}</parallelMavenExecution>
+            <parallelOptimized>${parallelOptimized}</parallelOptimized>
+            <parallelTestsTimeoutForcedInSeconds>${failsafe.parallel.forcedTimeout}</parallelTestsTimeoutForcedInSeconds>
+            <parallelTestsTimeoutInSeconds>${failsafe.parallel.timeout}</parallelTestsTimeoutInSeconds>
+            <perCoreThreadCount>${perCoreThreadCount}</perCoreThreadCount>
+            <pluginArtifactMap>${plugin.artifactMap}</pluginArtifactMap>
+            <pluginDescriptor>${plugin}</pluginDescriptor>
+            <printSummary>${failsafe.printSummary}</printSummary>
+            <projectArtifactMap>${project.artifactMap}</projectArtifactMap>
+            <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
+            <remoteRepositories>${project.pluginArtifactRepositories}</remoteRepositories>
+            <reportFormat>${failsafe.reportFormat}</reportFormat>
+            <reportNameSuffix>${surefire.reportNameSuffix}</reportNameSuffix>
+            <reportsDirectory>${project.build.directory}/failsafe-reports</reportsDirectory>
+            <rerunFailingTestsCount>${failsafe.rerunFailingTestsCount}</rerunFailingTestsCount>
+            <reuseForks>${reuseForks}</reuseForks>
+            <runOrder>${failsafe.runOrder}</runOrder>
+            <shutdown>${failsafe.shutdown}</shutdown>
+            <skip>${maven.test.skip}</skip>
+            <skipAfterFailureCount>${failsafe.skipAfterFailureCount}</skipAfterFailureCount>
+            <skipExec>${maven.test.skip.exec}</skipExec>
+            <skipITs>${skipITs}</skipITs>
+            <skipTests>${skipTests}</skipTests>
+            <suiteXmlFiles>${failsafe.suiteXmlFiles}</suiteXmlFiles>
+            <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary.xml</summaryFile>
+            <test>${it.test}</test>
+            <testClassesDirectory>${project.build.testOutputDirectory}</testClassesDirectory>
+            <testNGArtifactName>${testNGArtifactName}</testNGArtifactName>
+            <testSourceDirectory>${project.build.testSourceDirectory}</testSourceDirectory>
+            <threadCount>${threadCount}</threadCount>
+            <threadCountClasses>${threadCountClasses}</threadCountClasses>
+            <threadCountMethods>${threadCountMethods}</threadCountMethods>
+            <threadCountSuites>${threadCountSuites}</threadCountSuites>
+            <trimStackTrace>${trimStackTrace}</trimStackTrace>
+            <useFile>${failsafe.useFile}</useFile>
+            <useManifestOnlyJar>${failsafe.useManifestOnlyJar}</useManifestOnlyJar>
+            <useSystemClassLoader>${failsafe.useSystemClassLoader}</useSystemClassLoader>
+            <useUnlimitedThreads>${useUnlimitedThreads}</useUnlimitedThreads>
+            <workingDirectory>${basedir}</workingDirectory>
+            <project>${project}</project>
+            <session>${session}</session>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:04.81">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default" goal="integration-test" groupId="org.apache.maven.plugins" artifactId="maven-failsafe-plugin" version="2.19.1">
+            <reportsDirectory>${project.build.directory}/failsafe-reports</reportsDirectory>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:04.81">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkedProjectStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:04.811">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <DependencyResolutionRequest class="org.apache.maven.project.DefaultDependencyResolutionRequest" _time="2017-09-01 15:45:04.812">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+    </DependencyResolutionRequest>
+    <DependencyResolutionResult class="org.apache.maven.project.DefaultDependencyResolutionResult" _time="2017-09-01 15:45:04.837">
+        <resolvedDependencies>
+            <dependency extension="jar" baseVersion="2.0.1" groupId="com.google.code.findbugs" scope="compile" name="jsr305-2.0.1.jar" classifier="" artifactId="jsr305" optional="true" id="jsr305" type="jar" version="2.0.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="3.0.0" groupId="com.google.code.findbugs" scope="compile" name="annotations-3.0.0.jar" classifier="" artifactId="annotations" optional="true" id="annotations" type="jar" version="3.0.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/google/code/findbugs/annotations/3.0.0/annotations-3.0.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2" groupId="joda-time" scope="test" name="joda-time-2.2.jar" classifier="" artifactId="joda-time" optional="false" id="joda-time" type="jar" version="2.2" snapshot="false">
+                <file>/path/to/home/.m2/repository/joda-time/joda-time/2.2/joda-time-2.2.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.12" groupId="junit" scope="test" name="junit-4.12.jar" classifier="" artifactId="junit" optional="false" id="junit" type="jar" version="4.12" snapshot="false">
+                <file>/path/to/home/.m2/repository/junit/junit/4.12/junit-4.12.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-core-1.3.jar" classifier="" artifactId="hamcrest-core" optional="false" id="hamcrest-core" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.3" groupId="org.hamcrest" scope="test" name="hamcrest-all-1.3.jar" classifier="" artifactId="hamcrest-all" optional="false" id="hamcrest-all" type="jar" version="1.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.2.3" groupId="org.skyscreamer" scope="test" name="jsonassert-1.2.3.jar" classifier="" artifactId="jsonassert" optional="false" id="jsonassert" type="jar" version="1.2.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/skyscreamer/jsonassert/1.2.3/jsonassert-1.2.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="20090211" groupId="org.json" scope="test" name="json-20090211.jar" classifier="" artifactId="json" optional="false" id="json" type="jar" version="20090211" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/json/json/20090211/json-20090211.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.5.1" groupId="com.github.tomakehurst" scope="test" name="wiremock-2.5.1.jar" classifier="" artifactId="wiremock" optional="false" id="wiremock" type="jar" version="2.5.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/github/tomakehurst/wiremock/2.5.1/wiremock-2.5.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-server-9.2.13.v20150730.jar" classifier="" artifactId="jetty-server" optional="false" id="jetty-server" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-server/9.2.13.v20150730/jetty-server-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="3.1.0" groupId="javax.servlet" scope="test" name="javax.servlet-api-3.1.0.jar" classifier="" artifactId="javax.servlet-api" optional="false" id="javax.servlet-api" type="jar" version="3.1.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-http-9.2.13.v20150730.jar" classifier="" artifactId="jetty-http" optional="false" id="jetty-http" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-http/9.2.13.v20150730/jetty-http-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-io-9.2.13.v20150730.jar" classifier="" artifactId="jetty-io" optional="false" id="jetty-io" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-io/9.2.13.v20150730/jetty-io-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-servlet-9.2.13.v20150730.jar" classifier="" artifactId="jetty-servlet" optional="false" id="jetty-servlet" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-servlet/9.2.13.v20150730/jetty-servlet-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-security-9.2.13.v20150730.jar" classifier="" artifactId="jetty-security" optional="false" id="jetty-security" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-security/9.2.13.v20150730/jetty-security-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-servlets-9.2.13.v20150730.jar" classifier="" artifactId="jetty-servlets" optional="false" id="jetty-servlets" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-servlets/9.2.13.v20150730/jetty-servlets-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-continuation-9.2.13.v20150730.jar" classifier="" artifactId="jetty-continuation" optional="false" id="jetty-continuation" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-continuation/9.2.13.v20150730/jetty-continuation-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-util-9.2.13.v20150730.jar" classifier="" artifactId="jetty-util" optional="false" id="jetty-util" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-util/9.2.13.v20150730/jetty-util-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-webapp-9.2.13.v20150730.jar" classifier="" artifactId="jetty-webapp" optional="false" id="jetty-webapp" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-webapp/9.2.13.v20150730/jetty-webapp-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="9.2.13.v20150730" groupId="org.eclipse.jetty" scope="test" name="jetty-xml-9.2.13.v20150730.jar" classifier="" artifactId="jetty-xml" optional="false" id="jetty-xml" type="jar" version="9.2.13.v20150730" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/eclipse/jetty/jetty-xml/9.2.13.v20150730/jetty-xml-9.2.13.v20150730.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="18.0" groupId="com.google.guava" scope="test" name="guava-18.0.jar" classifier="" artifactId="guava" optional="false" id="guava" type="jar" version="18.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/google/guava/guava/18.0/guava-18.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.6.1" groupId="com.fasterxml.jackson.core" scope="test" name="jackson-core-2.6.1.jar" classifier="" artifactId="jackson-core" optional="false" id="jackson-core" type="jar" version="2.6.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.6.1/jackson-core-2.6.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.6.1" groupId="com.fasterxml.jackson.core" scope="test" name="jackson-annotations-2.6.1.jar" classifier="" artifactId="jackson-annotations" optional="false" id="jackson-annotations" type="jar" version="2.6.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.6.1/jackson-annotations-2.6.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.6.1" groupId="com.fasterxml.jackson.core" scope="test" name="jackson-databind-2.6.1.jar" classifier="" artifactId="jackson-databind" optional="false" id="jackson-databind" type="jar" version="2.6.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.6.1/jackson-databind-2.6.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.5.1" groupId="org.apache.httpcomponents" scope="test" name="httpclient-4.5.1.jar" classifier="" artifactId="httpclient" optional="false" id="httpclient" type="jar" version="4.5.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/httpcomponents/httpclient/4.5.1/httpclient-4.5.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.4.3" groupId="org.apache.httpcomponents" scope="test" name="httpcore-4.4.3.jar" classifier="" artifactId="httpcore" optional="false" id="httpcore" type="jar" version="4.4.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/httpcomponents/httpcore/4.4.3/httpcore-4.4.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.2" groupId="commons-logging" scope="test" name="commons-logging-1.2.jar" classifier="" artifactId="commons-logging" optional="false" id="commons-logging" type="jar" version="1.2" snapshot="false">
+                <file>/path/to/home/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.9" groupId="commons-codec" scope="test" name="commons-codec-1.9.jar" classifier="" artifactId="commons-codec" optional="false" id="commons-codec" type="jar" version="1.9" snapshot="false">
+                <file>/path/to/home/.m2/repository/commons-codec/commons-codec/1.9/commons-codec-1.9.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.3.0" groupId="org.xmlunit" scope="test" name="xmlunit-core-2.3.0.jar" classifier="" artifactId="xmlunit-core" optional="false" id="xmlunit-core" type="jar" version="2.3.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/xmlunit/xmlunit-core/2.3.0/xmlunit-core-2.3.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.3.0" groupId="org.xmlunit" scope="test" name="xmlunit-legacy-2.3.0.jar" classifier="" artifactId="xmlunit-legacy" optional="false" id="xmlunit-legacy" type="jar" version="2.3.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/xmlunit/xmlunit-legacy/2.3.0/xmlunit-legacy-2.3.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.0" groupId="com.jayway.jsonpath" scope="test" name="json-path-2.2.0.jar" classifier="" artifactId="json-path" optional="false" id="json-path" type="jar" version="2.2.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/jayway/jsonpath/json-path/2.2.0/json-path-2.2.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="2.2.1" groupId="net.minidev" scope="test" name="json-smart-2.2.1.jar" classifier="" artifactId="json-smart" optional="false" id="json-smart" type="jar" version="2.2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/json-smart/2.2.1/json-smart-2.2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.1" groupId="net.minidev" scope="test" name="accessors-smart-1.1.jar" classifier="" artifactId="accessors-smart" optional="false" id="accessors-smart" type="jar" version="1.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/minidev/accessors-smart/1.1/accessors-smart-1.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="5.0.3" groupId="org.ow2.asm" scope="test" name="asm-5.0.3.jar" classifier="" artifactId="asm" optional="false" id="asm" type="jar" version="5.0.3" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/ow2/asm/asm/5.0.3/asm-5.0.3.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="1.7.12" groupId="org.slf4j" scope="test" name="slf4j-api-1.7.12.jar" classifier="" artifactId="slf4j-api" optional="false" id="slf4j-api" type="jar" version="1.7.12" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/slf4j/slf4j-api/1.7.12/slf4j-api-1.7.12.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.9" groupId="net.sf.jopt-simple" scope="test" name="jopt-simple-4.9.jar" classifier="" artifactId="jopt-simple" optional="false" id="jopt-simple" type="jar" version="4.9" snapshot="false">
+                <file>/path/to/home/.m2/repository/net/sf/jopt-simple/jopt-simple/4.9/jopt-simple-4.9.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="3.4" groupId="org.apache.commons" scope="test" name="commons-lang3-3.4.jar" classifier="" artifactId="commons-lang3" optional="false" id="commons-lang3" type="jar" version="3.4" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="0.2.1" groupId="com.flipkart.zjsonpatch" scope="test" name="zjsonpatch-0.2.1.jar" classifier="" artifactId="zjsonpatch" optional="false" id="zjsonpatch" type="jar" version="0.2.1" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/flipkart/zjsonpatch/zjsonpatch/0.2.1/zjsonpatch-0.2.1.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.0" groupId="org.apache.commons" scope="test" name="commons-collections4-4.0.jar" classifier="" artifactId="commons-collections4" optional="false" id="commons-collections4" type="jar" version="4.0" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/apache/commons/commons-collections4/4.0/commons-collections4-4.0.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.0.6" groupId="com.github.jknack" scope="test" name="handlebars-4.0.6.jar" classifier="" artifactId="handlebars" optional="false" id="handlebars" type="jar" version="4.0.6" snapshot="false">
+                <file>/path/to/home/.m2/repository/com/github/jknack/handlebars/4.0.6/handlebars-4.0.6.jar</file>
+            </dependency>
+            <dependency extension="jar" baseVersion="4.5.1-1" groupId="org.antlr" scope="test" name="antlr4-runtime-4.5.1-1.jar" classifier="" artifactId="antlr4-runtime" optional="false" id="antlr4-runtime" type="jar" version="4.5.1-1" snapshot="false">
+                <file>/path/to/home/.m2/repository/org/antlr/antlr4-runtime/4.5.1-1/antlr4-runtime-4.5.1-1.jar</file>
+            </dependency>
+        </resolvedDependencies>
+    </DependencyResolutionResult>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:04.844">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="findbugs" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <remoteRepositories>${project.remoteArtifactRepositories}</remoteRepositories>
+            <skip>${findbugs.skip}</skip>
+            <skipEmptyReport>${findbugs.skipEmptyReport}</skipEmptyReport>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <userPrefs>${findbugs.userPrefs}</userPrefs>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:39.781">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="findbugs" goal="findbugs" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <remoteRepositories>${project.remoteArtifactRepositories}</remoteRepositories>
+            <skip>${findbugs.skip}</skip>
+            <skipEmptyReport>${findbugs.skipEmptyReport}</skipEmptyReport>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <userPrefs>${findbugs.userPrefs}</userPrefs>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkedProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:39.781">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ForkSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:39.782">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:39.786">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:39.879">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default" goal="check" groupId="org.codehaus.mojo" artifactId="findbugs-maven-plugin" version="3.0.4">
+            <classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
+            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+            <debug>${findbugs.debug}</debug>
+            <effort>${findbugs.effort}</effort>
+            <excludeBugsFile>${findbugs.excludeBugsFile}</excludeBugsFile>
+            <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
+            <failOnError>${findbugs.failOnError}</failOnError>
+            <findbugsXmlOutput>true</findbugsXmlOutput>
+            <findbugsXmlOutputDirectory>${project.build.directory}</findbugsXmlOutputDirectory>
+            <fork>${findbugs.fork}</fork>
+            <includeFilterFile>${findbugs.includeFilterFile}</includeFilterFile>
+            <includeTests>${findbugs.includeTests}</includeTests>
+            <jvmArgs>${findbugs.jvmArgs}</jvmArgs>
+            <localRepository>${localRepository}</localRepository>
+            <maxHeap>${findbugs.maxHeap}</maxHeap>
+            <maxRank>${findbugs.maxRank}</maxRank>
+            <nested>${findbugs.nested}</nested>
+            <omitVisitors>${findbugs.omitVisitors}</omitVisitors>
+            <onlyAnalyze>${findbugs.onlyAnalyze}</onlyAnalyze>
+            <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+            <outputEncoding>${outputEncoding}</outputEncoding>
+            <pluginArtifacts>${plugin.artifacts}</pluginArtifacts>
+            <pluginList>${findbugs.pluginList}</pluginList>
+            <project>${project}</project>
+            <relaxed>${findbugs.relaxed}</relaxed>
+            <remoteArtifactRepositories>${project.remoteArtifactRepositories}</remoteArtifactRepositories>
+            <skip>${findbugs.skip}</skip>
+            <sourceEncoding>${encoding}</sourceEncoding>
+            <testClassFilesDirectory>${project.build.testOutputDirectory}</testClassFilesDirectory>
+            <testSourceRoots>${project.testCompileSourceRoots}</testSourceRoots>
+            <threshold>${findbugs.threshold}</threshold>
+            <timeout>${findbugs.timeout}</timeout>
+            <trace>${findbugs.trace}</trace>
+            <visitors>${findbugs.visitors}</visitors>
+            <xmlEncoding>UTF-8</xmlEncoding>
+            <xmlOutput>${findbugs.xmlOutput}</xmlOutput>
+            <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+            <xrefLocation>${project.reporting.outputDirectory}/xref</xrefLocation>
+            <xrefTestLocation>${project.reporting.outputDirectory}/xref-test</xrefTestLocation>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:39.879">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="sign-artifacts" goal="sign" groupId="org.apache.maven.plugins" artifactId="maven-gpg-plugin" version="1.6">
+            <ascDirectory>${project.build.directory}/gpg</ascDirectory>
+            <defaultKeyring>${gpg.defaultKeyring}</defaultKeyring>
+            <executable>${gpg.executable}</executable>
+            <homedir>${gpg.homedir}</homedir>
+            <interactive>${settings.interactiveMode}</interactive>
+            <keyname>${gpg.keyname}</keyname>
+            <lockMode>${gpg.lockMode}</lockMode>
+            <passphrase>${gpg.passphrase}</passphrase>
+            <passphraseServerId>${gpg.passphraseServerId}</passphraseServerId>
+            <project>${project}</project>
+            <publicKeyring>${gpg.publicKeyring}</publicKeyring>
+            <secretKeyring>${gpg.secretKeyring}</secretKeyring>
+            <settings>${settings}</settings>
+            <skip>${gpg.skip}</skip>
+            <useAgent>${gpg.useagent}</useAgent>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:40.186">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="sign-artifacts" goal="sign" groupId="org.apache.maven.plugins" artifactId="maven-gpg-plugin" version="1.6">
+            <ascDirectory>${project.build.directory}/gpg</ascDirectory>
+            <defaultKeyring>${gpg.defaultKeyring}</defaultKeyring>
+            <executable>${gpg.executable}</executable>
+            <homedir>${gpg.homedir}</homedir>
+            <interactive>${settings.interactiveMode}</interactive>
+            <keyname>${gpg.keyname}</keyname>
+            <lockMode>${gpg.lockMode}</lockMode>
+            <passphrase>${gpg.passphrase}</passphrase>
+            <passphraseServerId>${gpg.passphraseServerId}</passphraseServerId>
+            <project>${project}</project>
+            <publicKeyring>${gpg.publicKeyring}</publicKeyring>
+            <secretKeyring>${gpg.secretKeyring}</secretKeyring>
+            <settings>${settings}</settings>
+            <skip>${gpg.skip}</skip>
+            <useAgent>${gpg.useagent}</useAgent>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:40.186">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.4">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:40.288">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="default-install" goal="install" groupId="org.apache.maven.plugins" artifactId="maven-install-plugin" version="2.4">
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <createChecksum>${createChecksum}</createChecksum>
+            <localRepository>${localRepository}</localRepository>
+            <packaging>${project.packaging}</packaging>
+            <pomFile>${project.file}</pomFile>
+            <skip>${maven.install.skip}</skip>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoStarted" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:45:40.288">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="injected-nexus-deploy" goal="deploy" groupId="org.sonatype.plugins" artifactId="nexus-staging-maven-plugin" version="1.6.7">
+            <altStagingDirectory>${altStagingDirectory}</altStagingDirectory>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <autoDropAfterRelease>${autoDropAfterRelease}</autoDropAfterRelease>
+            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            <detectBuildFailures>${detectBuildFailures}</detectBuildFailures>
+            <keepStagingRepositoryOnCloseRuleFailure>${keepStagingRepositoryOnCloseRuleFailure}</keepStagingRepositoryOnCloseRuleFailure>
+            <keepStagingRepositoryOnFailure>${keepStagingRepositoryOnFailure}</keepStagingRepositoryOnFailure>
+            <mavenSession>${session}</mavenSession>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pluginArtifactId>${plugin.artifactId}</pluginArtifactId>
+            <pluginGroupId>${plugin.groupId}</pluginGroupId>
+            <pluginVersion>${plugin.version}</pluginVersion>
+            <pomFile>${project.file}</pomFile>
+            <serverId>sonatype-nexus-staging</serverId>
+            <skipLocalStaging>${skipLocalStaging}</skipLocalStaging>
+            <skipNexusStagingDeployMojo>${skipNexusStagingDeployMojo}</skipNexusStagingDeployMojo>
+            <skipRemoteStaging>${skipRemoteStaging}</skipRemoteStaging>
+            <skipStaging>${skipStaging}</skipStaging>
+            <skipStagingRepositoryClose>${skipStagingRepositoryClose}</skipStagingRepositoryClose>
+            <sslAllowAll>${maven.wagon.http.ssl.allowall}</sslAllowAll>
+            <sslInsecure>${maven.wagon.http.ssl.insecure}</sslInsecure>
+            <stagingDescription>${stagingDescription}</stagingDescription>
+            <stagingProfileId>${stagingProfileId}</stagingProfileId>
+            <stagingProgressPauseDurationSeconds>${stagingProgressPauseDurationSeconds}</stagingProgressPauseDurationSeconds>
+            <stagingProgressTimeoutMinutes>${stagingProgressTimeoutMinutes}</stagingProgressTimeoutMinutes>
+            <stagingRepositoryId>${stagingRepositoryId}</stagingRepositoryId>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="MojoSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:46:49.64">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <plugin executionId="injected-nexus-deploy" goal="deploy" groupId="org.sonatype.plugins" artifactId="nexus-staging-maven-plugin" version="1.6.7">
+            <altStagingDirectory>${altStagingDirectory}</altStagingDirectory>
+            <artifact>${project.artifact}</artifact>
+            <attachedArtifacts>${project.attachedArtifacts}</attachedArtifacts>
+            <autoDropAfterRelease>${autoDropAfterRelease}</autoDropAfterRelease>
+            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            <detectBuildFailures>${detectBuildFailures}</detectBuildFailures>
+            <keepStagingRepositoryOnCloseRuleFailure>${keepStagingRepositoryOnCloseRuleFailure}</keepStagingRepositoryOnCloseRuleFailure>
+            <keepStagingRepositoryOnFailure>${keepStagingRepositoryOnFailure}</keepStagingRepositoryOnFailure>
+            <mavenSession>${session}</mavenSession>
+            <mojoExecution>${mojoExecution}</mojoExecution>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <offline>${settings.offline}</offline>
+            <packaging>${project.packaging}</packaging>
+            <pluginArtifactId>${plugin.artifactId}</pluginArtifactId>
+            <pluginGroupId>${plugin.groupId}</pluginGroupId>
+            <pluginVersion>${plugin.version}</pluginVersion>
+            <pomFile>${project.file}</pomFile>
+            <serverId>sonatype-nexus-staging</serverId>
+            <skipLocalStaging>${skipLocalStaging}</skipLocalStaging>
+            <skipNexusStagingDeployMojo>${skipNexusStagingDeployMojo}</skipNexusStagingDeployMojo>
+            <skipRemoteStaging>${skipRemoteStaging}</skipRemoteStaging>
+            <skipStaging>${skipStaging}</skipStaging>
+            <skipStagingRepositoryClose>${skipStagingRepositoryClose}</skipStagingRepositoryClose>
+            <sslAllowAll>${maven.wagon.http.ssl.allowall}</sslAllowAll>
+            <sslInsecure>${maven.wagon.http.ssl.insecure}</sslInsecure>
+            <stagingDescription>${stagingDescription}</stagingDescription>
+            <stagingProfileId>${stagingProfileId}</stagingProfileId>
+            <stagingProgressPauseDurationSeconds>${stagingProgressPauseDurationSeconds}</stagingProgressPauseDurationSeconds>
+            <stagingProgressTimeoutMinutes>${stagingProgressTimeoutMinutes}</stagingProgressTimeoutMinutes>
+            <stagingRepositoryId>${stagingRepositoryId}</stagingRepositoryId>
+            <updateReleaseInfo>${updateReleaseInfo}</updateReleaseInfo>
+        </plugin>
+    </ExecutionEvent>
+    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2017-09-01 15:46:49.641">
+        <project baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" version="1.2.6">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </project>
+        <no-execution-found/>
+        <artifact extension="jar" baseVersion="1.2.6" groupId="org.jmxtrans.agent" artifactId="jmxtrans-agent" id="org.jmxtrans.agent:jmxtrans-agent:jar:1.2.6" type="jar" version="1.2.6" snapshot="false">
+            <file>/path/to/jmxtrans-agent/target/checkout/target/jmxtrans-agent-1.2.6.jar</file>
+        </artifact>
+        <attachedArtifacts>
+            <artifact extension="jar" baseVersion="1.2.6" groupId="org.jmxtrans.agent" classifier="sources" artifactId="jmxtrans-agent" id="org.jmxtrans.agent:jmxtrans-agent:java-source:sources:1.2.6" type="java-source" version="1.2.6" snapshot="false">
+                <file>/path/to/jmxtrans-agent/target/checkout/target/jmxtrans-agent-1.2.6-sources.jar</file>
+            </artifact>
+            <artifact extension="jar" baseVersion="1.2.6" groupId="org.jmxtrans.agent" classifier="javadoc" artifactId="jmxtrans-agent" id="org.jmxtrans.agent:jmxtrans-agent:javadoc:javadoc:1.2.6" type="javadoc" version="1.2.6" snapshot="false">
+                <file>/path/to/jmxtrans-agent/target/checkout/target/jmxtrans-agent-1.2.6-javadoc.jar</file>
+            </artifact>
+            <artifact extension="jar.asc" baseVersion="1.2.6" groupId="org.jmxtrans.agent" artifactId="jmxtrans-agent" id="org.jmxtrans.agent:jmxtrans-agent:jar.asc:1.2.6" type="jar.asc" version="1.2.6" snapshot="false">
+                <file>/path/to/jmxtrans-agent/target/checkout/target/jmxtrans-agent-1.2.6.jar.asc</file>
+            </artifact>
+            <artifact extension="pom.asc" baseVersion="1.2.6" groupId="org.jmxtrans.agent" artifactId="jmxtrans-agent" id="org.jmxtrans.agent:jmxtrans-agent:pom.asc:1.2.6" type="pom.asc" version="1.2.6" snapshot="false">
+                <file>/path/to/jmxtrans-agent/target/checkout/target/jmxtrans-agent-1.2.6.pom.asc</file>
+            </artifact>
+            <artifact extension="jar.asc" baseVersion="1.2.6" groupId="org.jmxtrans.agent" classifier="sources" artifactId="jmxtrans-agent" id="org.jmxtrans.agent:jmxtrans-agent:jar.asc:sources:1.2.6" type="jar.asc" version="1.2.6" snapshot="false">
+                <file>/path/to/jmxtrans-agent/target/checkout/target/jmxtrans-agent-1.2.6-sources.jar.asc</file>
+            </artifact>
+            <artifact extension="jar.asc" baseVersion="1.2.6" groupId="org.jmxtrans.agent" classifier="javadoc" artifactId="jmxtrans-agent" id="org.jmxtrans.agent:jmxtrans-agent:jar.asc:javadoc:1.2.6" type="jar.asc" version="1.2.6" snapshot="false">
+                <file>/path/to/jmxtrans-agent/target/checkout/target/jmxtrans-agent-1.2.6-javadoc.jar.asc</file>
+            </artifact>
+        </attachedArtifacts>
+    </ExecutionEvent>
+    <MavenExecutionResult class="org.apache.maven.execution.DefaultMavenExecutionResult" _time="2017-09-01 15:46:49.962">
+        <buildSummary baseDir="/path/to/jmxtrans-agent/target/checkout" file="/path/to/jmxtrans-agent/target/checkout/pom.xml" groupId="org.jmxtrans.agent" name="JMX metrics exporter agent" artifactId="jmxtrans-agent" time="346547" version="1.2.6" class="org.apache.maven.execution.BuildSuccess">
+            <build sourceDirectory="/path/to/jmxtrans-agent/target/checkout/src/main/java" directory="/path/to/jmxtrans-agent/target/checkout/target"/>
+        </buildSummary>
+    </MavenExecutionResult>
+    <!-- 2017-09-01 15:46:49.962 - close:                                       -->
+    <!-- ignored:[org.eclipse.aether.RepositoryEvent,                           -->
+    <!-- org.apache.maven.settings.building.DefaultSettingsBuildingResult],     -->
+    <!-- blackListed: []                                                        -->
+
+</mavenExecution>


### PR DESCRIPTION
[JENKINS-46511](https://issues.jenkins-ci.org/browse/JENKINS-46511) Option to only trigger downstream pipelines when the generated artifact has been "mvn deploy", not "mvn package" or "mvn install"