### PR TITLE
[JENKINS-48657] restrict the build log messages "Skip 'xxx' disabled by configuration"...

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenSpyLogProcessor.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenSpyLogProcessor.java
@@ -98,9 +98,13 @@ public class MavenSpyLogProcessor implements Serializable {
                 for (MavenPublisher mavenPublisher : mavenPublishers) {
                     String skipFileName = mavenPublisher.getDescriptor().getSkipFileName();
                     if (Boolean.TRUE.equals(mavenPublisher.isDisabled())) {
-                        listener.getLogger().println("[withMaven] Skip '" + mavenPublisher.getDescriptor().getDisplayName() + "' disabled by configuration");
+                        if (LOGGER.isLoggable(Level.FINE)) {
+                            listener.getLogger().println("[withMaven] Skip '" + mavenPublisher.getDescriptor().getDisplayName() + "' disabled by configuration");
+                        }
                     } else if (StringUtils.isNotEmpty(skipFileName) && workspace.child(skipFileName).exists()) {
-                        listener.getLogger().println("[withMaven] Skip '" + mavenPublisher.getDescriptor().getDisplayName() + "' disabled by marker file '" + skipFileName + "'");
+                        if (LOGGER.isLoggable(Level.FINE)) {
+                            listener.getLogger().println("[withMaven] Skip '" + mavenPublisher.getDescriptor().getDisplayName() + "' disabled by marker file '" + skipFileName + "'");
+                        }
                     } else {
                         if (LOGGER.isLoggable(Level.FINE)) {
                             listener.getLogger().println("[withMaven] Run '" + mavenPublisher.getDescriptor().getDisplayName() + "'...");

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepGlobalConfigurationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepGlobalConfigurationTest.java
@@ -24,12 +24,6 @@
 package org.jenkinsci.plugins.pipeline.maven;
 
 import hudson.model.Result;
-import hudson.tasks.Maven;
-import jenkins.mvn.DefaultGlobalSettingsProvider;
-import jenkins.mvn.DefaultSettingsProvider;
-import jenkins.mvn.GlobalMavenConfig;
-import jenkins.plugins.git.GitSampleRepoRule;
-import jenkins.scm.impl.mock.GitSampleRepoRuleUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.maven.publishers.FindbugsAnalysisPublisher;
 import org.jenkinsci.plugins.pipeline.maven.publishers.GeneratedArtifactsPublisher;
@@ -38,19 +32,12 @@ import org.jenkinsci.plugins.pipeline.maven.publishers.TasksScannerPublisher;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
-import org.jvnet.hudson.test.ExtendedToolInstallations;
-import org.jvnet.hudson.test.JenkinsRule;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * TODO migrate to {@link WithMavenStepTest} once we have implemented a GitRepoRule that can be used on remote agents
@@ -85,6 +72,9 @@ public class WithMavenStepGlobalConfigurationTest extends AbstractIntegrationTes
         GlobalPipelineMavenConfig globalPipelineMavenConfig = GlobalPipelineMavenConfig.get();
 
         globalPipelineMavenConfig.setPublisherOptions(Collections.singletonList(publisher));
+        Logger logger = Logger.getLogger(MavenSpyLogProcessor.class.getName());
+        Level level = logger.getLevel();
+        logger.setLevel(Level.FINE);
         try {
 
 
@@ -108,6 +98,7 @@ public class WithMavenStepGlobalConfigurationTest extends AbstractIntegrationTes
             String message = "[withMaven] Skip '" + displayName + "' disabled by configuration";
             jenkinsRule.assertLogContains(message, build);
         } finally {
+            logger.setLevel(level);
             globalPipelineMavenConfig.setPublisherOptions((List<MavenPublisher>) null);
         }
     }
@@ -141,6 +132,9 @@ public class WithMavenStepGlobalConfigurationTest extends AbstractIntegrationTes
         GlobalPipelineMavenConfig globalPipelineMavenConfig = GlobalPipelineMavenConfig.get();
 
         globalPipelineMavenConfig.setPublisherOptions(Collections.singletonList(publisher));
+        Logger logger = Logger.getLogger(MavenSpyLogProcessor.class.getName());
+        Level level = logger.getLevel();
+        logger.setLevel(Level.FINE);
         try {
 
 
@@ -165,6 +159,7 @@ public class WithMavenStepGlobalConfigurationTest extends AbstractIntegrationTes
                     "Use pipeline level configuration for '" + displayName +                     "'", build);
             jenkinsRule.assertLogContains("[withMaven] Skip '" + displayName + "' disabled by configuration", build);
         } finally {
+            logger.setLevel(level);
             globalPipelineMavenConfig.setPublisherOptions((List<MavenPublisher>) null);
         }
     }

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepOnMasterTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepOnMasterTest.java
@@ -68,6 +68,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * TODO migrate to {@link WithMavenStepTest} once we have implemented a GitRepoRule that can be used on remote agents
@@ -251,30 +253,37 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
 
     private void maven_build_jar_project_on_master_with_disabled_publisher_param_succeeds(MavenPublisher.DescriptorImpl descriptor, String symbol, boolean disabled) throws Exception {
 
-        String displayName = descriptor.getDisplayName();
+        Logger logger = Logger.getLogger(MavenSpyLogProcessor.class.getName());
+        Level level = logger.getLevel();
+        logger.setLevel(Level.FINE);
+        try {
+            String displayName = descriptor.getDisplayName();
 
-        Symbol symbolAnnotation = descriptor.getClass().getAnnotation(Symbol.class);
-        String[] symbols = symbolAnnotation.value();
-        assertThat(new String[]{symbol},  is(symbols));
+            Symbol symbolAnnotation = descriptor.getClass().getAnnotation(Symbol.class);
+            String[] symbols = symbolAnnotation.value();
+            assertThat(new String[]{symbol}, is(symbols));
 
-        loadMavenJarProjectInGitRepo(this.gitRepoRule);
+            loadMavenJarProjectInGitRepo(this.gitRepoRule);
 
-        String pipelineScript = "node('master') {\n" +
-                "    git($/" + gitRepoRule.toString() + "/$)\n" +
-                "    withMaven(options:[" + symbol + "(disabled:" + disabled + ")]) {\n" +
-                "        sh 'mvn package verify'\n" +
-                "    }\n" +
-                "}";
+            String pipelineScript = "node('master') {\n" +
+                    "    git($/" + gitRepoRule.toString() + "/$)\n" +
+                    "    withMaven(options:[" + symbol + "(disabled:" + disabled + ")]) {\n" +
+                    "        sh 'mvn package verify'\n" +
+                    "    }\n" +
+                    "}";
 
-        WorkflowJob pipeline = jenkinsRule.createProject(WorkflowJob.class, "build-on-master-" + symbol + "-publisher-disabled-" + disabled);
-        pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
-        WorkflowRun build = jenkinsRule.assertBuildStatus(Result.SUCCESS, pipeline.scheduleBuild2(0));
+            WorkflowJob pipeline = jenkinsRule.createProject(WorkflowJob.class, "build-on-master-" + symbol + "-publisher-disabled-" + disabled);
+            pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+            WorkflowRun build = jenkinsRule.assertBuildStatus(Result.SUCCESS, pipeline.scheduleBuild2(0));
 
-        String message = "[withMaven] Skip '" + displayName + "' disabled by configuration";
-        if (disabled) {
-            jenkinsRule.assertLogContains(message, build);
-        } else {
-            jenkinsRule.assertLogNotContains(message, build);
+            String message = "[withMaven] Skip '" + displayName + "' disabled by configuration";
+            if (disabled) {
+                jenkinsRule.assertLogContains(message, build);
+            } else {
+                jenkinsRule.assertLogNotContains(message, build);
+            }
+        } finally {
+            logger.setLevel(level);
         }
     }
 


### PR DESCRIPTION
[JENKINS-48657](https://issues.jenkins-ci.org/browse/JENKINS-48657) restrict the build log messages "Skip 'xxx' disabled by configuration" and "Skip 'xxx' disabled by marker file ..." to Level.FINE