### PR TITLE
Detect builds running in kubernetes containers

### DIFF
--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-jdk.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-jdk.html
@@ -1,5 +1,5 @@
 <div>
     Select a JDK installation. If auto-install is disabled, the JDK will be downloaded and made available for the pipeline job.
     <p>
-    <strong>Note</strong>: This option does not work with <tt>docker.image('xxx').inside</tt>, the preinstalled JDK on the docker image will be used.
+    <strong>Note</strong>: This option does not work with <tt>docker.image('xxx').inside</tt> or <tt>container('xxx')</tt>, the preinstalled JDK on the docker image will be used.
 </div>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-maven.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-maven.html
@@ -1,5 +1,5 @@
 <div>
     Select a Maven installation. If auto-install is disabled, maven will be downloaded and made available for the pipeline job.
     <p>
-    <strong>Note</strong>: This option does not work with <tt>docker.image('xxx').inside</tt>,  the preinstalled maven on the docker image will be used.
+    <strong>Note</strong>: This option does not work with <tt>docker.image('xxx').inside</tt> or <tt>container('xxx')</tt>,  the preinstalled maven on the docker image will be used.
 </div>


### PR DESCRIPTION
Extend `detectWithContainer` to support builds running in kubernetes pods provided by the jenkins-kubernetes plugin