### PR TITLE
[JENKINS-47069] Add sample maven-bundle-plugin project

### DIFF
--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/multi_module_bundle_project/pom.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/multi_module_bundle_project/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>jenkins.mvn.test.bundle</groupId>
+    <artifactId>bundle-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>${project.artifactId}</name>
+    <description>Test pipeline triggering when dependency is produced with 'bundle' packaging</description>
+
+    <modules>
+      <module>print-api</module>
+      <module>print-impl</module>
+    </modules>
+
+</project>

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/multi_module_bundle_project/print-api/pom.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/multi_module_bundle_project/print-api/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>jenkins.mvn.test.bundle</groupId>
+        <artifactId>bundle-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>print-api</artifactId>
+    <packaging>bundle</packaging>
+    <name>${project.artifactId}</name>
+    <description>An OSGI bundle that defines an API</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>jenkins.mvn.test.bundle.print</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/multi_module_bundle_project/print-api/src/main/java/jenkins/mvn/test/bundle/print/PrintService.java
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/multi_module_bundle_project/print-api/src/main/java/jenkins/mvn/test/bundle/print/PrintService.java
@@ -1,0 +1,7 @@
+package jenkins.mvn.test.bundle.print;
+
+public interface PrintService
+{
+  public void print(String msg);
+
+}

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/multi_module_bundle_project/print-impl/pom.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/multi_module_bundle_project/print-impl/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>jenkins.mvn.test.bundle</groupId>
+        <artifactId>bundle-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>print-impl</artifactId>
+    <name>${project.artifactId}</name>
+    <description>A project that consumes an API jar that happens to be an OSGi bundle</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>print-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/multi_module_bundle_project/print-impl/src/main/java/jenkins/mvn/test/bundle/print/impl/PrintServiceImpl.java
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/multi_module_bundle_project/print-impl/src/main/java/jenkins/mvn/test/bundle/print/impl/PrintServiceImpl.java
@@ -1,0 +1,17 @@
+package jenkins.mvn.test.bundle.print.impl;
+
+import jenkins.mvn.test.bundle.print.PrintService;
+
+public class PrintServiceImpl implements PrintService
+{
+    public void print( String msg )
+    {
+        System.out.println( msg );
+    }
+
+    public static void main( String[] args )
+    {
+        PrintService printer = new PrintServiceImpl();
+        printer.print( "Hello World" );
+    }
+}


### PR DESCRIPTION
A sample project that uses the maven-bundle-plugin to produce
an OSGi bundle.

Modules:
  * print-api - OSGi bundle that exports a package containing an API.
  * print-impl - Non-OSGi project that consumes the OSGi bundle as a
                 plain jar dependency.