### PR TITLE
WorkflowJobDependencyTrigger is not only applicable to Job so its signature was wrong

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/trigger/WorkflowJobDependencyTrigger.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/trigger/WorkflowJobDependencyTrigger.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.pipeline.maven.trigger;
 
 import hudson.Extension;
 import hudson.model.Item;
-import hudson.model.Job;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import jenkins.branch.MultiBranchProject;
@@ -15,7 +14,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
-public class WorkflowJobDependencyTrigger extends Trigger<Job<?, ?>> {
+public class WorkflowJobDependencyTrigger extends Trigger<Item> {
 
     @DataBoundConstructor
     public WorkflowJobDependencyTrigger(){


### PR DESCRIPTION
[This](https://github.com/jenkinsci/pipeline-maven-plugin/blob/b06db243e39c890fedb41dede8c6ef093978390e/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/trigger/WorkflowJobDependencyTrigger.java#L28-L31) and [this](https://github.com/jenkinsci/pipeline-maven-plugin/blob/b06db243e39c890fedb41dede8c6ef093978390e/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListener.java#L143-L163) indicate that the generic type was incorrect.

@reviewbybees