### PR TITLE
[fix] The URL in the plugin pom was still referencing confluence

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -40,7 +40,6 @@
     This plugin provides integration with Pipeline, configures maven environment to use within a pipeline job by calling sh mvn or bat mvn.
     The selected maven installation will be configured and prepended to the path.
   </description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Maven+Plugin</url>
 
   <developers>
     <developer>


### PR DESCRIPTION
It overrides the update we did in the parent pom and prevents to deploy the new documentation on plugins.jenkins.io