### PR TITLE
Let the plugins site show past security issues

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,19 +37,6 @@ The **<<feature-default-configuration>> can be defined globally or at the folder
 
 This plugin allows transitioning smoothly from the legacy https://plugins.jenkins.io/maven-plugin/[Maven Integration] job type by allowing to reuse **<<feature-maven-integration-global-settings>>** and by proposing the **<<feature-trigger-downstream>>**.
 
-[WARNING]
-.Security issues
-====
-
-Older versions of this plugin may not be safe to use.
-Please review the following warnings before using an older version:
-
-* https://jenkins.io/security/advisory/2017-03-09/[Arbitrary files from Jenkins master available in Pipeline by using the withMaven step]
-* https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1409[XML External Entity processing vulnerability]
-* https://jenkins.io/security/advisory/2020-08-12/#SECURITY-1794%20(2)[CSRF vulnerability and missing permission check allow capturing credentials]
-* https://jenkins.io/security/advisory/2020-08-12/#SECURITY-1794%20(1)[Missing permission check allows enumerating credentials IDs]
-====
-
 toc::[]
 
 [#installation]


### PR DESCRIPTION
The plugins site already shows past security issues in the  right hand pane.  I don't think it helps readers to show the past security issues in two locations.

The git client plugin uses an asciidoc README and the security issues look like this:

![screencapture-plugins-jenkins-io-git-client-2020-09-01-09_23_01-edit](https://user-images.githubusercontent.com/156685/91872277-edc84100-ec34-11ea-91d9-dfb9e21578e2.png)
