### PR TITLE
Exclude flattened POMs from being replaced by the original POM in Maven Event Spy.

### DIFF
--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
@@ -115,16 +115,14 @@ public abstract class AbstractMavenEventHandler<E> implements MavenEventHandler<
             } catch (IOException e) {
                 throw new RuntimeIOException(e);
             }
-            if (absolutePath.endsWith(File.separator + "pom.xml")) {
+
+            if (absolutePath.endsWith(File.separator + "pom.xml") || absolutePath.endsWith(File.separator + ".flattened-pom.xml")) {
+                // JENKINS-43616: flatten-maven-plugin replaces the original pom as artifact with a .flattened-pom.xml
                 // no tweak
             } else if (absolutePath.endsWith(File.separator + "dependency-reduced-pom.xml")) {
                 // JENKINS-42302: maven-shade-plugin creates a temporary project file dependency-reduced-pom.xml
                 // TODO see if there is a better way to implement this "workaround"
                 absolutePath = absolutePath.replace(File.separator + "dependency-reduced-pom.xml", File.separator + "pom.xml");
-            } else if (absolutePath.endsWith(File.separator + ".flattened-pom.xml")) {
-                // JENKINS-43616: flatten-maven-plugin creates an intermediate project file .flattened-pom.xml
-                // TODO see if there is a better way to implement this "workaround"
-                absolutePath = absolutePath.replace(File.separator + ".flattened-pom.xml", File.separator + "pom.xml");
             } else {
                 logger.warn("[jenkins-event-spy] Unexpected Maven project file name '" + projectFile.getName() + "', problems may occur");
             }


### PR DESCRIPTION
If the flatten-maven-plugin is used to created a flattened pom (i.e. a BOM) and to replace the original POM of a project, the Maven Event Spy reverts the flattened POM to the original POM.
Due to this the original POM is archived in Jenkins instead of the flattened one.
This behavior of the Maven Event Spy has been introduced by JENKINS-43616 .

While this might be a valid workaround for the "dependency-reduced-pom.xml" issue ( JENKINS-42302 ), where only a temporary POM is created, it is the intended behavior of the maven-flatten-plugin to replace the original POM by the flattened one as the main build artifact and it therefore should be archived instead of the original one.