### PR TITLE
Jenkins core upgrade (2.138.4 -> 2.204.6) + Plugin parent upgrade (3.43 -> 4.6) + BOM

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -621,7 +621,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.0.2</version>
         <executions>
           <execution>
             <id>copy-maven-spy-jar</id>

--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -60,17 +60,6 @@
     </developer>
   </developers>
 
-  <properties>
-    <scm-api-plugin.version>2.2.8</scm-api-plugin.version>
-    <git-plugin.version>3.9.2</git-plugin.version>
-    <!--
-    stick to junit 1.20 clarifying the impact of the introduction of the dependencies
-    workflow-step-api or workflow-api-->
-    <junit-plugin.version>1.26.1</junit-plugin.version>
-    <asm.version>5.2</asm.version>
-    <workflow-support-plugin.version>2.22</workflow-support-plugin.version>
-  </properties>
-
   <scm>
     <url>https://github.com/jenkinsci/pipeline-maven-plugin/jenkins-plugin</url>
   </scm>
@@ -129,7 +118,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.29</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -140,23 +128,19 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-build-step</artifactId>
-      <version>2.7</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>2.0.20.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.18</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.34</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -166,12 +150,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.19</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>6.6</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -181,28 +163,16 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.54.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit-plugin.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
-    <!--
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit-plugin.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit-attachments</artifactId>
-      <version>1.4.2</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
@@ -295,43 +265,32 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.61.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.26</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>${workflow-support-plugin.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>${workflow-support-plugin.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>structs</artifactId>
-      <version>1.17</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>2.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -346,7 +305,6 @@
       -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.14</version>
       <optional>true</optional>
     </dependency>
 
@@ -359,7 +317,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-slaves</artifactId>
-      <version>1.29.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -372,14 +329,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>${scm-api-plugin.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>${git-plugin.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -391,7 +346,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>${git-plugin.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -399,39 +353,19 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>mailer</artifactId>
-        <version>1.21</version>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.204.x</artifactId>
+        <version>11</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>scm-api</artifactId>
-        <version>${scm-api-plugin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>ssh-credentials</artifactId>
-        <version>1.14</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>apache-httpcomponents-client-4-api</artifactId>
-        <version>4.5.5-3.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ant</groupId>
-        <artifactId>ant</artifactId>
-        <version>1.9.2</version>
-      </dependency>
+      <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+      <!-- Fix RequireUpperBoundDeps dependencies -->
+      <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-embedder</artifactId>
         <version>3.5.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-classworlds</artifactId>
-        <version>2.5.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
@@ -478,141 +412,19 @@
         <version>3.1.0</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-api</artifactId>
-        <version>1.1.0</version>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.8.2</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-impl</artifactId>
-        <version>1.1.0</version>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-all</artifactId>
+        <version>2.4.12</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-spi</artifactId>
-        <version>1.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-util</artifactId>
-        <version>1.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-provider-api</artifactId>
-        <version>3.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-annotations</artifactId>
-        <version>1.7.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.inject</groupId>
-        <artifactId>guice</artifactId>
-        <version>4.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.jcraft</groupId>
-        <artifactId>jsch</artifactId>
-        <version>0.1.54</version>
-      </dependency>
-      <!--
-      <dependency>
-        <groupId>org.apache.maven.doxia</groupId>
-        <artifactId>doxia-sink-api</artifactId>
-        <version>1.7</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.doxia</groupId>
-        <artifactId>doxia-core</artifactId>
-        <version>1.7</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.doxia</groupId>
-        <artifactId>doxia-site-renderer</artifactId>
-        <version>1.7</version>
-      </dependency>
-      -->
-      <dependency>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>2.11.0</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <version>1.8.3</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.5</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jvnet.localizer</groupId>
-        <artifactId>localizer</artifactId>
-        <version>1.24</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-fileupload</groupId>
-        <artifactId>commons-fileupload</artifactId>
-        <version>1.3.3</version>
-      </dependency>
-      <dependency>
-        <groupId>com.jcraft</groupId>
-        <artifactId>jzlib</artifactId>
-        <version>1.1.3-kohsuke-1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-container-default</artifactId>
-        <version>1.0-alpha-30</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.doxia</groupId>
-        <artifactId>doxia-logging-api</artifactId>
-        <version>1.4</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.doxia</groupId>
-        <artifactId>doxia-site-renderer</artifactId>
-        <version>1.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kohsuke.stapler</groupId>
-        <artifactId>stapler</artifactId>
-        <version>1.256</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.8.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci</groupId>
-        <artifactId>annotation-indexer</artifactId>
-        <version>1.12</version>
-      </dependency>
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm</artifactId>
-        <version>${asm.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm-analysis</artifactId>
-        <version>${asm.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm-commons</artifactId>
-        <version>${asm.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm-tree</artifactId>
-        <version>${asm.version}</version>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>annotations</artifactId>
+        <version>3.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
@@ -23,6 +23,10 @@
  */
 package org.jenkinsci.plugins.pipeline.maven;
 
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.model.Fingerprint;
 import hudson.model.FingerprintMap;
 import hudson.model.Node;
@@ -31,11 +35,6 @@ import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
-import hudson.tasks.Maven;
-import jenkins.mvn.DefaultGlobalSettingsProvider;
-import jenkins.mvn.DefaultSettingsProvider;
-import jenkins.mvn.GlobalMavenConfig;
-import jenkins.plugins.git.GitSampleRepoRule;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.pipeline.maven.docker.JavaGitContainer;
@@ -45,13 +44,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.test.acceptance.docker.DockerRule;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
-import org.jvnet.hudson.test.ExtendedToolInstallations;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
 import java.util.Collections;
@@ -67,6 +62,9 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
 
         JavaGitContainer slaveContainer = slaveRule.get();
 
+        SystemCredentialsProvider.getInstance().getDomainCredentialsMap()
+                .put(Domain.global(), Collections.singletonList(new UsernamePasswordCredentialsImpl(
+                        CredentialsScope.GLOBAL, "test", null, "test", "test")));
         DumbSlave agent = new DumbSlave("remote", "", "/home/test/slave", "1", Node.Mode.NORMAL, "",
                 new SSHLauncher(slaveContainer.ipBound(22), slaveContainer.port(22), "test"),
                 RetentionStrategy.INSTANCE, Collections.<NodeProperty<?>>emptyList());

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
@@ -68,7 +68,7 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
         JavaGitContainer slaveContainer = slaveRule.get();
 
         DumbSlave agent = new DumbSlave("remote", "", "/home/test/slave", "1", Node.Mode.NORMAL, "",
-                new SSHLauncher(slaveContainer.ipBound(22), slaveContainer.port(22), "test", "test", "", ""),
+                new SSHLauncher(slaveContainer.ipBound(22), slaveContainer.port(22), "test"),
                 RetentionStrategy.INSTANCE, Collections.<NodeProperty<?>>emptyList());
         jenkinsRule.jenkins.addNode(agent);
     }

--- a/maven-spy/pom.xml
+++ b/maven-spy/pom.xml
@@ -79,15 +79,9 @@
             <version>1.13.1</version>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>3.0.1</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.26</version>
             <scope>provided</scope>
         </dependency>
 
@@ -107,19 +101,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.5</version>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
                 <version>1.4</version>
@@ -135,13 +116,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,10 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.43</version>
+        <version>4.6</version>
         <relativePath />
     </parent>
+
     <artifactId>pipeline-maven-parent</artifactId>
     <version>${revision}${changelist}</version>
     <packaging>pom</packaging>
@@ -80,22 +81,24 @@
         <url>https://github.com/jenkinsci/pipeline-maven-plugin</url>
         <tag>${scmTag}</tag>
     </scm>
+
     <modules>
         <module>maven-spy</module>
         <module>jenkins-plugin</module>
     </modules>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <tagNameFormat>pipeline-maven-@{project.version}</tagNameFormat>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <properties>
         <revision>3.9.0</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.204.6</jenkins.version>
         <java.level>8</java.level>
     </properties>
 


### PR DESCRIPTION
* Use BOM for Jenkins 2.204.x + cleanup as much as possible the dependencies
* Bump Jenkins core requirement 2.138.4 -> 2.204.6
* Bump plugin parent 3.43 -> 4.6

It's a draft, I have to review more deeply the list of changes .... (it's a nightmare)

# maven-spy dependencies diff

## Compile

```
-[INFO]    com.google.code.findbugs:annotations:jar:3.0.1:compile (optional)
-[INFO]    com.google.code.findbugs:jsr305:jar:3.0.1:compile
```

## Runtime

```
```

## Provided

```
-[INFO]    args4j:args4j:jar:2.0.31:provided
-[INFO]    com.github.jnr:jffi:jar:1.2.15:provided
-[INFO]    com.github.jnr:jffi:jar:native:1.2.15:provided
-[INFO]    com.github.jnr:jnr-constants:jar:0.9.8:provided
-[INFO]    com.github.jnr:jnr-ffi:jar:2.1.4:provided
-[INFO]    com.github.jnr:jnr-posix:jar:3.0.41:provided
+[INFO]    args4j:args4j:jar:2.33:provided
+[INFO]    com.github.jnr:jffi:jar:1.2.17:provided
+[INFO]    com.github.jnr:jffi:jar:native:1.2.16:provided
+[INFO]    com.github.jnr:jnr-constants:jar:0.9.9:provided
+[INFO]    com.github.jnr:jnr-ffi:jar:2.1.8:provided
+[INFO]    com.github.jnr:jnr-posix:jar:3.0.45:provided
-[INFO]    com.github.spotbugs:spotbugs-annotations:jar:3.1.12:provided (optional)
+[INFO]    com.github.spotbugs:spotbugs-annotations:jar:3.1.11:provided (optional)
+[INFO]    com.google.code.findbugs:annotations:jar:3.0.0:provided
+[INFO]    com.google.code.findbugs:jsr305:jar:3.0.2:provided
-[INFO]    commons-beanutils:commons-beanutils:jar:1.8.3:provided
-[INFO]    commons-codec:commons-codec:jar:1.9:provided
+[INFO]    commons-beanutils:commons-beanutils:jar:1.9.3:provided
+[INFO]    commons-codec:commons-codec:jar:1.12:provided
-[INFO]    commons-io:commons-io:jar:2.4:provided
+[INFO]    commons-io:commons-io:jar:2.6:provided
-[INFO]    io.jenkins.stapler:jenkins-stapler-support:jar:1.0:provided
+[INFO]    io.jenkins.stapler:jenkins-stapler-support:jar:1.1:provided
-[INFO]    jfree:jcommon:jar:1.0.12:provided
-[INFO]    jfree:jfreechart:jar:1.0.9:provided
-[INFO]    net.i2p.crypto:eddsa:jar:0.2.0:provided
-[INFO]    net.java.dev.jna:jna:jar:4.5.2:provided
-[INFO]    net.java.sezpoz:sezpoz:jar:1.12:provided
+[INFO]    net.i2p.crypto:eddsa:jar:0.3.0:provided
+[INFO]    net.java.dev.jna:jna:jar:5.3.1:provided
+[INFO]    net.java.sezpoz:sezpoz:jar:1.13:provided
-[INFO]    org.apache.ant:ant-launcher:jar:1.9.2:provided
-[INFO]    org.apache.ant:ant:jar:1.9.2:provided
-[INFO]    org.apache.commons:commons-compress:jar:1.10:provided
+[INFO]    org.apache.ant:ant-launcher:jar:1.9.14:provided
+[INFO]    org.apache.ant:ant:jar:1.9.14:provided
+[INFO]    org.apache.commons:commons-compress:jar:1.19:provided
-[INFO]    org.codehaus.groovy:groovy-all:jar:2.4.11:provided
-[INFO]    org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:provided (optional)
+[INFO]    org.codehaus.groovy:groovy-all:jar:2.4.12:provided
+[INFO]    org.codehaus.mojo:animal-sniffer-annotations:jar:1.19:provided (optional)
+[INFO]    org.dom4j:dom4j:jar:2.1.1:provided
-[INFO]    org.jenkins-ci.dom4j:dom4j:jar:1.6.1-jenkins-4:provided
-[INFO]    org.jenkins-ci.main:cli:jar:2.138.4:provided
-[INFO]    org.jenkins-ci.main:jenkins-core:jar:2.138.4:provided
-[INFO]    org.jenkins-ci.main:remoting:jar:3.25:provided
+[INFO]    org.jenkins-ci.main:cli:jar:2.204.6:provided
+[INFO]    org.jenkins-ci.main:jenkins-core:jar:2.204.6:provided
+[INFO]    org.jenkins-ci.main:remoting:jar:3.36.1:provided
-[INFO]    org.jenkins-ci:jmdns:jar:3.4.0-jenkins-3:provided
-[INFO]    org.jenkins-ci:trilead-ssh2:jar:build-217-jenkins-11:provided
-[INFO]    org.jenkins-ci:version-number:jar:1.4:provided
+[INFO]    org.jenkins-ci:version-number:jar:1.6:provided
+[INFO]    org.jfree:jcommon:jar:1.0.23:provided
+[INFO]    org.jfree:jfreechart:jar:1.0.19:provided
+[INFO]    org.jmdns:jmdns:jar:3.5.5:provided
-[INFO]    org.jvnet.localizer:localizer:jar:1.24:provided
+[INFO]    org.jvnet.localizer:localizer:jar:1.26:provided
-[INFO]    org.jvnet.winp:winp:jar:1.26:provided
+[INFO]    org.jvnet.winp:winp:jar:1.28:provided
-[INFO]    org.kohsuke.stapler:stapler-groovy:jar:1.256:provided
-[INFO]    org.kohsuke.stapler:stapler-jelly:jar:1.256:provided
-[INFO]    org.kohsuke.stapler:stapler-jrebel:jar:1.256:provided
-[INFO]    org.kohsuke.stapler:stapler:jar:1.256:provided
-[INFO]    org.kohsuke:access-modifier-annotation:jar:1.16:provided
+[INFO]    org.kohsuke.stapler:stapler-groovy:jar:1.258:provided
+[INFO]    org.kohsuke.stapler:stapler-jelly:jar:1.258:provided
+[INFO]    org.kohsuke.stapler:stapler-jrebel:jar:1.258:provided
+[INFO]    org.kohsuke.stapler:stapler:jar:1.258:provided
+[INFO]    org.kohsuke:access-modifier-annotation:jar:1.14:provided
-[INFO]    org.kohsuke:libpam4j:jar:1.8:provided
+[INFO]    org.kohsuke:libpam4j:jar:1.11:provided
-[INFO]    org.kohsuke:trilead-putty-extension:jar:1.2:provided
-[INFO]    org.samba.jcifs:jcifs:jar:1.2.19:provided
-[INFO]    org.slf4j:slf4j-api:jar:1.7.25:provided
+[INFO]    org.samba.jcifs:jcifs:jar:1.3.17-kohsuke-1:provided
+[INFO]    org.slf4j:jcl-over-slf4j:jar:1.7.26:provided
+[INFO]    org.slf4j:log4j-over-slf4j:jar:1.7.26:provided
+[INFO]    org.slf4j:slf4j-api:jar:1.7.26:provided
```

## Test

```
-[INFO]    com.github.stephenc.findbugs:findbugs-annotations:jar:1.3.9-1:test
+[INFO]    com.shapesecurity:salvation:jar:2.7.2:test
+[INFO]    io.jenkins.lib:support-log-formatter:jar:1.0:test
+[INFO]    net.sf.jopt-simple:jopt-simple:jar:4.6:test
-[INFO]    org.apache.commons:commons-text:jar:1.3:test
+[INFO]    org.apache.commons:commons-math3:jar:3.2:test
+[INFO]    org.brotli:dec:jar:0.1.2:test
-[INFO]    org.eclipse.jetty.websocket:websocket-api:jar:9.4.10.v20180503:test
-[INFO]    org.eclipse.jetty.websocket:websocket-client:jar:9.4.10.v20180503:test
-[INFO]    org.eclipse.jetty.websocket:websocket-common:jar:9.4.10.v20180503:test
-[INFO]    org.eclipse.jetty:jetty-http:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-io:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-security:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-server:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-servlet:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-util:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-webapp:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-xml:jar:9.4.5.v20170502:test
+[INFO]    org.eclipse.jetty.websocket:websocket-api:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty.websocket:websocket-client:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty.websocket:websocket-common:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty.websocket:websocket-server:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty.websocket:websocket-servlet:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-client:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-http:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-io:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-security:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-server:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-servlet:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-util:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-webapp:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-xml:jar:9.4.31.v20200723:test
-[INFO]    org.hamcrest:hamcrest-core:jar:1.3:test
-[INFO]    org.hamcrest:hamcrest-library:jar:1.3:test
-[INFO]    org.jenkins-ci.main:jenkins-test-harness-htmlunit:jar:2.31-2:test
-[INFO]    org.jenkins-ci.main:jenkins-test-harness:jar:2.49:test
-[INFO]    org.jenkins-ci.main:jenkins-war:executable-war:2.138.4:test
+[INFO]    org.hamcrest:hamcrest-core:jar:2.2:test
+[INFO]    org.hamcrest:hamcrest-library:jar:2.2:test
+[INFO]    org.hamcrest:hamcrest:jar:2.2:test
+[INFO]    org.jenkins-ci.main:jenkins-test-harness-htmlunit:jar:3:test
+[INFO]    org.jenkins-ci.main:jenkins-test-harness:jar:2.66:test
+[INFO]    org.jenkins-ci.main:jenkins-war:executable-war:2.204.6:test
-[INFO]    org.jenkins-ci.modules:ssh-cli-auth:jar:1.4:test
-[INFO]    org.jenkins-ci.modules:sshd:jar:2.4:test
+[INFO]    org.jenkins-ci.modules:ssh-cli-auth:jar:1.7:test
+[INFO]    org.jenkins-ci.modules:sshd:jar:2.6:test
-[INFO]    org.jenkins-ci.modules:windows-slave-installer:jar:1.9.2:test
+[INFO]    org.jenkins-ci.modules:windows-slave-installer:jar:1.12:test
-[INFO]    org.jenkins-ci.ui:jquery-detached:jar:1.2:test
-[INFO]    org.netbeans.modules:org-netbeans-insane:jar:RELEASE72:test
+[INFO]    org.netbeans.modules:org-netbeans-insane:jar:RELEASE111:test
+[INFO]    org.openjdk.jmh:jmh-core:jar:1.23:test
+[INFO]    org.openjdk.jmh:jmh-generator-annprocess:jar:1.23:test
-[INFO]    org.slf4j:jcl-over-slf4j:jar:1.7.25:test
-[INFO]    org.slf4j:log4j-over-slf4j:jar:1.7.25:test
-[INFO]    org.slf4j:slf4j-jdk14:jar:1.7.25:test
+[INFO]    org.slf4j:slf4j-jdk14:jar:1.7.26:test
```

# pipeline-plugin dependencies diff

## Compile

```
+[INFO]    com.github.ben-manes.caffeine:caffeine:jar:2.8.2:compile
-[INFO]    com.google.code.findbugs:annotations:jar:2.0.0:compile (optional)
+[INFO]    com.google.code.findbugs:annotations:jar:3.0.0:compile
-[INFO]    com.google.code.gson:gson:jar:2.8.0:compile (optional)
+[INFO]    com.google.code.gson:gson:jar:2.8.2:compile
+[INFO]    com.google.errorprone:error_prone_annotations:jar:2.3.4:compile
+[INFO]    com.jayway.jsonpath:json-path:jar:2.4.0:compile
-[INFO]    com.jcraft:jsch:jar:0.1.54:compile
-[INFO]    com.jcraft:jzlib:jar:1.1.3-kohsuke-1:compile
+[INFO]    com.jcraft:jsch:jar:0.1.55:compile
-[INFO]    commons-beanutils:commons-beanutils:jar:1.8.3:compile
+[INFO]    commons-beanutils:commons-beanutils:jar:1.9.3:compile
-[INFO]    commons-codec:commons-codec:jar:1.9:compile
+[INFO]    commons-codec:commons-codec:jar:1.12:compile
-[INFO]    commons-digester:commons-digester:jar:2.1:compile
-[INFO]    commons-discovery:commons-discovery:jar:0.4:compile
-[INFO]    commons-fileupload:commons-fileupload:jar:1.3.3:compile
-[INFO]    commons-io:commons-io:jar:2.5:compile
+[INFO]    commons-io:commons-io:jar:2.6:compile
-[INFO]    commons-validator:commons-validator:jar:1.4.1:compile (optional)
+[INFO]    commons-validator:commons-validator:jar:1.6:compile
-[INFO]    javax.annotation:javax.annotation-api:jar:1.2:compile
-[INFO]    joda-time:joda-time:jar:2.9.5:compile
+[INFO]    joda-time:joda-time:jar:1.6:compile (optional)
+[INFO]    net.i2p.crypto:eddsa:jar:0.3.0:compile
-[INFO]    net.java.dev.jna:jna:jar:4.5.2:compile
+[INFO]    net.java.dev.jna:jna:jar:5.3.1:compile
-[INFO]    net.sf.ezmorph:ezmorph:jar:1.0.6:compile
+[INFO]    net.minidev:accessors-smart:jar:1.2:compile
+[INFO]    net.minidev:json-smart:jar:2.3:compile
-[INFO]    org.apache.ant:ant-launcher:jar:1.9.2:compile
-[INFO]    org.apache.ant:ant:jar:1.9.2:compile
+[INFO]    org.apache.ant:ant-launcher:jar:1.9.14:compile
+[INFO]    org.apache.ant:ant:jar:1.9.14:compile
-[INFO]    org.apache.commons:commons-lang3:jar:3.8.1:compile
+[INFO]    org.apache.commons:commons-lang3:jar:3.5:compile (optional)
-[INFO]    org.apache.maven.wagon:wagon-provider-api:jar:3.1.0:compile (optional)
+[INFO]    org.apache.maven.wagon:wagon-provider-api:jar:3.0.0:compile (optional)
-[INFO]    org.codehaus.groovy:groovy-all:jar:2.4.11:compile
+[INFO]    org.checkerframework:checker-qual:jar:3.3.0:compile
+[INFO]    org.codehaus.groovy:groovy-all:jar:2.4.12:compile
+[INFO]    org.connectbot.jbcrypt:jbcrypt:jar:1.0.0:compile
-[INFO]    org.jenkins-ci.plugins.workflow:workflow-api:jar:2.34:compile
-[INFO]    org.jenkins-ci.plugins.workflow:workflow-job:jar:2.29:compile
+[INFO]    org.jenkins-ci.plugins.workflow:workflow-api:jar:2.40:compile
+[INFO]    org.jenkins-ci.plugins.workflow:workflow-job:jar:2.39:compile
-[INFO]    org.jenkins-ci.plugins.workflow:workflow-step-api:jar:2.18:compile
+[INFO]    org.jenkins-ci.plugins.workflow:workflow-step-api:jar:2.22:compile
-[INFO]    org.jenkins-ci.plugins:branch-api:jar:2.0.20.1:compile
-[INFO]    org.jenkins-ci.plugins:cloudbees-folder:jar:6.6:compile
+[INFO]    org.jenkins-ci.plugins:branch-api:jar:2.5.6:compile
+[INFO]    org.jenkins-ci.plugins:cloudbees-folder:jar:6.14:compile
-[INFO]    org.jenkins-ci.plugins:credentials:jar:2.1.19:compile
-[INFO]    org.jenkins-ci.plugins:display-url-api:jar:1.0:compile
+[INFO]    org.jenkins-ci.plugins:credentials:jar:2.3.9:compile
+[INFO]    org.jenkins-ci.plugins:display-url-api:jar:2.3.2:compile
-[INFO]    org.jenkins-ci.plugins:jquery:jar:1.7.2-1:compile (optional)
-[INFO]    org.jenkins-ci.plugins:jsch:jar:0.1.54.1:compile
-[INFO]    org.jenkins-ci.plugins:junit-attachments:jar:1.4.2:compile (optional)
-[INFO]    org.jenkins-ci.plugins:junit:jar:1.26.1:compile (optional)
-[INFO]    org.jenkins-ci.plugins:mailer:jar:1.21:compile
+[INFO]    org.jenkins-ci.plugins:jquery:jar:1.12.4-1:compile (optional)
+[INFO]    org.jenkins-ci.plugins:jsch:jar:0.1.55.2:compile
+[INFO]    org.jenkins-ci.plugins:junit-attachments:jar:1.6:compile (optional)
+[INFO]    org.jenkins-ci.plugins:junit:jar:1.29:compile (optional)
+[INFO]    org.jenkins-ci.plugins:mailer:jar:1.32:compile
-[INFO]    org.jenkins-ci.plugins:pipeline-build-step:jar:2.7:compile (optional)
+[INFO]    org.jenkins-ci.plugins:pipeline-build-step:jar:2.12:compile (optional)
-[INFO]    org.jenkins-ci.plugins:scm-api:jar:2.2.8:compile
-[INFO]    org.jenkins-ci.plugins:script-security:jar:1.54.1:compile
-[INFO]    org.jenkins-ci.plugins:ssh-credentials:jar:1.14:compile
-[INFO]    org.jenkins-ci.plugins:structs:jar:1.17:compile
-[INFO]    org.jenkins-ci.plugins:token-macro:jar:2.0:compile
+[INFO]    org.jenkins-ci.plugins:scm-api:jar:2.6.3:compile
+[INFO]    org.jenkins-ci.plugins:script-security:jar:1.73:compile
+[INFO]    org.jenkins-ci.plugins:ssh-credentials:jar:1.18.1:compile
+[INFO]    org.jenkins-ci.plugins:structs:jar:1.20:compile
+[INFO]    org.jenkins-ci.plugins:token-macro:jar:2.12:compile
+[INFO]    org.jenkins-ci.plugins:trilead-api:jar:1.0.8:compile
-[INFO]    org.jenkins-ci:symbol-annotation:jar:1.17:compile
+[INFO]    org.jenkins-ci:symbol-annotation:jar:1.20:compile
+[INFO]    org.jenkins-ci:trilead-ssh2:jar:build-217-jenkins-21:compile
-[INFO]    org.jvnet.localizer:localizer:jar:1.24:compile
-[INFO]    org.jvnet:tiger-types:jar:2.2:compile
-[INFO]    org.kohsuke.stapler:json-lib:jar:2.4-jenkins-2:compile
-[INFO]    org.kohsuke.stapler:stapler-adjunct-jquery:jar:1.7.2-0:compile (optional)
+[INFO]    org.kohsuke.stapler:stapler-adjunct-jquery:jar:1.12.4-0:compile (optional)
-[INFO]    org.kohsuke.stapler:stapler:jar:1.256:compile
-[INFO]    org.kohsuke:asm5:jar:5.0.1:compile
-[INFO]    org.kohsuke:groovy-sandbox:jar:1.21:compile
+[INFO]    org.kohsuke:groovy-sandbox:jar:1.26:compile
+[INFO]    org.kohsuke:trilead-putty-extension:jar:1.2:compile
-[INFO]    org.ow2.asm:asm-analysis:jar:5.2:compile
-[INFO]    org.ow2.asm:asm-tree:jar:5.2:compile
-[INFO]    org.ow2.asm:asm-util:jar:5.0.3:compile
-[INFO]    org.ow2.asm:asm:jar:5.2:compile
-[INFO]    org.parboiled:parboiled-core:jar:1.1.7:compile
-[INFO]    org.parboiled:parboiled-java:jar:1.1.7:compile
+[INFO]    org.parboiled:parboiled-core:jar:1.1.8:compile
+[INFO]    org.parboiled:parboiled-java:jar:1.1.8:compile
-[INFO]    org.slf4j:slf4j-api:jar:1.7.25:compile (optional)
+[INFO]    org.slf4j:slf4j-api:jar:1.7.26:compile
```

## Runtime

```
+[INFO]    org.slf4j:jcl-over-slf4j:jar:1.7.26:runtime
```

## Provided

```
-[INFO]    args4j:args4j:jar:2.0.31:provided
+[INFO]    args4j:args4j:jar:2.33:provided
-[INFO]    com.github.jnr:jffi:jar:1.2.15:provided
-[INFO]    com.github.jnr:jffi:jar:native:1.2.15:provided
-[INFO]    com.github.jnr:jnr-constants:jar:0.9.8:provided
-[INFO]    com.github.jnr:jnr-ffi:jar:2.1.4:provided
-[INFO]    com.github.jnr:jnr-posix:jar:3.0.41:provided
+[INFO]    com.github.jnr:jffi:jar:1.2.17:provided
+[INFO]    com.github.jnr:jffi:jar:native:1.2.16:provided
+[INFO]    com.github.jnr:jnr-constants:jar:0.9.9:provided
+[INFO]    com.github.jnr:jnr-ffi:jar:2.1.8:provided
+[INFO]    com.github.jnr:jnr-posix:jar:3.0.45:provided
-[INFO]    com.github.spotbugs:spotbugs-annotations:jar:3.1.12:provided (optional)
+[INFO]    com.github.spotbugs:spotbugs-annotations:jar:3.1.11:provided (optional)
-[INFO]    com.infradna.tool:bridge-method-annotation:jar:1.17:provided
+[INFO]    com.infradna.tool:bridge-method-annotation:jar:1.13:provided
+[INFO]    com.jcraft:jzlib:jar:1.1.3-kohsuke-1:provided
+[INFO]    commons-digester:commons-digester:jar:2.1:provided
+[INFO]    commons-discovery:commons-discovery:jar:0.4:provided
+[INFO]    commons-fileupload:commons-fileupload:jar:1.3.1-jenkins-2:provided
-[INFO]    io.jenkins.stapler:jenkins-stapler-support:jar:1.0:provided
+[INFO]    io.jenkins.stapler:jenkins-stapler-support:jar:1.1:provided
+[INFO]    javax.annotation:javax.annotation-api:jar:1.2:provided
-[INFO]    jfree:jcommon:jar:1.0.12:provided
-[INFO]    jfree:jfreechart:jar:1.0.9:provided
-[INFO]    net.i2p.crypto:eddsa:jar:0.2.0:provided
-[INFO]    net.java.sezpoz:sezpoz:jar:1.12:provided
+[INFO]    net.java.sezpoz:sezpoz:jar:1.13:provided
+[INFO]    net.sf.ezmorph:ezmorph:jar:1.0.6:provided
-[INFO]    org.apache.commons:commons-compress:jar:1.10:provided
+[INFO]    org.apache.commons:commons-compress:jar:1.19:provided
-[INFO]    org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:provided (optional)
+[INFO]    org.codehaus.mojo:animal-sniffer-annotations:jar:1.19:provided (optional)
-[INFO]    org.connectbot.jbcrypt:jbcrypt:jar:1.0.0:provided
+[INFO]    org.dom4j:dom4j:jar:2.1.1:provided
-[INFO]    org.jenkins-ci.dom4j:dom4j:jar:1.6.1-jenkins-4:provided
-[INFO]    org.jenkins-ci.main:cli:jar:2.138.4:provided
-[INFO]    org.jenkins-ci.main:jenkins-core:jar:2.138.4:provided
+[INFO]    org.jenkins-ci.main:cli:jar:2.204.6:provided
+[INFO]    org.jenkins-ci.main:jenkins-core:jar:2.204.6:provided
-[INFO]    org.jenkins-ci.main:remoting:jar:3.25:provided
+[INFO]    org.jenkins-ci.main:remoting:jar:3.36.1:provided
-[INFO]    org.jenkins-ci:jmdns:jar:3.4.0-jenkins-3:provided
-[INFO]    org.jenkins-ci:trilead-ssh2:jar:build-217-jenkins-11:provided
-[INFO]    org.jenkins-ci:version-number:jar:1.4:provided
+[INFO]    org.jenkins-ci:version-number:jar:1.6:provided
+[INFO]    org.jfree:jcommon:jar:1.0.23:provided
+[INFO]    org.jfree:jfreechart:jar:1.0.19:provided
+[INFO]    org.jmdns:jmdns:jar:3.5.5:provided
+[INFO]    org.jvnet.localizer:localizer:jar:1.26:provided
-[INFO]    org.jvnet.winp:winp:jar:1.26:provided
+[INFO]    org.jvnet.winp:winp:jar:1.28:provided
+[INFO]    org.jvnet:tiger-types:jar:2.2:provided
+[INFO]    org.kohsuke.stapler:json-lib:jar:2.4-jenkins-2:provided
-[INFO]    org.kohsuke.stapler:stapler-groovy:jar:1.256:provided
-[INFO]    org.kohsuke.stapler:stapler-jelly:jar:1.256:provided
-[INFO]    org.kohsuke.stapler:stapler-jrebel:jar:1.256:provided
-[INFO]    org.kohsuke:access-modifier-annotation:jar:1.16:provided
+[INFO]    org.kohsuke.stapler:stapler-groovy:jar:1.258:provided
+[INFO]    org.kohsuke.stapler:stapler-jelly:jar:1.258:provided
+[INFO]    org.kohsuke.stapler:stapler-jrebel:jar:1.258:provided
+[INFO]    org.kohsuke.stapler:stapler:jar:1.258:provided
+[INFO]    org.kohsuke:access-modifier-annotation:jar:1.14:provided
+[INFO]    org.kohsuke:asm5:jar:5.0.1:provided
-[INFO]    org.kohsuke:libpam4j:jar:1.8:provided
+[INFO]    org.kohsuke:libpam4j:jar:1.11:provided
-[INFO]    org.kohsuke:trilead-putty-extension:jar:1.2:provided
-[INFO]    org.ow2.asm:asm-commons:jar:5.2:provided
+[INFO]    org.ow2.asm:asm-analysis:jar:5.0.3:provided
+[INFO]    org.ow2.asm:asm-commons:jar:5.0.3:provided
+[INFO]    org.ow2.asm:asm-tree:jar:5.0.3:provided
+[INFO]    org.ow2.asm:asm-util:jar:5.0.3:provided
+[INFO]    org.ow2.asm:asm:jar:5.0.3:provided
-[INFO]    org.samba.jcifs:jcifs:jar:1.2.19:provided
+[INFO]    org.samba.jcifs:jcifs:jar:1.3.17-kohsuke-1:provided
+[INFO]    org.slf4j:log4j-over-slf4j:jar:1.7.26:provided
```

## Test

```
-[INFO]    com.cloudbees:groovy-cps:jar:1.26:test
+[INFO]    com.cloudbees:groovy-cps:jar:1.32:test
-[INFO]    com.googlecode.javaewah:JavaEWAH:jar:0.7.9:test
+[INFO]    com.googlecode.javaewah:JavaEWAH:jar:1.1.6:test
+[INFO]    com.shapesecurity:salvation:jar:2.7.2:test
+[INFO]    io.jenkins.lib:support-log-formatter:jar:1.0:test
-[INFO]    junit:junit:jar:4.12:test
+[INFO]    junit:junit:jar:4.13:test
+[INFO]    net.sf.jopt-simple:jopt-simple:jar:4.6:test
-[INFO]    org.apache.commons:commons-text:jar:1.3:test
-[INFO]    org.apache.httpcomponents:fluent-hc:jar:4.5.5:test
-[INFO]    org.apache.httpcomponents:httpasyncclient-cache:jar:4.1.3:test
-[INFO]    org.apache.httpcomponents:httpasyncclient:jar:4.1.3:test
-[INFO]    org.apache.httpcomponents:httpclient-cache:jar:4.5.5:test
-[INFO]    org.apache.httpcomponents:httpclient:jar:4.5.5:test
-[INFO]    org.apache.httpcomponents:httpcore-nio:jar:4.4.6:test
-[INFO]    org.apache.httpcomponents:httpcore:jar:4.4.9:test
-[INFO]    org.apache.httpcomponents:httpmime:jar:4.5.5:test
+[INFO]    org.apache.commons:commons-math3:jar:3.2:test
+[INFO]    org.apache.httpcomponents:fluent-hc:jar:4.5.10:test
+[INFO]    org.apache.httpcomponents:httpasyncclient-cache:jar:4.1.4:test
+[INFO]    org.apache.httpcomponents:httpasyncclient:jar:4.1.4:test
+[INFO]    org.apache.httpcomponents:httpclient-cache:jar:4.5.10:test
+[INFO]    org.apache.httpcomponents:httpclient:jar:4.5.10:test
+[INFO]    org.apache.httpcomponents:httpcore-nio:jar:4.4.10:test
+[INFO]    org.apache.httpcomponents:httpcore:jar:4.4.12:test
+[INFO]    org.apache.httpcomponents:httpmime:jar:4.5.10:test
+[INFO]    org.bouncycastle:bcpg-jdk15on:jar:1.64:test
+[INFO]    org.bouncycastle:bcpkix-jdk15on:jar:1.64:test
+[INFO]    org.bouncycastle:bcprov-jdk15on:jar:1.64:test
+[INFO]    org.brotli:dec:jar:0.1.2:test
-[INFO]    org.eclipse.jetty.websocket:websocket-api:jar:9.4.10.v20180503:test
-[INFO]    org.eclipse.jetty.websocket:websocket-client:jar:9.4.10.v20180503:test
-[INFO]    org.eclipse.jetty.websocket:websocket-common:jar:9.4.10.v20180503:test
-[INFO]    org.eclipse.jetty:jetty-http:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-io:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-security:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-server:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-servlet:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-util:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-webapp:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jetty:jetty-xml:jar:9.4.5.v20170502:test
-[INFO]    org.eclipse.jgit:org.eclipse.jgit.http.apache:jar:4.5.4.201711221230-r:test
-[INFO]    org.eclipse.jgit:org.eclipse.jgit.http.server:jar:4.5.4.201711221230-r:test
-[INFO]    org.eclipse.jgit:org.eclipse.jgit:jar:4.5.4.201711221230-r:test
+[INFO]    org.eclipse.jetty.websocket:websocket-api:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty.websocket:websocket-client:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty.websocket:websocket-common:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty.websocket:websocket-server:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty.websocket:websocket-servlet:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-client:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-http:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-io:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-security:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-server:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-servlet:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-util:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-webapp:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jetty:jetty-xml:jar:9.4.31.v20200723:test
+[INFO]    org.eclipse.jgit:org.eclipse.jgit.http.apache:jar:5.6.1.202002131546-r:test
+[INFO]    org.eclipse.jgit:org.eclipse.jgit.http.server:jar:5.6.1.202002131546-r:test
+[INFO]    org.eclipse.jgit:org.eclipse.jgit.lfs:jar:5.6.1.202002131546-r:test
+[INFO]    org.eclipse.jgit:org.eclipse.jgit:jar:5.6.1.202002131546-r:test
-[INFO]    org.hamcrest:hamcrest-core:jar:1.3:test
-[INFO]    org.hamcrest:hamcrest-library:jar:1.3:test
+[INFO]    org.hamcrest:hamcrest-core:jar:2.2:test
+[INFO]    org.hamcrest:hamcrest-library:jar:2.2:test
+[INFO]    org.hamcrest:hamcrest:jar:2.2:test
-[INFO]    org.jboss.marshalling:jboss-marshalling-river:jar:1.4.12.jenkins-3:test
-[INFO]    org.jboss.marshalling:jboss-marshalling:jar:1.4.12.jenkins-3:test
+[INFO]    org.jboss.marshalling:jboss-marshalling-river:jar:2.0.6.Final:test
+[INFO]    org.jboss.marshalling:jboss-marshalling:jar:2.0.6.Final:test
-[INFO]    org.jenkins-ci.main:jenkins-test-harness-htmlunit:jar:2.31-2:test
+[INFO]    org.jenkins-ci.main:jenkins-test-harness-htmlunit:jar:3:test
-[INFO]    org.jenkins-ci.main:jenkins-test-harness:jar:2.49:test
-[INFO]    org.jenkins-ci.main:jenkins-war:executable-war:2.138.4:test
+[INFO]    org.jenkins-ci.main:jenkins-test-harness:jar:2.66:test
+[INFO]    org.jenkins-ci.main:jenkins-war:executable-war:2.204.6:test
-[INFO]    org.jenkins-ci.modules:ssh-cli-auth:jar:1.4:test
-[INFO]    org.jenkins-ci.modules:sshd:jar:2.4:test
+[INFO]    org.jenkins-ci.modules:ssh-cli-auth:jar:1.7:test
+[INFO]    org.jenkins-ci.modules:sshd:jar:2.6:test
-[INFO]    org.jenkins-ci.modules:windows-slave-installer:jar:1.9.2:test
+[INFO]    org.jenkins-ci.modules:windows-slave-installer:jar:1.12:test
-[INFO]    org.jenkins-ci.plugins.workflow:workflow-basic-steps:jar:2.12:test
-[INFO]    org.jenkins-ci.plugins.workflow:workflow-cps:jar:2.61.3:test
-[INFO]    org.jenkins-ci.plugins.workflow:workflow-durable-task-step:jar:2.26:test
+[INFO]    org.jenkins-ci.plugins.workflow:workflow-basic-steps:jar:2.20:test
+[INFO]    org.jenkins-ci.plugins.workflow:workflow-cps:jar:2.80:test
+[INFO]    org.jenkins-ci.plugins.workflow:workflow-durable-task-step:jar:2.35:test
-[INFO]    org.jenkins-ci.plugins.workflow:workflow-scm-step:jar:2.7:test
-[INFO]    org.jenkins-ci.plugins.workflow:workflow-support:jar:2.22:test
-[INFO]    org.jenkins-ci.plugins.workflow:workflow-support:jar:tests:2.22:test
+[INFO]    org.jenkins-ci.plugins.workflow:workflow-scm-step:jar:2.11:test
+[INFO]    org.jenkins-ci.plugins.workflow:workflow-support:jar:3.5:test
+[INFO]    org.jenkins-ci.plugins.workflow:workflow-support:jar:tests:3.5:test
-[INFO]    org.jenkins-ci.plugins:apache-httpcomponents-client-4-api:jar:4.5.5-3.0:test
+[INFO]    org.jenkins-ci.plugins:apache-httpcomponents-client-4-api:jar:4.5.10-2.0:test
-[INFO]    org.jenkins-ci.plugins:durable-task:jar:1.26:test
-[INFO]    org.jenkins-ci.plugins:git-client:jar:2.7.0:test
-[INFO]    org.jenkins-ci.plugins:git:jar:3.9.2:test
-[INFO]    org.jenkins-ci.plugins:git:jar:tests:3.9.2:test
+[INFO]    org.jenkins-ci.plugins:durable-task:jar:1.34:test
+[INFO]    org.jenkins-ci.plugins:git-client:jar:3.2.1:test
+[INFO]    org.jenkins-ci.plugins:git:jar:4.2.2:test
+[INFO]    org.jenkins-ci.plugins:git:jar:tests:4.2.2:test
-[INFO]    org.jenkins-ci.plugins:scm-api:jar:tests:2.2.8:test
-[INFO]    org.jenkins-ci.plugins:ssh-slaves:jar:1.29.4:test
+[INFO]    org.jenkins-ci.plugins:scm-api:jar:tests:2.6.3:test
+[INFO]    org.jenkins-ci.plugins:ssh-slaves:jar:1.31.2:test
-[INFO]    org.jenkins-ci.ui:ace-editor:jar:1.0.1:test
+[INFO]    org.jenkins-ci.ui:ace-editor:jar:1.1:test
-[INFO]    org.netbeans.modules:org-netbeans-insane:jar:RELEASE72:test
+[INFO]    org.netbeans.modules:org-netbeans-insane:jar:RELEASE111:test
+[INFO]    org.openjdk.jmh:jmh-core:jar:1.23:test
+[INFO]    org.openjdk.jmh:jmh-generator-annprocess:jar:1.23:test
-[INFO]    org.slf4j:jcl-over-slf4j:jar:1.7.25:test
-[INFO]    org.slf4j:log4j-over-slf4j:jar:1.7.25:test
-[INFO]    org.slf4j:slf4j-jdk14:jar:1.7.25:test
+[INFO]    org.slf4j:slf4j-jdk14:jar:1.7.26:test
```