### PR TITLE
[JENKINS-48539] use Maven built-in logging framework (SLF4J) instead …

### DIFF
--- a/maven-spy/pom.xml
+++ b/maven-spy/pom.xml
@@ -91,6 +91,12 @@
             <version>3.0.1</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
@@ -47,6 +47,8 @@ import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.SurefireTestExecuti
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.DevNullMavenEventReporter;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.FileMavenEventReporter;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -75,6 +77,8 @@ public class JenkinsMavenEventSpy extends AbstractEventSpy {
 
     public final static String DISABLE_MAVEN_EVENT_SPY_ENVIRONMENT_VARIABLE_NAME =  "JENKINS_MAVEN_AGENT_DISABLED";
 
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
     private MavenEventReporter reporter;
 
     /*
@@ -93,7 +97,7 @@ public class JenkinsMavenEventSpy extends AbstractEventSpy {
     public JenkinsMavenEventSpy() throws IOException {
         this.disabled = isEventSpyDisabled();
         if (disabled) {
-            System.out.println("[jenkins-maven-event-spy] INFO Jenkins Maven Event Spy is disabled");
+            logger.info("[jenkins-event-spy] Jenkins Maven Event Spy is disabled");
         }
     }
 
@@ -163,9 +167,8 @@ public class JenkinsMavenEventSpy extends AbstractEventSpy {
 
         } catch (Throwable t) {
             blackList.add(event.getClass());
-            System.err.println("[jenkins-maven-event-spy] WARNING Exception processing " + event);
+            logger.warn("[jenkins-event-spy] Exception processing " + event, t);
             reporter.print(getClass().getName() + ": Exception processing " + event);
-            t.printStackTrace();
         }
     }
 

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
@@ -31,6 +31,8 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.RuntimeIOException;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,6 +48,9 @@ import javax.annotation.Nullable;
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
 public abstract class AbstractMavenEventHandler<E> implements MavenEventHandler<E> {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
     protected final MavenEventReporter reporter;
 
     protected AbstractMavenEventHandler(MavenEventReporter reporter) {
@@ -121,8 +126,7 @@ public abstract class AbstractMavenEventHandler<E> implements MavenEventHandler<
                 // TODO see if there is a better way to implement this "workaround"
                 absolutePath = absolutePath.replace(File.separator + ".flattened-pom.xml", File.separator + "pom.xml");
             } else {
-                System.out.println("[jenkins-maven-event-spy] WARNING: unexpected Maven project file name '"
-                        + projectFile.getName() + "', problems may occur");
+                logger.warn("[jenkins-event-spy] Unexpected Maven project file name '" + projectFile.getName() + "', problems may occur");
             }
             projectElt.setAttribute("file", absolutePath);
         }

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/InvokerStartExecutionHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/InvokerStartExecutionHandler.java
@@ -29,6 +29,8 @@ import static org.jenkinsci.plugins.pipeline.maven.eventspy.JenkinsMavenEventSpy
 import org.apache.maven.execution.ExecutionEvent;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,11 +44,13 @@ import javax.annotation.Nullable;
  * the environment.
  * <p>
  * Thus our spy will not run during Invoker integration tests, to avoid recording integration
- * tests artefacts and dependencies.
+ * tests artifacts and dependencies.
  * @author <a href="mailto:benoit.guerin1@free.fr">Benoit Guérin</a>
  *
  */
 public class InvokerStartExecutionHandler extends AbstractExecutionHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     public InvokerStartExecutionHandler(final MavenEventReporter reporter) {
         super(reporter);
@@ -74,8 +78,7 @@ public class InvokerStartExecutionHandler extends AbstractExecutionHandler {
     public boolean _handle(final ExecutionEvent executionEvent) {
         final boolean result = super._handle(executionEvent);
 
-        //TODO move from "system.out.println" to a real logger
-        System.out.println("[jenkins-maven-event-spy] INFO start of goal " + getSupportedPluginGoal() + ", disabling spy in IT tests.");
+        logger.debug("[jenkins-event-spy] Start of goal " + getSupportedPluginGoal() + ", disabling spy in IT tests.");
 
         // First retrieve the "environmentVariables" configuration of the captured Mojo
         Xpp3Dom env = executionEvent.getMojoExecution().getConfiguration().getChild("environmentVariables");

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/reporter/FileMavenEventReporter.java
@@ -30,6 +30,8 @@ import org.codehaus.plexus.util.xml.XmlWriterUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomWriter;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.RuntimeIOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -48,6 +50,9 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class FileMavenEventReporter implements MavenEventReporter {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
     /**
      * report file gets initially created with a "maven-spy-*.log.tmp" file extension and gets renamed "maven-spy-*.log"
      * at the end of the execution
@@ -76,7 +81,7 @@ public class FileMavenEventReporter implements MavenEventReporter {
                 boolean created = reportsFolder.mkdirs();
                 if (!created) {
                     reportsFolder = new File(".");
-                    System.err.println("[jenkins-maven-event-spy] WARNING Failure to create folder '" + reportsFolder.getAbsolutePath() +
+                    logger.warn("[jenkins-event-spy] Failure to create folder '" + reportsFolder.getAbsolutePath() +
                             "', generate report in '" + reportsFolder.getAbsolutePath() + "'");
                 }
             }
@@ -91,7 +96,7 @@ public class FileMavenEventReporter implements MavenEventReporter {
         xmlWriter.addAttribute("_time", new Timestamp(System.currentTimeMillis()).toString());
 
         try {
-            System.out.println("[jenkins-maven-event-spy] INFO generate " + outFile.getCanonicalPath() + " ...");
+            logger.info("[jenkins-event-spy] Generate " + outFile.getCanonicalPath() + " ...");
         } catch (IOException e) {
             throw new RuntimeIOException(e);
         }
@@ -125,12 +130,12 @@ public class FileMavenEventReporter implements MavenEventReporter {
 
             boolean result = outFile.renameTo(finalFile);
             if (result == false) {
-                System.out.println("[jenkins-maven-event-spy] WARNING failure to rename " + outFile + " into " + finalFile);
+                logger.warn("[jenkins-event-spy] Failure to rename " + outFile + " into " + finalFile);
             } else {
                 outFile = finalFile;
             }
             try {
-                System.out.println("[jenkins-maven-event-spy] INFO generated " + outFile.getCanonicalPath());
+                logger.info("[jenkins-event-spy] Generated " + outFile.getCanonicalPath());
             } catch (IOException e) {
                 throw new RuntimeIOException(e);
             }


### PR DESCRIPTION
[JENKINS-48539](https://issues.jenkins-ci.org/browse/JENKINS-48539) use Maven built-in logging framework (SLF4J) instead of `System.out`

![](https://snag.gy/Jsvn9j.jpg)