### PR TITLE
[JENKINS-49549] Only display once the "Deployed Artifacts" report if …

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher2.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/MavenLinkerPublisher2.java
@@ -38,7 +38,12 @@ public class MavenLinkerPublisher2 extends MavenPublisher {
     @Override
     public void process(StepContext context, Element mavenSpyLogsElt) throws IOException, InterruptedException {
         Run<?, ?> run = context.get(Run.class);
-        run.addAction(new MavenReport(run));
+        MavenReport mavenReport = run.getAction(MavenReport.class);
+        if (mavenReport == null) {
+            run.addAction(new MavenReport(run));
+        } else {
+            // nothing to do, MavenReport action is already registered
+        }
     }
 
     @Extension


### PR DESCRIPTION
[JENKINS-49549](https://issues.jenkins-ci.org/browse/JENKINS-49549) Only display once the "Deployed Artifacts" report if withMaven is invoked 2+ times in a pipeline