### PR TITLE
[INFRA-1310] Reverting obsolete exclusion

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -168,12 +168,6 @@
       <version>1.4.2</version>
       <scope>compile</scope>
       <optional>true</optional>
-      <exclusions>
-        <exclusion> <!-- TODO pending https://github.com/jenkinsci/junit-attachments-plugin/pull/18 -->
-          <groupId>org.kohsuke.stapler</groupId>
-          <artifactId>stapler</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Can revert #85 as it is unnecessary as of a change made in #82, though https://github.com/jenkinsci/junit-attachments-plugin/pull/18 has also been released as 1.5 if you want it.

@reviewbybees