### PR TITLE
JENKINS-57324 Fix '%' char escaping in the windows batch script wrapper for mvn.cmd

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -616,6 +616,8 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             String lineSep = "\r\n";
             script.append("@echo off").append(lineSep);
             script.append("echo ----- withMaven Wrapper script -----").append(lineSep);
+            // JENKINS-57324 escape '%' as '%%'. See https://en.wikibooks.org/wiki/Windows_Batch_Scripting#Quoting_and_escaping
+            mavenConfig = mavenConfig.replace("%", "%%");
             script.append("\"" + mvnExec.getRemote() + "\" " + mavenConfig + " %*").append(lineSep);
         }
 

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2Test.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2Test.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.plugins.pipeline.maven;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+public class WithMavenStepExecution2Test {
+
+    @Test
+    @Issue("JENKINS-57324")
+    public void testEscapeWindowsBatchChars(){
+
+        String mavenConfig ="--batch-mode --show-version " +
+                "--settings \"e:\\folder\\branches%2Ftest\\workspace@tmp\\withMaven94865076\\settings.xml\" " +
+                "--global-settings \"e:\\folder\\branches%2Ftest\\workspace@tmp\\withMaven94865076\\globalSettings.xml\"";
+
+       String actualEscapedMavenConfig = mavenConfig.replace("%", "%%");
+       String expectedEscapedMavenConfig = "--batch-mode --show-version " +
+               "--settings \"e:\\folder\\branches%%2Ftest\\workspace@tmp\\withMaven94865076\\settings.xml\" " +
+               "--global-settings \"e:\\folder\\branches%%2Ftest\\workspace@tmp\\withMaven94865076\\globalSettings.xml\"";
+        System.out.println("Expected escaped mavenConfig: " + expectedEscapedMavenConfig);
+        Assert.assertThat(actualEscapedMavenConfig, Matchers.is(expectedEscapedMavenConfig));
+
+    }
+}


### PR DESCRIPTION
JENKINS-57324 Fix '%' char escaping in the windows batch script wrapper for mvn.cmd