### PR TITLE
JENKINS-53831 stop displaying warning message when withMaven(){} is u…

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -252,11 +252,14 @@ class WithMavenStepExecution extends StepExecution {
         Launcher launcher1 = launcher;
         while (launcher1 instanceof Launcher.DecoratedLauncher) {
             String launcherClassName = launcher1.getClass().getName();
-            if (launcherClassName.contains("WithContainerStep")) {
-                LOGGER.fine("Step running within docker.image()");
+            if (launcherClassName.contains("org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator")) {
+                LOGGER.log(Level.FINE, "Step running within Kubernetes withContainer(): {1}", launcherClassName);
+                return false;
+            } if (launcherClassName.contains("WithContainerStep")) {
+                LOGGER.log(Level.FINE, "Step running within docker.image(): {1}", launcherClassName);
                 return true;
             } else if (launcherClassName.contains("ContainerExecDecorator")) {
-                LOGGER.fine("Step running within container()");
+                LOGGER.log(Level.FINE, "Step running within docker.image(): {1}", launcherClassName);
                 return true;
             }
             launcher1 = ((Launcher.DecoratedLauncher) launcher1).getInner();


### PR DESCRIPTION
JENKINS-53831 stop displaying warning message when withMaven(){} is used in an agent provisioned by the jenkins-kubernetes-plugin