### PR TITLE
JENKINS-55370 prevent cases where `jenkins.rootUrl` is `null` during the initialization 

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/db/migration/MigrationStep.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/db/migration/MigrationStep.java
@@ -5,6 +5,7 @@ import jenkins.model.Jenkins;
 import javax.annotation.Nonnull;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Objects;
 
 public interface MigrationStep {
     void execute(@Nonnull Connection cnn, @Nonnull JenkinsDetails jenkinsDetails) throws SQLException;
@@ -12,13 +13,15 @@ public interface MigrationStep {
     /**
      * for unit tests outside of Jenkins
      */
-    public static class JenkinsDetails {
+    class JenkinsDetails {
+        @Nonnull
         public String getMasterLegacyInstanceId() {
             return Jenkins.getInstance().getLegacyInstanceId();
         }
 
+        @Nonnull
         public String getMasterRootUrl(){
-            return Jenkins.getInstance().getRootUrl();
+            return Objects.toString(Jenkins.getInstance().getRootUrl(), "");
         }
     }
 }

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginH2DaoInitializationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginH2DaoInitializationTest.java
@@ -25,8 +25,17 @@
 package org.jenkinsci.plugins.pipeline.maven.dao;
 
 import org.h2.jdbcx.JdbcConnectionPool;
+import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.pipeline.maven.db.migration.MigrationStep;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import javax.annotation.Nonnull;
 
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
@@ -53,5 +62,74 @@ public class PipelineMavenPluginH2DaoInitializationTest {
                 };
             }
         };
+    }
+
+    @Test
+    public void initialize_database_with_null_master_url() throws SQLException {
+        JdbcConnectionPool jdbcConnectionPool = JdbcConnectionPool.create("jdbc:h2:mem:", "sa", "");
+
+        PipelineMavenPluginH2Dao daoWithEmptyJenkinsUrl = new PipelineMavenPluginH2Dao(jdbcConnectionPool) {
+            @Override
+            protected MigrationStep.JenkinsDetails getJenkinsDetails() {
+                return new MigrationStep.JenkinsDetails() {
+                    @Nonnull
+                    @Override
+                    public String getMasterLegacyInstanceId() {
+                        return "123456";
+                    }
+
+                    @Nonnull
+                    @Override
+                    public String getMasterRootUrl() {
+                        return "";
+                    }
+                };
+            }
+        };
+
+        // VERIFY THAT THE JENKINS_MASTER TABLE IS INITIALIZED WITH AN JENKINS_MASTER.URL = ""
+        try (Connection cnn = jdbcConnectionPool.getConnection()) {
+            Long jenkinsMasterPrimaryKey = daoWithEmptyJenkinsUrl.getJenkinsMasterPrimaryKey(cnn);
+
+            try (PreparedStatement stmt = cnn.prepareStatement("SELECT URL FROM JENKINS_MASTER WHERE ID = ?")) {
+                stmt.setLong(1, jenkinsMasterPrimaryKey);
+                try(ResultSet rst = stmt.executeQuery()) {
+                    rst.next();
+                    Assert.assertThat(rst.getString("URL"), Matchers.is(""));
+                }
+            }
+        }
+
+        PipelineMavenPluginH2v1Dao daoWithValidJenkinsUrl = new PipelineMavenPluginH2v1Dao(jdbcConnectionPool) {
+            @Override
+            protected MigrationStep.JenkinsDetails getJenkinsDetails() {
+                return new MigrationStep.JenkinsDetails() {
+                    @Nonnull
+                    @Override
+                    public String getMasterLegacyInstanceId() {
+                        return "123456";
+                    }
+
+                    @Nonnull
+                    @Override
+                    public String getMasterRootUrl() {
+                        return "http://jenkins.mycompany.com";
+                    }
+                };
+            }
+        };
+
+        // VERIFY THAT THE JENKINS_MASTER TABLE IS UPDATE WITH AN JENKINS_MASTER.URL = "http://jenkins.mycompany.com"
+        try (Connection cnn = jdbcConnectionPool.getConnection()) {
+            Long jenkinsMasterPrimaryKey = daoWithValidJenkinsUrl.getJenkinsMasterPrimaryKey(cnn);
+
+            try (PreparedStatement stmt = cnn.prepareStatement("SELECT URL FROM JENKINS_MASTER WHERE ID = ?")) {
+                stmt.setLong(1, jenkinsMasterPrimaryKey);
+                try(ResultSet rst = stmt.executeQuery()) {
+                    rst.next();
+                    Assert.assertThat(rst.getString("URL"), Matchers.is("http://jenkins.mycompany.com"));
+                }
+            }
+        }
     }
 }

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginH2v1DaoInitializationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginH2v1DaoInitializationTest.java
@@ -25,8 +25,17 @@
 package org.jenkinsci.plugins.pipeline.maven.dao;
 
 import org.h2.jdbcx.JdbcConnectionPool;
+import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.pipeline.maven.db.migration.MigrationStep;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import javax.annotation.Nonnull;
 
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
@@ -53,5 +62,74 @@ public class PipelineMavenPluginH2v1DaoInitializationTest {
                 };
             }
         };
+    }
+
+    @Test
+    public void initialize_database_with_null_master_url() throws SQLException {
+        JdbcConnectionPool jdbcConnectionPool = JdbcConnectionPool.create("jdbc:h2:mem:", "sa", "");
+
+        PipelineMavenPluginH2v1Dao daoWithEmptyJenkinsUrl = new PipelineMavenPluginH2v1Dao(jdbcConnectionPool) {
+            @Override
+            protected MigrationStep.JenkinsDetails getJenkinsDetails() {
+                return new MigrationStep.JenkinsDetails() {
+                    @Nonnull
+                    @Override
+                    public String getMasterLegacyInstanceId() {
+                        return "123456";
+                    }
+
+                    @Nonnull
+                    @Override
+                    public String getMasterRootUrl() {
+                        return "";
+                    }
+                };
+            }
+        };
+
+        // VERIFY THAT THE JENKINS_MASTER TABLE IS INITIALIZED WITH AN JENKINS_MASTER.URL = ""
+        try (Connection cnn = jdbcConnectionPool.getConnection()) {
+            Long jenkinsMasterPrimaryKey = daoWithEmptyJenkinsUrl.getJenkinsMasterPrimaryKey(cnn);
+
+            try (PreparedStatement stmt = cnn.prepareStatement("SELECT URL FROM JENKINS_MASTER WHERE ID = ?")) {
+                stmt.setLong(1, jenkinsMasterPrimaryKey);
+                try(ResultSet rst = stmt.executeQuery()) {
+                    rst.next();
+                    Assert.assertThat(rst.getString("URL"), Matchers.is(""));
+                }
+            }
+        }
+
+        PipelineMavenPluginH2v1Dao daoWithValidJenkinsUrl = new PipelineMavenPluginH2v1Dao(jdbcConnectionPool) {
+            @Override
+            protected MigrationStep.JenkinsDetails getJenkinsDetails() {
+                return new MigrationStep.JenkinsDetails() {
+                    @Nonnull
+                    @Override
+                    public String getMasterLegacyInstanceId() {
+                        return "123456";
+                    }
+
+                    @Nonnull
+                    @Override
+                    public String getMasterRootUrl() {
+                        return "http://jenkins.mycompany.com";
+                    }
+                };
+            }
+        };
+
+        // VERIFY THAT THE JENKINS_MASTER TABLE IS UPDATE WITH AN JENKINS_MASTER.URL = "http://jenkins.mycompany.com"
+        try (Connection cnn = jdbcConnectionPool.getConnection()) {
+            Long jenkinsMasterPrimaryKey = daoWithValidJenkinsUrl.getJenkinsMasterPrimaryKey(cnn);
+
+            try (PreparedStatement stmt = cnn.prepareStatement("SELECT URL FROM JENKINS_MASTER WHERE ID = ?")) {
+                stmt.setLong(1, jenkinsMasterPrimaryKey);
+                try(ResultSet rst = stmt.executeQuery()) {
+                    rst.next();
+                    Assert.assertThat(rst.getString("URL"), Matchers.is("http://jenkins.mycompany.com"));
+                }
+            }
+        }
     }
 }

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginMySqlDaoInitializationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginMySqlDaoInitializationTest.java
@@ -25,8 +25,17 @@
 package org.jenkinsci.plugins.pipeline.maven.dao;
 
 import org.h2.jdbcx.JdbcConnectionPool;
+import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.pipeline.maven.db.migration.MigrationStep;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import javax.annotation.Nonnull;
 
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
@@ -53,5 +62,74 @@ public class PipelineMavenPluginMySqlDaoInitializationTest {
                 };
             }
         };
+    }
+
+    @Test
+    public void initialize_database_with_null_master_url() throws SQLException {
+        JdbcConnectionPool jdbcConnectionPool = JdbcConnectionPool.create("jdbc:h2:mem:;MODE=MYSQL", "sa", "");
+
+        PipelineMavenPluginMySqlDao daoWithEmptyJenkinsUrl = new PipelineMavenPluginMySqlDao(jdbcConnectionPool) {
+            @Override
+            protected MigrationStep.JenkinsDetails getJenkinsDetails() {
+                return new MigrationStep.JenkinsDetails() {
+                    @Nonnull
+                    @Override
+                    public String getMasterLegacyInstanceId() {
+                        return "123456";
+                    }
+
+                    @Nonnull
+                    @Override
+                    public String getMasterRootUrl() {
+                        return "";
+                    }
+                };
+            }
+        };
+
+        // VERIFY THAT THE JENKINS_MASTER TABLE IS INITIALIZED WITH AN JENKINS_MASTER.URL = ""
+        try (Connection cnn = jdbcConnectionPool.getConnection()) {
+            Long jenkinsMasterPrimaryKey = daoWithEmptyJenkinsUrl.getJenkinsMasterPrimaryKey(cnn);
+
+            try (PreparedStatement stmt = cnn.prepareStatement("SELECT URL FROM JENKINS_MASTER WHERE ID = ?")) {
+                stmt.setLong(1, jenkinsMasterPrimaryKey);
+                try(ResultSet rst = stmt.executeQuery()) {
+                    rst.next();
+                    Assert.assertThat(rst.getString("URL"), Matchers.is(""));
+                }
+            }
+        }
+
+        PipelineMavenPluginH2v1Dao daoWithValidJenkinsUrl = new PipelineMavenPluginH2v1Dao(jdbcConnectionPool) {
+            @Override
+            protected MigrationStep.JenkinsDetails getJenkinsDetails() {
+                return new MigrationStep.JenkinsDetails() {
+                    @Nonnull
+                    @Override
+                    public String getMasterLegacyInstanceId() {
+                        return "123456";
+                    }
+
+                    @Nonnull
+                    @Override
+                    public String getMasterRootUrl() {
+                        return "http://jenkins.mycompany.com";
+                    }
+                };
+            }
+        };
+
+        // VERIFY THAT THE JENKINS_MASTER TABLE IS UPDATE WITH AN JENKINS_MASTER.URL = "http://jenkins.mycompany.com"
+        try (Connection cnn = jdbcConnectionPool.getConnection()) {
+            Long jenkinsMasterPrimaryKey = daoWithValidJenkinsUrl.getJenkinsMasterPrimaryKey(cnn);
+
+            try (PreparedStatement stmt = cnn.prepareStatement("SELECT URL FROM JENKINS_MASTER WHERE ID = ?")) {
+                stmt.setLong(1, jenkinsMasterPrimaryKey);
+                try(ResultSet rst = stmt.executeQuery()) {
+                    rst.next();
+                    Assert.assertThat(rst.getString("URL"), Matchers.is("http://jenkins.mycompany.com"));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
JENKINS-55370 prevent cases where `jenkins.rootUrl` is `null` during the initialization of the pipeline-maven-plugin and update the `jenkins_master.url if the url has changed.