### PR TITLE
WIP [JENKINS-46785] Strategy to enable / disable publishers in pipelines.

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisher.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisher.java
@@ -1,32 +1,16 @@
 package org.jenkinsci.plugins.pipeline.maven;
 
-import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
-import hudson.model.TaskListener;
-import jenkins.model.Jenkins;
-import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.beanutils.BeanUtilsBean2;
-import org.apache.commons.beanutils.PropertyUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.w3c.dom.Element;
 
-import java.beans.PropertyDescriptor;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -105,125 +89,5 @@ public abstract class MavenPublisher extends AbstractDescribableImpl<MavenPublis
         }
     }
 
-    /**
-     * <p>Build the list of {@link MavenPublisher}s that should be invoked for the build execution of the given {@link TaskListener}
-     * with the desired configuration.
-     * </p>
-     * <p>
-     * The desired configuration is based on:
-     * </p>
-     * <ul>
-     * <li>The default configuration of the publishers</li>
-     * <li>The global configuration of the publishers defined in the "Global Tools Configuration' section</li>
-     * <li>The configuration specified in the {@code withMaven(options=[...])} step</li>
-     * </ul>
-     *
-     * @param configuredPublishers
-     * @param listener
-     */
-    @Nonnull
-    public static List<MavenPublisher> buildPublishersList(@Nonnull List<MavenPublisher> configuredPublishers, @Nonnull TaskListener listener) {
 
-        // configuration passed as parameter of "withMaven(options=[...]){}"
-        // mavenPublisher.descriptor.id -> mavenPublisher
-        Map<String, MavenPublisher> configuredPublishersById = new HashMap<>();
-        for (MavenPublisher mavenPublisher : configuredPublishers) {
-            if (mavenPublisher == null) {
-                // skip null publisher options injected by Jenkins pipeline, probably caused by a missing plugin
-            } else {
-                configuredPublishersById.put(mavenPublisher.getDescriptor().getId(), mavenPublisher);
-            }
-        }
-
-        // configuration defined globally
-        Map<String, MavenPublisher> globallyConfiguredPublishersById = new HashMap<>();
-        GlobalPipelineMavenConfig globalPipelineMavenConfig = GlobalPipelineMavenConfig.get();
-
-        List<MavenPublisher> globallyConfiguredPublishers = globalPipelineMavenConfig == null ? Collections.<MavenPublisher>emptyList() : globalPipelineMavenConfig.getPublisherOptions();
-        if (globallyConfiguredPublishers == null) {
-            globallyConfiguredPublishers = Collections.emptyList();
-        }
-        for (MavenPublisher mavenPublisher : globallyConfiguredPublishers) {
-            globallyConfiguredPublishersById.put(mavenPublisher.getDescriptor().getId(), mavenPublisher);
-        }
-
-
-        // mavenPublisher.descriptor.id -> mavenPublisher
-        Map<String, MavenPublisher> defaultPublishersById = new HashMap<>();
-        DescriptorExtensionList<MavenPublisher, Descriptor<MavenPublisher>> descriptorList = Jenkins.getInstance().getDescriptorList(MavenPublisher.class);
-        for (Descriptor<MavenPublisher> descriptor : descriptorList) {
-            try {
-                defaultPublishersById.put(descriptor.getId(), descriptor.clazz.newInstance());
-            } catch (InstantiationException | IllegalAccessException e) {
-                PrintWriter error = listener.error("[withMaven] Exception instantiation default config for Maven Publisher '" + descriptor.getDisplayName() + "' / " + descriptor.getId() + ": " + e);
-                e.printStackTrace(error);
-                error.close();
-                LOGGER.log(Level.WARNING, "Exception instantiating " + descriptor.clazz + ": " + e, e);
-                e.printStackTrace();
-            }
-        }
-
-
-        if (LOGGER.isLoggable(Level.FINE)) {
-            listener.getLogger().println("[withMaven] Maven Publishers with configuration provided by the pipeline: " + configuredPublishersById.values());
-            listener.getLogger().println("[withMaven] Maven Publishers with configuration defined globally: " + globallyConfiguredPublishersById.values());
-            listener.getLogger().println("[withMaven] Maven Publishers with default configuration: " + defaultPublishersById.values());
-        }
-
-        // TODO FILTER
-        List<MavenPublisher> results = new ArrayList<>();
-        for (Map.Entry<String, MavenPublisher> entry : defaultPublishersById.entrySet()) {
-            String publisherId = entry.getKey();
-            MavenPublisher publisher = buildConfiguredMavenPublisher(
-                    configuredPublishersById.get(publisherId),
-                    globallyConfiguredPublishersById.get(publisherId),
-                    entry.getValue(),
-                    listener);
-            results.add(publisher);
-        }
-        Collections.sort(results);
-        return results;
-    }
-
-    public static MavenPublisher buildConfiguredMavenPublisher(@Nullable MavenPublisher pipelinePublisher, @Nullable MavenPublisher globallyConfiguredPublisher, @Nonnull MavenPublisher defaultPublisher, @Nonnull TaskListener listener) {
-
-        MavenPublisher result;
-        String logMessage;
-
-        if (pipelinePublisher == null && globallyConfiguredPublisher == null) {
-            result = defaultPublisher;
-            logMessage = "default";
-        } else if (pipelinePublisher == null && globallyConfiguredPublisher != null) {
-            result = globallyConfiguredPublisher;
-            logMessage = "globally";
-        } else if (pipelinePublisher != null && globallyConfiguredPublisher == null) {
-            result = pipelinePublisher;
-            logMessage = "pipeline";
-        } else if (pipelinePublisher != null && globallyConfiguredPublisher != null)  {
-            // workaround FindBugs "Bug kind and pattern: NP - NP_NULL_ON_SOME_PATH"
-            // check pipelinePublisher and globallyConfiguredPublisher are non null even if it is useless
-
-            result = pipelinePublisher;
-            logMessage = "pipeline";
-            listener.getLogger().println("[withMaven] WARNING merging publisher configuration defined in the 'Global Tool Configuration' and at the pipeline level is not yet supported." +
-                    " Use pipeline level configuration for '" + result.getDescriptor().getDisplayName() + "'");
-//
-//            PropertyDescriptor[] propertyDescriptors = PropertyUtils.getPropertyDescriptors(defaultPublisher);
-//            for(PropertyDescriptor propertyDescriptor: propertyDescriptors) {
-//                Method readMethod = propertyDescriptor.getReadMethod();
-//                Method writeMethod = propertyDescriptor.getWriteMethod();
-//
-//                Object defaultValue = readMethod.invoke(defaultPublisher);
-//                Object globallyDefinedValue = readMethod.invoke(globallyConfiguredPublisher);
-//                Object pipelineValue = readMethod.invoke(pipelinePublisher);
-//            }
-        } else {
-            throw new IllegalStateException("Should not happen, workaround for Findbugs NP_NULL_ON_SOME_PATH above");
-        }
-
-        if (LOGGER.isLoggable(Level.FINE))
-            listener.getLogger().println("[withMaven] Use " + logMessage + " defined publisher for '" + result.getDescriptor().getDisplayName() + "'");
-        return result;
-
-    }
 }

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherStrategy.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherStrategy.java
@@ -1,0 +1,197 @@
+package org.jenkinsci.plugins.pipeline.maven;
+
+import hudson.DescriptorExtensionList;
+import hudson.model.Descriptor;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+public enum MavenPublisherStrategy {
+
+    IMPLICIT("Implicit") {
+        /**
+         * <p>Build the list of {@link MavenPublisher}s that should be invoked for the build execution of the given {@link TaskListener}
+         * with the desired configuration.
+         * </p>
+         * <p>
+         * The desired configuration is based on:
+         * </p>
+         * <ul>
+         * <li>The default configuration of the publishers</li>
+         * <li>The global configuration of the publishers defined in the "Global Tools Configuration' section</li>
+         * <li>The configuration specified in the {@code withMaven(options=[...])} step</li>
+         * </ul>
+         *  @param configuredPublishers
+         * @param listener
+         */
+        @Nonnull
+        public List<MavenPublisher> buildPublishersList(@Nonnull List<MavenPublisher> configuredPublishers, @Nonnull TaskListener listener) {
+
+            // configuration passed as parameter of "withMaven(options=[...]){}"
+            // mavenPublisher.descriptor.id -> mavenPublisher
+            Map<String, MavenPublisher> configuredPublishersById = new HashMap<>();
+            for (MavenPublisher mavenPublisher : configuredPublishers) {
+                if (mavenPublisher == null) {
+                    // skip null publisher options injected by Jenkins pipeline, probably caused by a missing plugin
+                } else {
+                    configuredPublishersById.put(mavenPublisher.getDescriptor().getId(), mavenPublisher);
+                }
+            }
+
+            // configuration defined globally
+            Map<String, MavenPublisher> globallyConfiguredPublishersById = new HashMap<>();
+            GlobalPipelineMavenConfig globalPipelineMavenConfig = GlobalPipelineMavenConfig.get();
+
+            List<MavenPublisher> globallyConfiguredPublishers = globalPipelineMavenConfig == null ? Collections.<MavenPublisher>emptyList() : globalPipelineMavenConfig.getPublisherOptions();
+            if (globallyConfiguredPublishers == null) {
+                globallyConfiguredPublishers = Collections.emptyList();
+            }
+            for (MavenPublisher mavenPublisher : globallyConfiguredPublishers) {
+                globallyConfiguredPublishersById.put(mavenPublisher.getDescriptor().getId(), mavenPublisher);
+            }
+
+
+            // mavenPublisher.descriptor.id -> mavenPublisher
+            Map<String, MavenPublisher> defaultPublishersById = new HashMap<>();
+            DescriptorExtensionList<MavenPublisher, Descriptor<MavenPublisher>> descriptorList = Jenkins.getInstance().getDescriptorList(MavenPublisher.class);
+            for (Descriptor<MavenPublisher> descriptor : descriptorList) {
+                try {
+                    defaultPublishersById.put(descriptor.getId(), descriptor.clazz.newInstance());
+                } catch (InstantiationException | IllegalAccessException e) {
+                    PrintWriter error = listener.error("[withMaven] Exception instantiation default config for Maven Publisher '" + descriptor.getDisplayName() + "' / " + descriptor.getId() + ": " + e);
+                    e.printStackTrace(error);
+                    error.close();
+                    LOGGER.log(Level.WARNING, "Exception instantiating " + descriptor.clazz + ": " + e, e);
+                    e.printStackTrace();
+                }
+            }
+
+
+            if (LOGGER.isLoggable(Level.FINE)) {
+                listener.getLogger().println("[withMaven] Maven Publishers with configuration provided by the pipeline: " + configuredPublishersById.values());
+                listener.getLogger().println("[withMaven] Maven Publishers with configuration defined globally: " + globallyConfiguredPublishersById.values());
+                listener.getLogger().println("[withMaven] Maven Publishers with default configuration: " + defaultPublishersById.values());
+            }
+
+            // TODO FILTER
+            List<MavenPublisher> results = new ArrayList<>();
+            for (Map.Entry<String, MavenPublisher> entry : defaultPublishersById.entrySet()) {
+                String publisherId = entry.getKey();
+                MavenPublisher publisher = buildConfiguredMavenPublisher(
+                        configuredPublishersById.get(publisherId),
+                        globallyConfiguredPublishersById.get(publisherId),
+                        entry.getValue(),
+                        listener);
+                results.add(publisher);
+            }
+            Collections.sort(results);
+            return results;
+        }
+    },
+
+    EXPLICIT("Explicit") {
+        @Nonnull
+        @Override
+        public List<MavenPublisher> buildPublishersList
+                (@Nonnull List<MavenPublisher> configuredPublishers, @Nonnull TaskListener listener) {
+
+            // filter null entries caused by missing plugins
+            List<MavenPublisher> result = new ArrayList<>();
+            for(MavenPublisher publisher: configuredPublishers) {
+                if (publisher != null) {
+                    result.add(publisher);
+                }
+            }
+
+            if (LOGGER.isLoggable(Level.FINE)) {
+                listener.getLogger().println("[withMaven] Maven Publishers: " + result);
+            }
+            return result;
+        }
+    };
+    final String description;
+
+    MavenPublisherStrategy(String description) {
+        this.description = description;
+    }
+
+    public MavenPublisher buildConfiguredMavenPublisher(@Nullable MavenPublisher pipelinePublisher, @Nullable MavenPublisher globallyConfiguredPublisher, @Nonnull MavenPublisher defaultPublisher, @Nonnull TaskListener listener) {
+
+        MavenPublisher result;
+        String logMessage;
+
+        if (pipelinePublisher == null && globallyConfiguredPublisher == null) {
+            result = defaultPublisher;
+            logMessage = "default";
+        } else if (pipelinePublisher == null && globallyConfiguredPublisher != null) {
+            result = globallyConfiguredPublisher;
+            logMessage = "globally";
+        } else if (pipelinePublisher != null && globallyConfiguredPublisher == null) {
+            result = pipelinePublisher;
+            logMessage = "pipeline";
+        } else if (pipelinePublisher != null && globallyConfiguredPublisher != null)  {
+            // workaround FindBugs "Bug kind and pattern: NP - NP_NULL_ON_SOME_PATH"
+            // check pipelinePublisher and globallyConfiguredPublisher are non null even if it is useless
+
+            result = pipelinePublisher;
+            logMessage = "pipeline";
+            listener.getLogger().println("[withMaven] WARNING merging publisher configuration defined in the 'Global Tool Configuration' and at the pipeline level is not yet supported." +
+                    " Use pipeline level configuration for '" + result.getDescriptor().getDisplayName() + "'");
+//
+//            PropertyDescriptor[] propertyDescriptors = PropertyUtils.getPropertyDescriptors(defaultPublisher);
+//            for(PropertyDescriptor propertyDescriptor: propertyDescriptors) {
+//                Method readMethod = propertyDescriptor.getReadMethod();
+//                Method writeMethod = propertyDescriptor.getWriteMethod();
+//
+//                Object defaultValue = readMethod.invoke(defaultPublisher);
+//                Object globallyDefinedValue = readMethod.invoke(globallyConfiguredPublisher);
+//                Object pipelineValue = readMethod.invoke(pipelinePublisher);
+//            }
+        } else {
+            throw new IllegalStateException("Should not happen, workaround for Findbugs NP_NULL_ON_SOME_PATH above");
+        }
+
+        if (LOGGER.isLoggable(Level.FINE))
+            listener.getLogger().println("[withMaven] Use " + logMessage + " defined publisher for '" + result.getDescriptor().getDisplayName() + "'");
+        return result;
+
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * <p>Build the list of {@link MavenPublisher}s that should be invoked for the build execution of the given {@link TaskListener}
+     * with the desired configuration.
+     * </p>
+     * <p>
+     * The desired configuration is based on:
+     * </p>
+     * <ul>
+     * <li>The default configuration of the publishers</li>
+     * <li>The global configuration of the publishers defined in the "Global Tools Configuration' section</li>
+     * <li>The configuration specified in the {@code withMaven(options=[...])} step</li>
+     * </ul>
+     *  @param configuredPublishers
+     * @param listener
+     */
+    @Nonnull
+    public abstract List<MavenPublisher> buildPublishersList(@Nonnull List<MavenPublisher> configuredPublishers, @Nonnull TaskListener listener);
+
+    private final static Logger LOGGER = Logger.getLogger(MavenPublisherStrategy.class.getName());
+}

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenSpyLogProcessor.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenSpyLogProcessor.java
@@ -58,7 +58,8 @@ public class MavenSpyLogProcessor implements Serializable {
 
     private static final Logger LOGGER = Logger.getLogger(MavenSpyLogProcessor.class.getName());
 
-    public void processMavenSpyLogs(StepContext context, FilePath mavenSpyLogFolder, List<MavenPublisher> options) throws IOException, InterruptedException {
+    public void processMavenSpyLogs(@Nonnull StepContext context, @Nonnull FilePath mavenSpyLogFolder, @Nonnull List<MavenPublisher> options,
+                                    @Nonnull MavenPublisherStrategy publisherStrategy) throws IOException, InterruptedException {
         FilePath[] mavenSpyLogsList = mavenSpyLogFolder.list("maven-spy-*.log");
         LOGGER.log(Level.FINE, "Found {0} maven execution reports in {1}", new Object[]{mavenSpyLogsList.length, mavenSpyLogFolder});
 
@@ -79,7 +80,7 @@ public class MavenSpyLogProcessor implements Serializable {
         for (FilePath mavenSpyLogs : mavenSpyLogsList) {
             try {
                 if (LOGGER.isLoggable(Level.FINE)) {
-                    listener.getLogger().println("[withMaven]  Evaluate Maven Spy logs: " + mavenSpyLogs.getRemote());
+                    listener.getLogger().println("[withMaven] Evaluate Maven Spy logs: " + mavenSpyLogs.getRemote());
                 }
                 InputStream mavenSpyLogsInputStream = mavenSpyLogs.read();
                 if (mavenSpyLogsInputStream == null) {
@@ -94,7 +95,10 @@ public class MavenSpyLogProcessor implements Serializable {
 
                 Element mavenSpyLogsElt = documentBuilder.parse(mavenSpyLogsInputStream).getDocumentElement();
 
-                List<MavenPublisher> mavenPublishers = MavenPublisher.buildPublishersList(options, listener);
+                if (LOGGER.isLoggable(Level.FINE)){
+                    listener.getLogger().println("[withMaven] Maven Publisher Strategy: " + publisherStrategy.getDescription());
+                }
+                List<MavenPublisher> mavenPublishers = publisherStrategy.buildPublishersList(options, listener);
                 for (MavenPublisher mavenPublisher : mavenPublishers) {
                     String skipFileName = mavenPublisher.getDescriptor().getSkipFileName();
                     if (Boolean.TRUE.equals(mavenPublisher.isDisabled())) {

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
@@ -75,6 +75,7 @@ public class WithMavenStep extends Step {
     private String jdk;
     private String mavenLocalRepo = "";
     private List<MavenPublisher> options = new ArrayList<>();
+    private MavenPublisherStrategy publisherStrategy = MavenPublisherStrategy.IMPLICIT;
 
     @DataBoundConstructor
     public WithMavenStep() {
@@ -151,6 +152,15 @@ public class WithMavenStep extends Step {
     @DataBoundSetter
     public void setMavenLocalRepo(String mavenLocalRepo) {
         this.mavenLocalRepo = mavenLocalRepo;
+    }
+
+    public MavenPublisherStrategy getPublisherStrategy() {
+        return publisherStrategy;
+    }
+
+    @DataBoundSetter
+    public void setPublisherStrategy(MavenPublisherStrategy publisherStrategy) {
+        this.publisherStrategy = publisherStrategy;
     }
 
     public List<MavenPublisher> getOptions() {
@@ -251,6 +261,15 @@ public class WithMavenStep extends Step {
             r.add("--- Use system default settings or file path ---",null);
             for (Config config : ConfigFiles.getConfigsInContext(context, GlobalMavenSettingsConfigProvider.class)) {
                 r.add(config.name, config.id);
+            }
+            return r;
+        }
+
+        @Restricted(NoExternalUse.class) // Only for UI calls
+        public ListBoxModel doFillPublisherStrategyItems(@AncestorInPath ItemGroup context) {
+            ListBoxModel r = new ListBoxModel();
+            for(MavenPublisherStrategy publisherStrategy: MavenPublisherStrategy.values()) {
+                r.add(publisherStrategy.getDescription(), publisherStrategy.name());
             }
             return r;
         }

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -216,7 +216,7 @@ class WithMavenStepExecution extends StepExecution {
 
         LOGGER.log(Level.FINEST, "envOverride: {0}", envOverride); // JENKINS-40484
 
-        body = getContext().newBodyInvoker().withContexts(envEx, newFilter).withCallback(new WorkspaceCleanupCallback(tempBinDir, step.getOptions())).start();
+        body = getContext().newBodyInvoker().withContexts(envEx, newFilter).withCallback(new WithMavenStepExecutionCallBack(tempBinDir, step.getOptions(), step.getPublisherStrategy())).start();
 
         return false;
     }
@@ -897,21 +897,25 @@ class WithMavenStepExecution extends StepExecution {
     /**
      * Callback to cleanup tmp script after finishing the job
      */
-    private static class WorkspaceCleanupCallback extends BodyExecutionCallback.TailCall {
+    private static class WithMavenStepExecutionCallBack extends BodyExecutionCallback.TailCall {
         private final FilePath tempBinDir;
+
+        private final MavenPublisherStrategy mavenPublisherStrategy;
 
         private final List<MavenPublisher> options;
 
         private final MavenSpyLogProcessor mavenSpyLogProcessor = new MavenSpyLogProcessor();
 
-        public WorkspaceCleanupCallback(@Nonnull FilePath tempBinDir, @Nonnull List<MavenPublisher> options) {
+        public WithMavenStepExecutionCallBack(@Nonnull FilePath tempBinDir, @Nonnull List<MavenPublisher> options,
+                                              @Nonnull MavenPublisherStrategy mavenPublisherStrategy) {
             this.tempBinDir = tempBinDir;
             this.options = options;
+            this.mavenPublisherStrategy = mavenPublisherStrategy;
         }
 
         @Override
         protected void finished(StepContext context) throws Exception {
-            mavenSpyLogProcessor.processMavenSpyLogs(context, tempBinDir, options);
+            mavenSpyLogProcessor.processMavenSpyLogs(context, tempBinDir, options, mavenPublisherStrategy);
 
             try {
                 tempBinDir.deleteRecursive();

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/config.jelly
@@ -54,6 +54,10 @@ THE SOFTWARE.
         <f:textbox/>
     </f:entry>
 
+    <f:entry title="${%Publisher Strategy}" field="publisherStrategy">
+        <f:select/>
+    </f:entry>
+
     <f:entry title="${%Options}">
         <f:repeatableHeteroProperty field="options" targetType="org.jenkinsci.plugins.pipeline.maven.MavenPublisher"
                                     addCaption="${%Add Option}" hasHeader="true" oneEach="true"/>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-publisherStrategy.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-publisherStrategy.html
@@ -1,0 +1,14 @@
+<div>
+    <table>
+        <tr>
+            <td><code>IMPLICIT</code></td>
+            <td>All Maven publishers are implicitly enabled and used, even if they are not configured in
+                "<code>withMaven(options:...)</code>".</td>
+        </tr>
+        <tr>
+            <td><code>EXPLICIT</code></td>
+            <td>Only the Maven publishers explicitly configured in
+                "<code>withMaven(options:...)</code>" are used.</td>
+        </tr>
+    </table>
+</div>

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherStrategyTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherStrategyTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
-public class MavenPublisherTest {
+public class MavenPublisherStrategyTest {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
@@ -36,7 +36,7 @@ public class MavenPublisherTest {
     public void listMavenPublishers() throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        List<MavenPublisher> mavenPublishers = MavenPublisher.buildPublishersList(Collections.<MavenPublisher>emptyList(), new StreamTaskListener(baos));
+        List<MavenPublisher> mavenPublishers = MavenPublisherStrategy.IMPLICIT.buildPublishersList(Collections.<MavenPublisher>emptyList(), new StreamTaskListener(baos));
         Assert.assertThat(mavenPublishers.size(), CoreMatchers.is(9));
 
         Map<String, MavenPublisher> reportersByDescriptorId = new HashMap<>();


### PR DESCRIPTION
[JENKINS-46785](https://issues.jenkins-ci.org/browse/JENKINS-46785) Strategy to enable / disable publishers in pipelines.

Default strategy, "IMPLICIT" is the current strategy to implicitly enable all publishers unless they are explicitly disabled. The second available strategy, "EXPLICIT", requires to explicitly enable the publishers in the "`withMaven(options: [...])`" attribute

- [x] write implementation
- [ ] write test