### PR TITLE
[fix] Enforce the url in the submodules

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -40,6 +40,7 @@
     This plugin provides integration with Pipeline, configures maven environment to use within a pipeline job by calling sh mvn or bat mvn.
     The selected maven installation will be configured and prepended to the path.
   </description>
+  <url>https://github.com/jenkinsci/pipeline-maven-plugin/blob/master/README.adoc</url>
 
   <developers>
     <developer>

--- a/maven-spy/pom.xml
+++ b/maven-spy/pom.xml
@@ -39,6 +39,7 @@
         Maven Spy injected with "-Dmaven.ext.class.path" to generatesMaven execution reports that are consumed by the
         Jenkins Pipeline withMaven(){} step.
     </description>
+    <url>https://github.com/jenkinsci/pipeline-maven-plugin/blob/master/README.adoc</url>
 
     <developers>
         <developer>


### PR DESCRIPTION
Otherwise the plugin get this invalid URL for the doc : https://github.com/jenkinsci/pipeline-maven-plugin/blob/master/README.adoc/pipeline-maven