### PR TITLE
[JENKINS-48362] Support whitespace in Maven installation path

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -559,13 +559,13 @@ class WithMavenStepExecution extends StepExecution {
             String lineSep = "\n";
             script.append("#!/bin/sh -e").append(lineSep);
             script.append("echo ----- withMaven Wrapper script -----").append(lineSep);
-            script.append(mvnExec.getRemote() + " " + mavenConfig + " \"$@\"").append(lineSep);
+            script.append("\"" + mvnExec.getRemote() + "\" " + mavenConfig + " \"$@\"").append(lineSep);
 
         } else { // Windows
             String lineSep = "\r\n";
             script.append("@echo off").append(lineSep);
             script.append("echo ----- withMaven Wrapper script -----").append(lineSep);
-            script.append(mvnExec.getRemote() + " " + mavenConfig + " %*").append(lineSep);
+            script.append("\"" + mvnExec.getRemote() + "\" " + mavenConfig + " %*").append(lineSep);
         }
 
         LOGGER.log(Level.FINER, "Generated Maven wrapper script: \n{0}", script);


### PR DESCRIPTION
[JENKINS-48362](https://issues.jenkins-ci.org/browse/JENKINS-48362) Regression: 3.0.3 no longer support whitespace in Maven installation path