### PR TITLE
JENKINS-51073 Quick fix for quote problems

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -342,7 +342,7 @@ class WithMavenStepExecution extends StepExecution {
             mavenConfig.append("--global-settings \"" + globalSettingsFilePath + "\" ");
         }
         if (StringUtils.isNotEmpty(mavenLocalRepo)) {
-            mavenConfig.append("-Dmaven.repo.local=\"" + mavenLocalRepo + "\" ");
+            mavenConfig.append("\"-Dmaven.repo.local=" + mavenLocalRepo + "\" ");
         }
 
         envOverride.put("MAVEN_CONFIG", mavenConfig.toString());


### PR DESCRIPTION
by surrounding the whole -D statement with quotes (`"-Dmaven.repo.local=/bla/blub"` instead of `-Dmaven.repo.local="/bla/blub"`), the local repo works with maven wrapper as well as with standalone maven.