### PR TITLE
[JENKINS-61791] Strip Ansi Color escape sequences from captured exceptions

### DIFF
--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
@@ -204,6 +204,14 @@ public abstract class AbstractMavenEventHandler<E> implements MavenEventHandler<
         return null;
     }
 
+    private static final Pattern ANSI_PATTERN = Pattern.compile("\\x1b\\[[0-9;]*m");
+    private static String removeAnsiColor(String input) {
+    	if (input!=null) {
+    		input = ANSI_PATTERN.matcher(input).replaceAll("");
+    	}
+    	return input;
+    }
+    
     public Xpp3Dom newElement(@Nonnull String name, @Nullable Throwable t) {
         Xpp3Dom rootElt = new Xpp3Dom(name);
         if (t == null) {
@@ -213,13 +221,13 @@ public abstract class AbstractMavenEventHandler<E> implements MavenEventHandler<
 
         Xpp3Dom messageElt = new Xpp3Dom("message");
         rootElt.addChild(messageElt);
-        messageElt.setValue(t.getMessage());
+        messageElt.setValue(removeAnsiColor(t.getMessage()));
 
         Xpp3Dom stackTraceElt = new Xpp3Dom("stackTrace");
         rootElt.addChild(stackTraceElt);
         StringWriter stackTrace = new StringWriter();
         t.printStackTrace(new PrintWriter(stackTrace, true));
-        stackTraceElt.setValue(stackTrace.toString());
+        stackTraceElt.setValue(removeAnsiColor(stackTrace.toString()));
         return rootElt;
     }
 

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
@@ -56,6 +56,12 @@ public abstract class AbstractMavenEventHandler<E> implements MavenEventHandler<
 
     protected final MavenEventReporter reporter;
 
+    /**
+     * Regex pattern to extract ANSI escape sequences
+     */
+    private static final Pattern ANSI_PATTERN = Pattern.compile("\\x1b\\[[0-9;]*m");
+
+
     protected AbstractMavenEventHandler(MavenEventReporter reporter) {
         this.reporter = reporter;
     }
@@ -205,7 +211,6 @@ public abstract class AbstractMavenEventHandler<E> implements MavenEventHandler<
         return null;
     }
 
-    private static final Pattern ANSI_PATTERN = Pattern.compile("\\x1b\\[[0-9;]*m");
     private static String removeAnsiColor(String input) {
     	if (input!=null) {
     		input = ANSI_PATTERN.matcher(input).replaceAll("");

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/AbstractMavenEventHandler.java
@@ -42,6 +42,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;


### PR DESCRIPTION
The exception message captured by the maven spy contains ANSI Escape sequences (coloring) when maven is executed with console coloring enabled. These escape codes are not valid XML characters and must be stripped from the message before being written in the XML file.
