### PR TITLE
[JENKINS-48678] - Define Maven Settings and Global Maven Settings at the folder level.

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty.java
@@ -1,0 +1,86 @@
+package org.jenkinsci.plugins.pipeline.maven;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.CopyOnWriteList;
+import jenkins.mvn.GlobalMavenConfig;
+import jenkins.mvn.GlobalSettingsProvider;
+import jenkins.mvn.SettingsProvider;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Provides a way to override maven configuration at a folder level
+ */
+public class MavenConfigFolderOverrideProperty extends AbstractFolderProperty<AbstractFolder<?>> {
+
+    /**
+     * Provides access to the settings.xml to be used for a build.
+     */
+    private SettingsProvider settings;
+
+    /**
+     * Provides access to the global settings.xml to be used for a build.
+     */
+    private GlobalSettingsProvider globalSettings;
+
+    /**
+     * Defines if the instance level configuration should be overriden by this folder one
+     */
+    private boolean override;
+
+    /**
+     * Constructor.
+     */
+    @DataBoundConstructor
+    public MavenConfigFolderOverrideProperty() {
+    }
+
+    public boolean isOverride() {
+        return override;
+    }
+
+    @DataBoundSetter
+    public void setOverride(boolean override) {
+        this.override = override;
+    }
+
+    public SettingsProvider getSettings() {
+        return settings;
+    }
+    @DataBoundSetter
+    protected void setSettings(SettingsProvider settings) {
+        this.settings = settings;
+    }
+
+    public GlobalSettingsProvider getGlobalSettings() {
+        return globalSettings;
+    }
+
+    @DataBoundSetter
+    protected void setGlobalSettings(GlobalSettingsProvider globalSettings) {
+        this.globalSettings = globalSettings;
+    }
+
+    /**
+     * Descriptor class.
+     */
+    @Extension
+    public static class DescriptorImpl extends AbstractFolderPropertyDescriptor {
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Override Maven Settings";
+        }
+    }
+}

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty.java
@@ -26,11 +26,13 @@ public class MavenConfigFolderOverrideProperty extends AbstractFolderProperty<Ab
     /**
      * Provides access to the settings.xml to be used for a build.
      */
+    @DataBoundSetter
     private SettingsProvider settings;
 
     /**
      * Provides access to the global settings.xml to be used for a build.
      */
+    @DataBoundSetter
     private GlobalSettingsProvider globalSettings;
 
     /**
@@ -57,7 +59,7 @@ public class MavenConfigFolderOverrideProperty extends AbstractFolderProperty<Ab
     public SettingsProvider getSettings() {
         return settings;
     }
-    @DataBoundSetter
+
     protected void setSettings(SettingsProvider settings) {
         this.settings = settings;
     }
@@ -66,7 +68,7 @@ public class MavenConfigFolderOverrideProperty extends AbstractFolderProperty<Ab
         return globalSettings;
     }
 
-    @DataBoundSetter
+
     protected void setGlobalSettings(GlobalSettingsProvider globalSettings) {
         this.globalSettings = globalSettings;
     }

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -667,7 +667,7 @@ class WithMavenStepExecution extends StepExecution {
         MavenConfigFolderOverrideProperty overrideProperty = getMavenConfigOverrideProperty();
         StringBuilder mavenSettingsLog=new StringBuilder();
 
-        if (overrideProperty != null) {
+        if (overrideProperty != null && overrideProperty.getSettings() != null) {
             // Settings overriden by a folder property
             if(LOGGER.isLoggable(Level.FINE)) {
                 mavenSettingsLog.append("[withMaven] using overriden Maven settings by folder '").append(overrideProperty.getOwner().getDisplayName()).append("'. ");
@@ -789,7 +789,7 @@ class WithMavenStepExecution extends StepExecution {
         MavenConfigFolderOverrideProperty overrideProperty = getMavenConfigOverrideProperty();
 
         StringBuilder mavenSettingsLog = new StringBuilder();
-        if (overrideProperty != null) {
+        if (overrideProperty != null && overrideProperty.getGlobalSettings() != null) {
             // Settings overriden by a folder property
             if (LOGGER.isLoggable(Level.FINE)) {
                 mavenSettingsLog.append("[withMaven] using overriden Maven global settings by folder '").append(overrideProperty.getOwner().getDisplayName()).append("'. ");

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -70,7 +70,6 @@ import hudson.Util;
 import hudson.console.ConsoleLogFilter;
 import hudson.model.BuildListener;
 import hudson.model.Computer;
-import hudson.model.Describable;
 import hudson.model.ItemGroup;
 import hudson.model.JDK;
 import hudson.model.Job;

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -636,7 +636,7 @@ class WithMavenStepExecution extends StepExecution {
         // Settings from Config File Provider
         if (StringUtils.isNotEmpty(step.getMavenSettingsConfig())) {
             if (LOGGER.isLoggable(Level.FINE)) {
-                console.format("[withMaven] use Maven settings provided by the Jenkins Managed Configuration File '%s' %n", step.getMavenSettingsConfig());
+                console.format("[withMaven] using Maven settings provided by the Jenkins Managed Configuration File '%s' %n", step.getMavenSettingsConfig());
             }
             settingsFromConfig(step.getMavenSettingsConfig(), settingsDest, credentials);
             envOverride.put("MVN_SETTINGS", settingsDest.getRemote());
@@ -651,7 +651,7 @@ class WithMavenStepExecution extends StepExecution {
             if ((settings = ws.child(settingsPath)).exists()) {
                 // settings file residing on the agent
                 if (LOGGER.isLoggable(Level.FINE)) {
-                    console.format("[withMaven] use Maven settings provided on the build agent '%s' %n", settingsPath);
+                    console.format("[withMaven] using Maven settings provided on the build agent '%s' %n", settingsPath);
                     LOGGER.log(Level.FINE, "Copying maven settings file from build agent {0} to {1}", new Object[] { settings, settingsDest });
                 }
                 settings.copyTo(settingsDest);
@@ -759,7 +759,7 @@ class WithMavenStepExecution extends StepExecution {
         // Global settings from Config File Provider
         if (StringUtils.isNotEmpty(step.getGlobalMavenSettingsConfig())) {
             if (LOGGER.isLoggable(Level.FINE)) {
-                console.format("[withMaven] use Maven global settings provided by the Jenkins Managed Configuration File '%s' %n", step.getGlobalMavenSettingsConfig());
+                console.format("[withMaven] using Maven global settings provided by the Jenkins Managed Configuration File '%s' %n", step.getGlobalMavenSettingsConfig());
             }
             globalSettingsFromConfig(step.getGlobalMavenSettingsConfig(), settingsDest, credentials);
             envOverride.put("GLOBAL_MVN_SETTINGS", settingsDest.getRemote());
@@ -773,7 +773,7 @@ class WithMavenStepExecution extends StepExecution {
             if ((settings = ws.child(settingsPath)).exists()) {
                 // Global settings file residing on the agent
                 if (LOGGER.isLoggable(Level.FINE)) {
-                    console.format("[withMaven] use Maven global settings provided on the build agent '%s' %n", settingsPath);
+                    console.format("[withMaven] using Maven global settings provided on the build agent '%s' %n", settingsPath);
                     LOGGER.log(Level.FINE, "Copying maven global settings file from build agent {0} to {1}", new Object[] { settings, settingsDest });
                 }
                 settings.copyTo(settingsDest);
@@ -892,13 +892,13 @@ class WithMavenStepExecution extends StepExecution {
             if (resolvedCredentials.isEmpty()) {
                 mavenSettingsFileContent = mavenSettingsConfig.content;
                 if (LOGGER.isLoggable(Level.FINE)) {
-                    console.println("[withMaven] use Maven settings.xml '" + mavenSettingsConfig.id + "' with NO Maven servers credentials provided by Jenkins");
+                    console.println("[withMaven] using Maven settings.xml '" + mavenSettingsConfig.id + "' with NO Maven servers credentials provided by Jenkins");
                 }
             } else {
                 List<String> tempFiles = new ArrayList<String>();
                 mavenSettingsFileContent = CredentialsHelper.fillAuthentication(mavenSettingsConfig.content, mavenSettingsConfig.isReplaceAll, resolvedCredentials, tempBinDir, tempFiles);
                 if (LOGGER.isLoggable(Level.FINE)) {
-                    console.println("[withMaven] use Maven settings.xml '" + mavenSettingsConfig.id + "' with Maven servers credentials provided by Jenkins " +
+                    console.println("[withMaven] using Maven settings.xml '" + mavenSettingsConfig.id + "' with Maven servers credentials provided by Jenkins " +
                             "(replaceAll: " + mavenSettingsConfig.isReplaceAll + "): " +
                             Joiner.on(", ").skipNulls().join(Iterables.transform(resolvedCredentials.entrySet(), new MavenServerToCredentialsMappingToStringFunction())));
                 }
@@ -949,12 +949,12 @@ class WithMavenStepExecution extends StepExecution {
             String mavenGlobalSettingsFileContent;
             if (resolvedCredentials.isEmpty()) {
                 mavenGlobalSettingsFileContent = mavenGlobalSettingsConfig.content;
-                console.println("[withMaven] use Maven global settings.xml '" + mavenGlobalSettingsConfig.id + "' with NO Maven servers credentials provided by Jenkins");
+                console.println("[withMaven] using Maven global settings.xml '" + mavenGlobalSettingsConfig.id + "' with NO Maven servers credentials provided by Jenkins");
 
             } else {
                 List<String> tempFiles = new ArrayList<String>();
                 mavenGlobalSettingsFileContent = CredentialsHelper.fillAuthentication(mavenGlobalSettingsConfig.content, mavenGlobalSettingsConfig.isReplaceAll, resolvedCredentials, tempBinDir, tempFiles);
-                console.println("[withMaven] use Maven global settings.xml '" + mavenGlobalSettingsConfig.id + "' with Maven servers credentials provided by Jenkins " +
+                console.println("[withMaven] using Maven global settings.xml '" + mavenGlobalSettingsConfig.id + "' with Maven servers credentials provided by Jenkins " +
                         "(replaceAll: " + mavenGlobalSettingsConfig.isReplaceAll + "): " +
                         Joiner.on(", ").skipNulls().join(Iterables.transform(resolvedCredentials.entrySet(), new MavenServerToCredentialsMappingToStringFunction())));
 

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty/config.jelly
@@ -1,0 +1,31 @@
+<!--
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<f:section title="${%Pipeline Maven Configuration}">
+      <f:optionalBlock title="${%Override global maven configuration}" field="override" inline="true">
+        <f:dropdownDescriptorSelector title="${%Settings file}"  field="settings" default="${null}"/>
+        <f:dropdownDescriptorSelector title="${%Global Settings file}" field="globalSettings"  default="${null}"/>
+        </f:optionalBlock>
+    </f:section>
+</j:jelly>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty/help-Settings.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty/help-Settings.html
@@ -1,0 +1,11 @@
+<div>
+  Select a maven settings element from the available providers.
+
+  The settings element in the <code>settings.xml</code> file contains elements used
+  to define values which configure Maven execution in various ways, like the <code>pom.xml</code>,
+  but should not be bundled to any specific project, or distributed to an audience.
+  These include values such as the local repository location, alternate remote repository servers,
+  and authentication information.
+  <p>
+  see also: <a href="http://maven.apache.org/settings.html"><code>settings.xml</code> reference</a>
+</div>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty/help-globalSettings.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty/help-globalSettings.html
@@ -1,0 +1,11 @@
+<div>
+  Select a global maven settings element from the available providers.
+
+  The settings element in the <code>settings.xml</code> file contains elements used
+  to define values which configure Maven execution in various ways, like the <code>pom.xml</code>,
+  but should not be bundled to any specific project, or distributed to an audience.
+  These include values such as the local repository location, alternate remote repository servers,
+  and authentication information.
+  <p>
+  see also: <a href="http://maven.apache.org/settings.html"><code>settings.xml</code> reference</a>
+</div>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-48678

- This change allows define Maven Settings and Maven Global Settings at a folder level
- Logs for these settings have been refactored so only one line is printed per settings file and only if log level is set to `Level.FINE`. Examples:
```
[withMaven] using Maven settings provided by the Jenkins global configuration. Maven settings on the build agent'/Users/alobato/.m2/settings.xml'
[withMaven] using Maven global settings provided by the Jenkins global configuration. Maven global settings on the build agent '/Users/alobato/.m2/settings.xml'
[withMaven] using overriden Maven settings by folder 'folder'. Config File Provider maven settings file 'FolderSettings'
[withMaven] using overriden Maven global settings by folder 'folder'. Config File Provider maven global settings file 'FolderGlobal'
```
- [x] Write tests for the new feature

<img width="836" alt="screen shot 2018-01-15 at 13 10 57" src="https://user-images.githubusercontent.com/17157380/34941835-b494f7b8-f9f5-11e7-85b7-d9c2d58d4ad2.png">


@reviewbybees
@cloubees/astro