### PR TITLE
[JENKINS-50508] extract dependencies to the "Static Code Analysis Plug-ins"

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/AbstractHealthAwarePublisher.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/AbstractHealthAwarePublisher.java
@@ -63,10 +63,15 @@ public abstract class AbstractHealthAwarePublisher extends MavenPublisher {
         this.thresholdLimit = thresholdLimit;
     }
 
-    protected void setHealthAwarePublisherAttributes(HealthAwarePublisher healthAwarePublisher) {
-        healthAwarePublisher.setHealthy(this.healthy);
-        healthAwarePublisher.setUnHealthy(this.unHealthy);
-        healthAwarePublisher.setThresholdLimit(this.thresholdLimit);
+    /**
+     * WARNING due to <a href="https://issues.jenkins-ci.org/browse/JENKINS-50508">JENKINS-50508</a>, the MUST be NO reference to
+     * any class of the and of the <a href="https://wiki.jenkins.io/display/JENKINS/Static+Code+Analysis+Plug-ins">Static Code Analysis Plug-ins</a>
+     * and to its package "{@code hudson.plugins.analysis.core}".
+     *
+     * @param healthAwarePublisher typed as an @{code Object} instead of being typed as a {@code hudson.plugins.analysis.core.HealthAwarePublisher} due to JENKINS-50508
+     */
+    protected void setHealthAwarePublisherAttributes(Object healthAwarePublisher) {
+        Helper.setHealthAwarePublisherAttributes(healthAwarePublisher, this);
     }
 
     /**
@@ -77,4 +82,17 @@ public abstract class AbstractHealthAwarePublisher extends MavenPublisher {
     }
 
 
+    /**
+     * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+     */
+    static class Helper {
+        protected static void setHealthAwarePublisherAttributes(Object healthAwarePublisherAsObject, AbstractHealthAwarePublisher abstractHealthAwarePublisher) {
+            if (healthAwarePublisherAsObject instanceof HealthAwarePublisher) {
+                HealthAwarePublisher healthAwarePublisher = (HealthAwarePublisher) healthAwarePublisherAsObject;
+                healthAwarePublisher.setHealthy(abstractHealthAwarePublisher.getHealthy());
+                healthAwarePublisher.setUnHealthy(abstractHealthAwarePublisher.getUnHealthy());
+                healthAwarePublisher.setThresholdLimit(abstractHealthAwarePublisher.getThresholdLimit());
+            }
+        }
+    }
 }

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/FindbugsAnalysisPublisher.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/FindbugsAnalysisPublisher.java
@@ -33,7 +33,6 @@ import hudson.model.TaskListener;
 import hudson.plugins.findbugs.FindBugsPublisher;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.maven.MavenArtifact;
-import org.jenkinsci.plugins.pipeline.maven.MavenPublisher;
 import org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor;
 import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/TasksScannerPublisher.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/TasksScannerPublisher.java
@@ -6,13 +6,9 @@ import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
-import hudson.plugins.tasks.TasksPublisher;
-import hudson.plugins.tasks.TasksResultAction;
-
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.maven.MavenArtifact;
-import org.jenkinsci.plugins.pipeline.maven.MavenPublisher;
 import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -41,32 +37,32 @@ public class TasksScannerPublisher extends AbstractHealthAwarePublisher {
     /**
      * Coma separated high priority task identifiers
      *
-     * @see TasksPublisher#getHigh()
+     * @see hudson.plugins.tasks.TasksPublisher#getHigh()
      */
     private String highPriorityTaskIdentifiers = "";
     /**
-     * @see TasksPublisher#getNormal()
+     * @see hudson.plugins.tasks.TasksPublisher#getNormal()
      */
     private String normalPriorityTaskIdentifiers = "";
     /**
-     * @see TasksPublisher#getLow()
+     * @see hudson.plugins.tasks.TasksPublisher#getLow()
      */
     private String lowPriorityTaskIdentifiers = "";
     /**
-     * @see TasksPublisher#getIgnoreCase()
+     * @see hudson.plugins.tasks.TasksPublisher#getIgnoreCase()
      */
     private boolean ignoreCase = false;
     /**
-     * @see TasksPublisher#getPattern()
+     * @see hudson.plugins.tasks.TasksPublisher#getPattern()
      */
     private String pattern = "";
     /**
-     * @see TasksPublisher#getExcludePattern()
+     * @see hudson.plugins.tasks.TasksPublisher#getExcludePattern()
      */
     private String excludePattern = "";
 
     /**
-     * @see TasksPublisher#getAsRegexp()
+     * @see hudson.plugins.tasks.TasksPublisher#getAsRegexp()
      */
     private boolean asRegexp = false;
 
@@ -153,12 +149,12 @@ public class TasksScannerPublisher extends AbstractHealthAwarePublisher {
         }
 
         // To avoid duplicates
-        TasksResultAction tasksResult = run.getAction(TasksResultAction.class);
+        hudson.plugins.tasks.TasksResultAction tasksResult = run.getAction(hudson.plugins.tasks.TasksResultAction.class);
         if (tasksResult != null) {
             run.removeAction(tasksResult);
         }
 
-        TasksPublisher tasksPublisher = new TasksPublisher();
+        hudson.plugins.tasks.TasksPublisher tasksPublisher = new hudson.plugins.tasks.TasksPublisher();
         String pattern = StringUtils.isEmpty(this.pattern)? XmlUtils.join(sourceDirectoriesPatterns, ",") : this.pattern;
         tasksPublisher.setPattern(pattern);
         tasksPublisher.setExcludePattern(StringUtils.trimToNull(this.excludePattern));


### PR DESCRIPTION
[JENKINS-50508] extract dependencies to the "Static Code Analysis Plug-ins", to the package `hudson.plugins.analysis.core` or other plugins outside of `org.jenkinsci.plugins.pipeline.maven.MavenPublisher` sub classes to prevent class loading issues and NPE when the related plugins are not installed.