### PR TITLE
JENKINS-59500 feature: Downstream pipelines are not triggered when the artifact has type docker-info

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginDao.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginDao.java
@@ -190,7 +190,24 @@ public interface PipelineMavenPluginDao {
      * @see Item#getFullName()
      */
     @Nonnull
-    SortedSet<String> listDownstreamJobs(@Nonnull String groupId, @Nonnull String artifactId, @Nonnull String version, @Nullable String baseVersion, @Nonnull String type);
+    default SortedSet<String> listDownstreamJobs(@Nonnull String groupId, @Nonnull String artifactId, @Nonnull String version, @Nullable String baseVersion, @Nonnull String type) {
+        return listDownstreamJobs(groupId, artifactId, version, baseVersion, type, null);
+    }
+
+    /**
+     * List the downstream jobs who have a dependency on the given artifact.
+     *
+     * @param groupId Maven artifact group ID  (see {@link Artifact#getArtifactId()})
+     * @param artifactId Maven artifact id (see {@link Artifact#getArtifactId()})
+     * @param version Maven artifact version (see {@link Artifact#getVersion()})
+     * @param baseVersion Maven artifact (see {@link Artifact#getBaseVersion()})
+     * @param type Maven artifact type (see {@link Artifact#getType()}})
+     * @param classifier Maven artifact classifier (see {@link Artifact#getClassifier()}})
+     * @return list of job full names (see {@link Item#getFullName()}) by {@link MavenArtifact}
+     * @see Item#getFullName()
+     */
+    @Nonnull
+    SortedSet<String> listDownstreamJobs(@Nonnull String groupId, @Nonnull String artifactId, @Nonnull String version, @Nullable String baseVersion, @Nonnull String type, @Nullable String classifier);
 
     /**
      * List the upstream jobs who generate an artifact that the given build depends on

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginMonitoringDao.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginMonitoringDao.java
@@ -169,10 +169,10 @@ public class PipelineMavenPluginMonitoringDao implements PipelineMavenPluginJdbc
 
     @Nonnull
     @Override
-    public SortedSet<String> listDownstreamJobs(String groupId, String artifactId, String version, String baseVersion, String type) {
+    public SortedSet<String> listDownstreamJobs(String groupId, String artifactId, String version, String baseVersion, String type, String classifier) {
         long nanosBefore = System.nanoTime();
         try {
-            return delegate.listDownstreamJobs(groupId, artifactId, version, baseVersion, type);
+            return delegate.listDownstreamJobs(groupId, artifactId, version, baseVersion, type, classifier);
         } finally {
             long nanosAfter = System.nanoTime();
             findCount.incrementAndGet();

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginNullDao.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/dao/PipelineMavenPluginNullDao.java
@@ -36,6 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
@@ -108,7 +109,7 @@ public class PipelineMavenPluginNullDao implements PipelineMavenPluginDao {
 
     @Nonnull
     @Override
-    public SortedSet<String> listDownstreamJobs(String groupId, String artifactId, String version, String baseVersion, String type) {
+    public SortedSet<String> listDownstreamJobs(String groupId, String artifactId, String version, String baseVersion, String type, String classifier) {
         return new TreeSet<>();
     }
 

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListener.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListener.java
@@ -131,6 +131,7 @@ public class DownstreamPipelineTriggerRunListener extends RunListener<WorkflowRu
         String upstreamPipelineFullName = upstreamPipeline.getFullName();
         int upstreamBuildNumber = upstreamBuild.getNumber();
         Map<MavenArtifact, SortedSet<String>> downstreamPipelinesByArtifact = globalPipelineMavenConfig.getDao().listDownstreamJobsByArtifact(upstreamPipelineFullName, upstreamBuildNumber);
+        LOGGER.log(Level.FINER, "got downstreamPipelinesByArtifact for project {0} and build #{1}: {2}", new Object[]{upstreamPipelineFullName, upstreamBuildNumber, downstreamPipelinesByArtifact});
 
         Map<String, Set<MavenArtifact>> jobsToTrigger = new TreeMap<>();
         Map<String, Set<String>>  omittedPipelineTriggersByPipelineFullname = new HashMap<>();

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenReport/index.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenReport/index.jelly
@@ -22,6 +22,7 @@ Inspired by /hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
                                 <j:otherwise>
                                     <a href="${artifact.url}">${artifact.fileName}</a>
                                 </j:otherwise>
+                                (type: ${artifact.type})
                             </j:choose>
                         </li>
                     </j:forEach>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenReport/jobMain.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenReport/jobMain.jelly
@@ -8,7 +8,7 @@
                 <ul>
                     <j:forEach var="artifact" items="${it.deployedArtifacts}">
                         <li>
-                            <a href="${artifact.url}">${artifact.fileName}</a>
+                            <a href="${artifact.url}">${artifact.fileName}</a> (type: ${artifact.type})
                         </li>
                     </j:forEach>
                 </ul>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenReport/summary.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/publishers/MavenReport/summary.jelly
@@ -5,7 +5,7 @@
       Deployed Artifacts
     <ul>
       <j:forEach var="artifact" items="${it.deployedArtifacts}">
-        <li><a href="${artifact.url}">${artifact.fileName}</a></li>
+        <li><a href="${artifact.url}">${artifact.fileName}</a> (type: ${artifact.type})</li>
     </j:forEach>
     </ul>
   </t:summary>


### PR DESCRIPTION
Considering two Maven artefacts having same groupId / artifactId / version and same type or `null` classifier or same classifier to be the same