### PR TITLE
[JENKINS-51224] make workflow-job a required dependency

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -104,7 +104,6 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
       <version>2.11.1</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
[JENKINS-51224] make workflow-job a required dependency, otherwise DownstreamPipelineTriggerRunListener causes an exception