### PR TITLE
bits.netbeans.org Maven repo is dead

### DIFF
--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_nbm_base_project/pom.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_nbm_base_project/pom.xml
@@ -32,21 +32,11 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>netbeans</id>
-            <name>Repository hosting NetBeans modules</name>
-            <url>https://bits.netbeans.org/nexus/content/groups/netbeans</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
     <dependencies>
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-api-annotations-common</artifactId>
-            <version>RELEASE82</version>
+            <version>RELEASE121</version>
         </dependency>
         <dependency>
             <groupId>com.netbeans.sample</groupId>

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_nbm_dependency_project/pom.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_nbm_dependency_project/pom.xml
@@ -32,21 +32,11 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>netbeans</id>
-            <name>Repository hosting NetBeans modules</name>
-            <url>https://bits.netbeans.org/nexus/content/groups/netbeans</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
     <dependencies>
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-api-annotations-common</artifactId>
-            <version>RELEASE82</version>
+            <version>RELEASE121</version>
         </dependency>
     </dependencies>
     <properties>


### PR DESCRIPTION
Amends #156: after the transition to Apache NetBeans, the old Maven repository is dead and artifacts are not publicly available in general. (Some have been mirrored to the Jenkins Artifactory but better not rely on that!) Should fix the test failure noted in https://github.com/jenkinsci/pipeline-maven-plugin/pull/290#issuecomment-707549911. CC @JaroslavTulach
