### PR TITLE
JENKINS-55378 Add support for MariaDB

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginMySqlDao.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginMySqlDao.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.pipeline.maven.dao;
 
 import com.mysql.cj.exceptions.MysqlErrorNumbers;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pipeline.maven.util.RuntimeSqlException;
 
 import java.sql.Connection;
@@ -35,12 +36,40 @@ import java.sql.Statement;
 import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
 public class PipelineMavenPluginMySqlDao extends AbstractPipelineMavenPluginDao {
+
+    /**
+     * Extract the MariaDB server version from {@link DatabaseMetaData#getDatabaseProductVersion()}
+     *
+     * @param jdbcDatabaseProductVersion such as  "5.5.5-10.2.20-MariaDB", "5.5.5-10.3.11-MariaDB-1:10.3.11+maria~bionic"
+     * @return {@code null} if this is not a MariaDB version, the MariaDB server version (e.g. "10.2.20", "10.3.11") if parsed, the entire {@link DatabaseMetaData#getDatabaseProductVersion()} if the parsing oof the MariaDB server version failed
+     */
+    @Nullable
+    public  static String extractMariaDbVersion(@Nullable String jdbcDatabaseProductVersion) {
+        if (jdbcDatabaseProductVersion == null) {
+            return null;
+        }
+
+        if(!jdbcDatabaseProductVersion.contains("MariaDB")) {
+            return null;
+        }
+
+        String mariaDbVersion = StringUtils.substringBetween(jdbcDatabaseProductVersion, "-", "-MariaDB");
+
+        if (mariaDbVersion == null) { // MariaDB version format has changed.
+           return jdbcDatabaseProductVersion;
+        } else {
+            return mariaDbVersion;
+        }
+    }
+
+
     public PipelineMavenPluginMySqlDao(@Nonnull DataSource ds) {
         super(ds);
     }

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/config.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
         </f:entry>
         <f:entry title="${%Database Configuration}">
             <f:entry title="${%JDBC URL}" field="jdbcUrl"
-                     description="JDBC URL. For production grade workloads, use MySQL. If empty, then a non production grade H2 embedded database will be used.">
+                     description="JDBC URL. For production grade workloads, use MySQL / MariaDB. If empty, then a non production grade H2 embedded database will be used.">
                 <f:textbox/>
             </f:entry>
             <f:entry title="${%JDBC Credentials}" field="jdbcCredentialsId">

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/help-jdbcUrl.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/help-jdbcUrl.html
@@ -1,3 +1,3 @@
 <div>
-    <p>Supported databases are H2 and MySQL. For production grade workloads, use MySQL. If empty, then a non production grade H2 embedded database will be used.</p>
+    <p>Supported databases are H2 and MySQL / MariaDB. For production grade workloads, use MySQL / MariaDB. If empty, then a non production grade H2 embedded database will be used.</p>
 </div>

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginMySqlDaoTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginMySqlDaoTest.java
@@ -24,8 +24,12 @@
 
 package org.jenkinsci.plugins.pipeline.maven.dao;
 
+import org.apache.commons.lang.StringUtils;
 import org.h2.jdbcx.JdbcConnectionPool;
+import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.pipeline.maven.db.migration.MigrationStep;
+import org.junit.Assert;
+import org.junit.Test;
 
 import javax.sql.DataSource;
 
@@ -57,5 +61,20 @@ public class PipelineMavenPluginMySqlDaoTest extends PipelineMavenPluginDaoAbstr
                 };
             }
         };
+    }
+
+    @Test
+    public void test_mariadb_version_parsing_JENKINS_55378() {
+        String actual = PipelineMavenPluginMySqlDao.extractMariaDbVersion("5.5.5-10.2.20-MariaDB");
+        Assert.assertThat(actual, Matchers.is("10.2.20"));
+    }
+
+    /**
+     * docker run  -e MYSQL_ROOT_PASSWORD=mypass -e MYSQL_DATABASE=jenkins -e MYSQL_USER=jenkins -e MYSQL_PASSWORD=jenkins -p 3307:3306 -d mariadb/server:latest
+     */
+    @Test
+    public void test_mariadb_version_parsing_mariadb_as_docker_container() {
+        String actual = PipelineMavenPluginMySqlDao.extractMariaDbVersion("5.5.5-10.3.11-MariaDB-1:10.3.11+maria~bionic");
+        Assert.assertThat(actual, Matchers.is("10.3.11"));
     }
 }


### PR DESCRIPTION
JENKINS-55378 Add support for MariaDB. If MariaDB is detected, an info message "MariaDB version x.y.z detected. Please ensure that your MariaDB version is at least version 10.2+" is displayed