### PR TITLE
Java 11 cleanup - change <tt> to <code> in Javadoc

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
@@ -59,7 +59,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Configures maven environment to use within a pipeline job by calling <tt>sh mvn</tt> or <tt>bat mvn</tt>.
+ * Configures maven environment to use within a pipeline job by calling <code>sh mvn</code> or <code>bat mvn</code>.
  * The selected maven installation will be configured and prepended to the path.
  *
  */

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution.java
@@ -142,7 +142,7 @@ class WithMavenStepExecution extends StepExecution {
     private transient BodyExecution body;
 
     /**
-     * Indicates if running on docker with <tt>docker.image()</tt> or <tt>container()</tt>
+     * Indicates if running on docker with <code>docker.image()</code> or <code>container()</code>
      */
     private boolean withContainer;
 
@@ -229,19 +229,19 @@ class WithMavenStepExecution extends StepExecution {
     }
 
     /**
-     * Detects if this step is running inside <tt>docker.image()</tt> or <tt>container()</tt>
+     * Detects if this step is running inside <code>docker.image()</code> or <code>container()</code>
      * <p>
      * This has the following implications:
      * <li>Tool intallers do no work, as they install in the host, see:
      * https://issues.jenkins-ci.org/browse/JENKINS-36159
      * <li>Environment variables do not apply because they belong either to the master or the agent, but not to the
-     * container running the <tt>sh</tt> command for maven This is due to the fact that <tt>docker.image()</tt> all it
-     * does is decorate the launcher and excute the command with a <tt>docker run</tt> which means that the inherited
+     * container running the <code>sh</code> command for maven This is due to the fact that <code>docker.image()</code> all it
+     * does is decorate the launcher and excute the command with a <code>docker run</code> which means that the inherited
      * environment from the OS will be totally different eg: MAVEN_HOME, JAVA_HOME, PATH, etc.
-     * <li>Kubernetes' <tt>container()</tt> support is still in early stages, and environment variables might not be
+     * <li>Kubernetes' <code>container()</code> support is still in early stages, and environment variables might not be
      * completely configured, depending on the version of the Jenkins Kubernetes plugin.
      *
-     * @return true if running inside a container with <tt>docker.image()</tt> or <tt>container()</tt>
+     * @return true if running inside a container with <code>docker.image()</code> or <code>container()</code>
      * @see <a href=
      * "https://github.com/jenkinsci/docker-workflow-plugin/blob/master/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java">
      * WithContainerStep</a> and <a href=

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/service/PipelineTriggerService.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/service/PipelineTriggerService.java
@@ -257,7 +257,7 @@ public class PipelineTriggerService {
             downstreamPipelineAuth = auth;
         }
 
-        try (ACLContext _ = ACL.as(downstreamPipelineAuth)) {
+        try (ACLContext ignored = ACL.as(downstreamPipelineAuth)) {
             WorkflowJob upstreamPipelineObtainedAsImpersonated = getItemByFullName(upstreamPipeline.getFullName(), WorkflowJob.class);
             boolean result = upstreamPipelineObtainedAsImpersonated != null;
             LOGGER.log(Level.FINE, "isUpstreamBuildVisibleByDownstreamBuildAuth({0}, {1}): taskAuth: {2}, downstreamPipelineAuth: {3}, upstreamPipelineObtainedAsImpersonated:{4}, result: {5}",

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-jdk.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-jdk.html
@@ -1,5 +1,5 @@
 <div>
     Select a JDK installation. If auto-install is disabled, the JDK will be downloaded and made available for the pipeline job.
     <p>
-    <strong>Note</strong>: This option does not work with <tt>docker.image('xxx').inside</tt> or <tt>container('xxx')</tt>, the preinstalled JDK on the docker image will be used.
+    <strong>Note</strong>: This option does not work with <code>docker.image('xxx').inside</code> or <code>container('xxx')</code>, the preinstalled JDK on the docker image will be used.
 </div>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-maven.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-maven.html
@@ -1,5 +1,5 @@
 <div>
     Select a Maven installation. If auto-install is disabled, maven will be downloaded and made available for the pipeline job.
     <p>
-    <strong>Note</strong>: This option does not work with <tt>docker.image('xxx').inside</tt> or <tt>container('xxx')</tt>,  the preinstalled maven on the docker image will be used.
+    <strong>Note</strong>: This option does not work with <code>docker.image('xxx').inside</code> or <code>container('xxx')</code>,  the preinstalled maven on the docker image will be used.
 </div>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-mavenLocalRepo.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-mavenLocalRepo.html
@@ -2,8 +2,8 @@
   Specify a custom local repository path.
   Shell-like environment variable expansions work with this field, by using the ${VARIABLE} syntax.
   
-  Normally, Jenkins uses the local Maven repository as determined by Maven, by default <tt>~/.m2/repository</tt> and can be overridden by
-  &lt;localRepository> in <tt>~/.m2/settings.xml</tt> (see <a href="https://maven.apache.org/guides/mini/guide-configuring-maven.html#Configuring_your_Local_Repository">Configuring your Local Repository</a>)) 
+  Normally, Jenkins uses the local Maven repository as determined by Maven, by default <code>~/.m2/repository</code> and can be overridden by
+  &lt;localRepository> in <code>~/.m2/settings.xml</code> (see <a href="https://maven.apache.org/guides/mini/guide-configuring-maven.html#Configuring_your_Local_Repository">Configuring your Local Repository</a>))
 
   <p>
   This normally means that all the jobs that are executed on the same node shares a single Maven repository.
@@ -13,12 +13,12 @@
   repositories in POM might have them.
 
   <p>
-  By using this option, Jenkins will tell Maven to use a custom path for the build as the local Maven repository by using <tt>-Dmaven.repo.local</tt>
+  By using this option, Jenkins will tell Maven to use a custom path for the build as the local Maven repository by using <code>-Dmaven.repo.local</code>
   <br>
 
   If specified as a relative path then this value well be resolved against the workspace root and not the current working directory.
   <br>
-  ie. if <tt>.repository</tt> is specified then <tt>$WORKSPACE/.repository</tt> will be used.
+  ie. if <code>.repository</code> is specified then <code>$WORKSPACE/.repository</code> will be used.
 
   <p>
   This means each job could get its own isolated Maven repository just for itself. It fixes the above problems,

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-mavenOpts.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-mavenOpts.html
@@ -2,5 +2,5 @@
   Specify JVM specific options needed when launching Maven as an external process, these are not maven specific options.
   See: <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#CBBIJCHG">Java Options</a>
   <p>
-  Shell-like environment variable expansions work in this field, by using the <tt>${VARIABLE}</tt> syntax.
+  Shell-like environment variable expansions work in this field, by using the <code>${VARIABLE}</code> syntax.
 </div>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help.html
@@ -1,4 +1,4 @@
 <div>
-Configures maven environment to use within a pipeline job by calling <tt>sh mvn</tt> or <tt>bat mvn</tt>.
+Configures maven environment to use within a pipeline job by calling <code>sh mvn</code> or <code>bat mvn</code>.
 The selected maven installation will be configured and prepended to the path.
 </div>


### PR DESCRIPTION
Fixes Javadoc processing errors with latest Java