### PR TITLE
[JENKINS-53396] Verify downstream pipeline eligibility only once when  multiple generated maven artifacts trigger a pipeline

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListener.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListener.java
@@ -93,6 +93,21 @@ public class DownstreamPipelineTriggerRunListener extends RunListener<WorkflowRu
             downstreamPipelinesLoop:
             for (String downstreamPipelineFullName : downstreamPipelines) {
 
+                if (jobsToTrigger.containsKey(downstreamPipelineFullName)) {
+                    // downstream pipeline has already been added to the list of pipelines to trigger,
+                    // it's meeting requirements (not an infinite loop, authorized by security, not excessive triggering, buildable...)
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        listener.getLogger().println("[withMaven - DownstreamPipelineTriggerRunListener] Skip eligibility check of pipeline " + downstreamPipelineFullName + " for artifact " + mavenArtifact.getShortDescription() + ", eligibility already confirmed");
+                    }
+                    Set<MavenArtifact> mavenArtifacts = jobsToTrigger.get(downstreamPipelineFullName);
+                    if (mavenArtifacts == null) {
+                        listener.getLogger().println("[withMaven - DownstreamPipelineTriggerRunListener] Invalid state, no artifacts found for pipeline '" + downstreamPipelineFullName + "' while evaluating " + mavenArtifact.getShortDescription());
+                    } else {
+                        mavenArtifacts.add(mavenArtifact);
+                    }
+                    continue;
+                }
+
                 if (Objects.equals(downstreamPipelineFullName, upstreamPipelineFullName)) {
                     // Don't trigger myself
                     continue;


### PR DESCRIPTION
[JENKINS-53396] Verify downstream pipeline eligibility only once when multiple generated maven artifacts trigger a pipeline

Troubleshooting message style when an eligibility check is skipped and when the logger `org.jenkinsci.plugins.pipeline.maven.listeners.DownstreamPipelineTriggerRunListener=FINEST`:

```
[withMaven - DownstreamPipelineTriggerRunListener] Skip eligibility check of pipeline dependency-graph/my-downstream-of-a-multi-jar-project/master for artifact com.example.multi-jar:jar-2:jar:0.0.1-SNAPSHOT(0.0.1-20180903.201513-17), eligibility already confirmed
```