### PR TITLE
[JENKINS-49334] MavenLinkerPublisher option

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher.java
@@ -1,0 +1,182 @@
+package org.jenkinsci.plugins.pipeline.maven.publishers;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.pipeline.maven.MavenPublisher;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Run;
+import jenkins.tasks.SimpleBuildStep.LastBuildAction;
+
+public class MavenLinkerPublisher extends MavenPublisher implements LastBuildAction {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = Logger.getLogger(MavenLinkerPublisher.class.getName());
+    private transient List<Artifact> artifacts = new ArrayList<>();
+
+    @DataBoundConstructor
+    public MavenLinkerPublisher() {
+        // default DataBoundConstructor
+    }
+
+    @Override
+    public void process(StepContext context, Element mavenSpyLogsElt) throws IOException, InterruptedException {
+
+        Run<?, ?> run = context.get(Run.class);
+
+        for (Element repositoryEvent : getArtifactDeployedEvents(mavenSpyLogsElt)) {
+            Artifact artifact = getArtifact(repositoryEvent);
+            artifacts.add(artifact);
+        }
+
+        run.addAction(this);
+    }
+
+    @Nonnull
+    static List<Element> getArtifactDeployedEvents(@Nonnull Element mavenSpyLogs) {
+        List<Element> elements = new ArrayList<>();
+
+        NodeList nodes = mavenSpyLogs.getChildNodes();
+
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (node instanceof Element) {
+                Element element = (Element) node;
+                if (StringUtils.equals(element.getNodeName(), "RepositoryEvent")) {
+                    Attr type = element.getAttributeNode("type");
+                    if (null != type && StringUtils.equals(type.getValue(), "ARTIFACT_DEPLOYED")) {
+                        elements.add(element);
+                    }
+                }
+            }
+        }
+
+        LOGGER.log(Level.FINE, "Found {0} deployed elements", elements.size());
+        return elements;
+    }
+
+    static Artifact getArtifact(@Nonnull Element repositoryEvent) {
+
+        Artifact artifact = null;
+        String groupId = null;
+        String artifactId = null;
+        String baseVersion = null;
+        String version = null;
+        String classifier = null;
+        String type = null;
+        String url = null;
+
+        NodeList nodes = repositoryEvent.getChildNodes();
+
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (node instanceof Element) {
+                Element element = (Element) node;
+                if (StringUtils.equals(element.getNodeName(), "artifact")) {
+                    groupId = element.getAttribute("groupId");
+                    artifactId = element.getAttribute("artifactId");
+                    baseVersion = element.getAttribute("baseVersion");
+                    version = element.getAttribute("version");
+                    classifier = element.getAttribute("classifier");
+                    type = element.getAttribute("type");
+                }
+                if (StringUtils.equals(element.getNodeName(), "repository")) {
+                    url = element.getAttribute("url");
+                    url += "/" + groupId.replace('.', '/') + "/" + artifactId + "/" + baseVersion + "/" + artifactId
+                            + "-" + version;
+                    if (!StringUtils.isBlank(classifier)) {
+                        url += "-" + classifier;
+                    }
+                    url += "." + type;
+                    artifact = new Artifact(getNameFromUrl(url), url);
+                }
+            }
+        }
+
+        return artifact;
+    }
+
+    static String getNameFromUrl(@Nonnull String url) {
+        return url.substring(url.lastIndexOf('/') + 1, url.length());
+    }
+
+    public List<Artifact> getArtifacts() {
+        LOGGER.log(Level.FINE, "displaying {0} artifacts", artifacts.size());
+        return artifacts;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Maven Linker Action";
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends Action> getProjectActions() {
+        return new ArrayList<>();
+    }
+
+    private void readObject(ObjectInputStream stream) throws ClassNotFoundException, IOException {
+        stream.defaultReadObject();
+        artifacts = new ArrayList<>();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends MavenPublisher.DescriptorImpl {
+
+        @Override
+        public String getSkipFileName() {
+            return ".skip-maven-linker-publisher";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Maven Linker Publisher";
+        }
+    }
+
+    public static class Artifact {
+
+        String name;
+        String url;
+
+        public Artifact(String name, String url) {
+            super();
+            this.name = name;
+            this.url = url;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+    }
+}

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher/config.jelly
@@ -1,0 +1,31 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe, Tom Huybrechts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+    <st:include page="maven-publisher" class="${descriptor.clazz}"/>
+
+</j:jelly>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher/help-disabled.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher/help-disabled.html
@@ -1,0 +1,3 @@
+<div>
+    Skip generating and publishing the links.
+</div>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher/help.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher/help.html
@@ -1,0 +1,3 @@
+<div>
+    This publisher generates and publishes the links (url) of deployed Maven artifacts.<br/>
+</div>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher/summary.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher/summary.jelly
@@ -1,0 +1,10 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <t:summary icon="package.gif"><b>Deployed Artifacts:</b>
+    <ul>
+      <j:forEach var="artifact" items="${it.artifacts}">
+        <li><a href="${artifact.url}">${artifact.name}</a></li>
+    </j:forEach>
+    </ul>
+  </t:summary>
+</j:jelly>

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherTest.java
@@ -11,6 +11,7 @@ import org.jenkinsci.plugins.pipeline.maven.publishers.GeneratedArtifactsPublish
 import org.jenkinsci.plugins.pipeline.maven.publishers.InvokerRunsPublisher;
 import org.jenkinsci.plugins.pipeline.maven.publishers.JGivenTestsPublisher;
 import org.jenkinsci.plugins.pipeline.maven.publishers.JunitTestsPublisher;
+import org.jenkinsci.plugins.pipeline.maven.publishers.MavenLinkerPublisher;
 import org.jenkinsci.plugins.pipeline.maven.publishers.PipelineGraphPublisher;
 import org.jenkinsci.plugins.pipeline.maven.publishers.TasksScannerPublisher;
 import org.junit.Assert;
@@ -37,7 +38,7 @@ public class MavenPublisherTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         List<MavenPublisher> mavenPublishers = MavenPublisher.buildPublishersList(Collections.<MavenPublisher>emptyList(), new StreamTaskListener(baos));
-        Assert.assertThat(mavenPublishers.size(), CoreMatchers.is(9));
+        Assert.assertThat(mavenPublishers.size(), CoreMatchers.is(10));
 
         Map<String, MavenPublisher> reportersByDescriptorId = new HashMap<>();
         for(MavenPublisher mavenPublisher : mavenPublishers) {
@@ -51,5 +52,6 @@ public class MavenPublisherTest {
         assertThat(reportersByDescriptorId.containsKey(new InvokerRunsPublisher.DescriptorImpl().getId()), is(true));
         assertThat(reportersByDescriptorId.containsKey(new ConcordionTestsPublisher.DescriptorImpl().getId()), is(true));
         assertThat(reportersByDescriptorId.containsKey(new JGivenTestsPublisher.DescriptorImpl().getId()), is(true));
+        assertThat(reportersByDescriptorId.containsKey(new MavenLinkerPublisher.DescriptorImpl().getId()), is(true));
     }
 }

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.pipeline.maven.eventspy;
 import org.apache.maven.eventspy.AbstractEventSpy;
 import org.apache.maven.eventspy.EventSpy;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.ArtifactDeployedEventHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.CatchAllExecutionHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.DefaultSettingsBuildingRequestHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.DependencyResolutionRequestHandler;
@@ -88,7 +89,7 @@ public class JenkinsMavenEventSpy extends AbstractEventSpy {
 
     private Set<Class> blackList = new HashSet();
     private Set<String> ignoredList = new HashSet(Arrays.asList(
-            "org.eclipse.aether.RepositoryEvent",
+            /*"org.eclipse.aether.RepositoryEvent",*/
             "org.apache.maven.settings.building.DefaultSettingsBuildingResult"/*,
             "org.apache.maven.execution.DefaultMavenExecutionResult"*/));
 
@@ -132,6 +133,7 @@ public class JenkinsMavenEventSpy extends AbstractEventSpy {
         handlers.add(new MavenExecutionResultHandler(reporter));
         handlers.add(new SessionEndedHandler(reporter));
         handlers.add(new DeployDeployExecutionHandler(reporter));
+        handlers.add(new ArtifactDeployedEventHandler(reporter));
 
         handlers.add(new CatchAllExecutionHandler(reporter));
 

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/ArtifactDeployedEventHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/ArtifactDeployedEventHandler.java
@@ -1,0 +1,79 @@
+package org.jenkinsci.plugins.pipeline.maven.eventspy.handler;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.aether.RepositoryEvent;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
+
+public class ArtifactDeployedEventHandler implements MavenEventHandler {
+
+    protected final MavenEventReporter reporter;
+
+    public ArtifactDeployedEventHandler(MavenEventReporter reporter) {
+        this.reporter = reporter;
+    }
+
+    @Override
+    public boolean handle(Object event) {
+
+        if (event instanceof RepositoryEvent) {
+            RepositoryEvent repositoryEvent = (RepositoryEvent) event;
+
+            if (repositoryEvent.getType() == RepositoryEvent.EventType.ARTIFACT_DEPLOYED) {
+                reporter.print(newElement(repositoryEvent));
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected Xpp3Dom newElement(@Nullable org.eclipse.aether.RepositoryEvent event) {
+        Xpp3Dom element = new Xpp3Dom("RepositoryEvent");
+        if (event == null) {
+            return element;
+        }
+
+        element.setAttribute("class", event.getClass().getName());
+        element.setAttribute("type", event.getType().toString());
+        element.addChild(newElement("artifact", event.getArtifact()));
+        element.addChild(newElement("repository", event.getRepository()));
+
+        return element;
+    }
+
+    protected Xpp3Dom newElement(String name, @Nullable org.eclipse.aether.repository.ArtifactRepository repository) {
+        Xpp3Dom element = new Xpp3Dom(name);
+        if (repository == null) {
+            return element;
+        }
+
+        element.setAttribute("id", repository.getId());
+        element.setAttribute("layout", repository.getContentType());
+        element.setAttribute("url", StringUtils.substringBetween(repository.toString(), "(", ","));
+
+        return element;
+    }
+
+    protected Xpp3Dom newElement(@Nonnull String name, @Nullable org.eclipse.aether.artifact.Artifact artifact) {
+        Xpp3Dom element = new Xpp3Dom(name);
+        if (artifact == null) {
+            return element;
+        }
+
+        element.setAttribute("id", artifact.toString());
+        element.setAttribute("groupId", artifact.getGroupId());
+        element.setAttribute("artifactId", artifact.getArtifactId());
+        element.setAttribute("baseVersion", artifact.getBaseVersion());
+        element.setAttribute("version", artifact.getVersion());
+        element.setAttribute("classifier", artifact.getClassifier());
+        element.setAttribute("type", artifact.getExtension());
+        element.setAttribute("snapshot", String.valueOf(artifact.isSnapshot()));
+        element.setAttribute("file", artifact.getFile().getAbsolutePath());
+
+        return element;
+    }
+}


### PR DESCRIPTION
[JENKINS-49334](https://issues.jenkins-ci.org/browse/JENKINS-49334) MavenLinkerPublisher option

**MavenLinkerPublisher** is an optional publisher to **withMaven()** to publish links of deployed artifacts.

Unlike **GeneratedArtifactsPublisher**, **MavenLinkerPublisher** does not archive artifacts on master; simply track the deployed artifacts and display the url.

![screen shot 2018-02-01 at 9 39 47 pm](https://user-images.githubusercontent.com/4955591/35719247-539e926a-079d-11e8-8df3-917576f4df1f.png)


 