### PR TITLE
[JENKINS-47013] Fix XML file format when the file path of the working directory contains "--"

### DIFF
--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
@@ -140,7 +140,6 @@ public class JenkinsMavenEventSpy extends AbstractEventSpy {
         }
 
         reporter.print(element);
-        reporter.print("new File(.): " + new File(".").getCanonicalPath());
     }
 
     @Override


### PR DESCRIPTION
[JENKINS-47013](https://issues.jenkins-ci.org/browse/JENKINS-47013) Fix XML file format when the file path of the working directory contains "--"

Workaround the fact that `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(org.codehaus.plexus.util.xml.XMLWriter, java.lang.String)` doesn't escape the reserved char sequence '`--`'