### PR TITLE
Allow to silent traceability information

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -107,6 +107,7 @@ For example, you might end up having builds incorrectly succeed, just because yo
 By using this option, Jenkins will tell Maven to use a custom path for the build as the local Maven repository by using `-Dmaven.repo.local` +
 If specified as a relative path then this value will be resolved against the workspace root and not the current working directory. +
 ie. `$WORKSPACE/.repository` if `.repository` value is specified.
+* *Maven Traceability* (`traceability`): adds additional output to the maven wrapper script. Maven is executed with parameter `--show-version` and the start of the wrapper script is indicated by `----- withMaven Wrapper script -----`. Defaults to `true`.
 
 IMPORTANT: `mavenSettingsConfig` and `globalMavenSettingsConfig` use the *ID*, not the *name*, of the Maven settings file (resp Maven Global Settings file).
 

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty.java
@@ -29,7 +29,7 @@ public class MavenConfigFolderOverrideProperty extends AbstractFolderProperty<Ab
     private GlobalSettingsProvider globalSettings;
 
     /**
-     * Defines if the instance level configuration should be overriden by this folder one
+     * Defines if the instance level configuration should be overridden by this folder one
      */
     private boolean override;
 

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStep.java
@@ -78,6 +78,7 @@ public class WithMavenStep extends Step {
     private String mavenLocalRepo = "";
     private List<MavenPublisher> options = new ArrayList<>();
     private MavenPublisherStrategy publisherStrategy = MavenPublisherStrategy.IMPLICIT;
+    private boolean traceability = true;
 
     @DataBoundConstructor
     public WithMavenStep() {
@@ -171,6 +172,15 @@ public class WithMavenStep extends Step {
     @DataBoundSetter
     public void setPublisherStrategy(MavenPublisherStrategy publisherStrategy) {
         this.publisherStrategy = publisherStrategy;
+    }
+
+    public boolean isTraceability() {
+        return traceability;
+    }
+
+    @DataBoundSetter
+    public void setTraceability(final boolean traceability) {
+        this.traceability = traceability;
     }
 
     public List<MavenPublisher> getOptions() {

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -75,6 +75,7 @@ import org.jenkinsci.plugins.configfiles.maven.security.ServerCredentialMapping;
 import org.jenkinsci.plugins.pipeline.maven.console.MaskPasswordsConsoleLogFilter;
 import org.jenkinsci.plugins.pipeline.maven.console.MavenColorizerConsoleLogFilter;
 import org.jenkinsci.plugins.pipeline.maven.util.FileUtils;
+import org.jenkinsci.plugins.pipeline.maven.util.TaskListenerTraceWrapper;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
@@ -89,7 +90,6 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintStream;
 import java.net.URL;
 import java.security.CodeSource;
 import java.util.ArrayList;
@@ -140,7 +140,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
      */
     private boolean withContainer;
 
-    private transient PrintStream console;
+    private transient TaskListenerTraceWrapper console;
 
     WithMavenStepExecution2(StepContext context, WithMavenStep step) throws Exception {
         super(context);
@@ -160,7 +160,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
 
     protected boolean doStart() throws Exception {
         envOverride = new EnvVars();
-        console = listener.getLogger();
+        console = new TaskListenerTraceWrapper(listener, step.isTraceability());
 
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.log(Level.FINE, "Maven: {0}", step.getMaven());
@@ -176,9 +176,9 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             LOGGER.log(Level.FINE, "ws: {0}", ws.getRemote()); // JENKINS-47804
         }
 
-        listener.getLogger().println("[withMaven] Options: " + step.getOptions());
+        console.trace("[withMaven] Options: " + step.getOptions());
         ExtensionList<MavenPublisher> availableMavenPublishers = Jenkins.get().getExtensionList(MavenPublisher.class);
-        listener.getLogger().println("[withMaven] Available options: " + availableMavenPublishers.stream().map(
+        console.trace("[withMaven] Available options: " + availableMavenPublishers.stream().map(
                 MavenPublisher::toString).collect(Collectors.joining(",")));
 
         getComputer();
@@ -186,9 +186,9 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         withContainer = detectWithContainer();
 
         if (withContainer) {
-            listener.getLogger().print("[withMaven] IMPORTANT \"withMaven(){...}\" step running within a Docker container. See " );
-            listener.hyperlink("https://github.com/jenkinsci/pipeline-maven-plugin/FAQ.adoc", "Pipeline Maven Plugin FAQ");
-            listener.getLogger().println(" in case of problem.");
+            console.trace("[withMaven] IMPORTANT \"withMaven(){...}\" step running within a Docker container. See " );
+            console.traceHyperlink("https://github.com/jenkinsci/pipeline-maven-plugin/FAQ.adoc", "Pipeline Maven Plugin FAQ");
+            console.trace(" in case of problem.");
         }
 
         setupJDK();
@@ -264,7 +264,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
     private void setupJDK() throws AbortException, IOException, InterruptedException {
         String jdkInstallationName = step.getJdk();
         if (StringUtils.isEmpty(jdkInstallationName)) {
-            console.println("[withMaven] using JDK installation provided by the build agent");
+            console.trace("[withMaven] using JDK installation provided by the build agent");
             return;
         }
 
@@ -277,7 +277,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             return;
         }
 
-        console.println("[withMaven] using JDK installation " + jdkInstallationName);
+        console.trace("[withMaven] using JDK installation " + jdkInstallationName);
 
         JDK jdk = Jenkins.get().getJDK(jdkInstallationName);
         if (jdk == null) {
@@ -340,9 +340,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         boolean isUnix = Boolean.TRUE.equals(getComputer().isUnix());
         StringBuilder mavenConfig = new StringBuilder();
         mavenConfig.append("--batch-mode ");
-        if (step.isTraceability()) {
-            mavenConfig.append("--show-version ");
-        }
+        ifTraceabilityEnabled(() -> mavenConfig.append("--show-version "));
         if (StringUtils.isNotEmpty(settingsFilePath)) {
             // JENKINS-57324 escape '%' as '%%'. See https://en.wikibooks.org/wiki/Windows_Batch_Scripting#Quoting_and_escaping
         	if (!isUnix) settingsFilePath=settingsFilePath.replace("%", "%%");
@@ -535,7 +533,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             }
         }
 
-        console.println(consoleMessage.toString());
+        console.trace(consoleMessage.toString());
 
         LOGGER.log(Level.FINE, "Found exec for maven on: {0}", mvnExecPath);
         return mvnExecPath;
@@ -560,7 +558,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         }
         mavenInstallation = mavenInstallation.forNode(node, listener).forEnvironment(env);
         mavenInstallation.buildEnvVars(envOverride);
-        console.println("[withMaven] using Maven installation '" + mavenInstallation.getName() + "'");
+        console.trace("[withMaven] using Maven installation '" + mavenInstallation.getName() + "'");
 
         return mavenInstallation.getExecutable(launcher);
     }
@@ -607,17 +605,13 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         if (isUnix) { // Linux, Unix, MacOSX
             String lineSep = "\n";
             script.append("#!/bin/sh -e").append(lineSep);
-            if (step.isTraceability()) {
-                script.append("echo ----- withMaven Wrapper script -----").append(lineSep);
-            }
+            ifTraceabilityEnabled(() -> script.append("echo ----- withMaven Wrapper script -----").append(lineSep));
             script.append("\"").append(mvnExec.getRemote()).append("\" ").append(mavenConfig).append(" \"$@\"").append(lineSep);
 
         } else { // Windows
             String lineSep = "\r\n";
             script.append("@echo off").append(lineSep);
-            if (step.isTraceability()) {
-                script.append("echo ----- withMaven Wrapper script -----").append(lineSep);
-            }
+            ifTraceabilityEnabled(() -> script.append("echo ----- withMaven Wrapper script -----").append(lineSep));
             // JENKINS-57324 escape '%' as '%%'. See https://en.wikibooks.org/wiki/Windows_Batch_Scripting#Quoting_and_escaping
             mavenConfig = mavenConfig.replace("%", "%%");
             script.append("\"").append(mvnExec.getRemote()).append("\" ").append(mavenConfig).append(" %*").append(lineSep);
@@ -691,7 +685,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         // Settings from Config File Provider
         if (StringUtils.isNotEmpty(step.getMavenSettingsConfig())) {
             if (LOGGER.isLoggable(Level.FINE)) {
-                console.format("[withMaven] using Maven settings provided by the Jenkins Managed Configuration File '%s' %n", step.getMavenSettingsConfig());
+                console.formatTrace("[withMaven] using Maven settings provided by the Jenkins Managed Configuration File '%s' %n", step.getMavenSettingsConfig());
             }
             settingsFromConfig(step.getMavenSettingsConfig(), settingsDest, credentials);
             envOverride.put("MVN_SETTINGS", settingsDest.getRemote());
@@ -706,7 +700,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             if ((settings = ws.child(settingsPath)).exists()) {
                 // settings file residing on the agent
                 if (LOGGER.isLoggable(Level.FINE)) {
-                    console.format("[withMaven] using Maven settings provided on the build agent '%s' %n", settingsPath);
+                    console.formatTrace("[withMaven] using Maven settings provided on the build agent '%s' %n", settingsPath);
                     LOGGER.log(Level.FINE, "Copying maven settings file from build agent {0} to {1}", new Object[] { settings, settingsDest });
                 }
                 settings.copyTo(settingsDest);
@@ -725,7 +719,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         if (overrideProperty != null && overrideProperty.getSettings() != null) {
             // Settings overridden by a folder property
             if(LOGGER.isLoggable(Level.FINE)) {
-                mavenSettingsLog.append("[withMaven] using overriden Maven settings by folder '").append(overrideProperty.getOwner().getDisplayName()).append("'. ");
+                mavenSettingsLog.append("[withMaven] using overridden Maven settings by folder '").append(overrideProperty.getOwner().getDisplayName()).append("'. ");
             }
             settingsProvider = overrideProperty.getSettings();
         } else {
@@ -740,7 +734,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             MvnSettingsProvider mvnSettingsProvider = (MvnSettingsProvider) settingsProvider;
             if (LOGGER.isLoggable(Level.FINE)) {
                 mavenSettingsLog.append("Config File Provider maven settings file '").append(mvnSettingsProvider.getSettingsConfigId()).append("'");
-                console.println(mavenSettingsLog);
+                console.trace(mavenSettingsLog);
             }
             settingsFromConfig(mvnSettingsProvider.getSettingsConfigId(), settingsDest, credentials);
             envOverride.put("MVN_SETTINGS", settingsDest.getRemote());
@@ -776,7 +770,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
                 console.println(mavenSettingsLog);
             }
         } else {
-            console.println("[withMaven] Ignore unsupported Maven SettingsProvider " + settingsProvider);
+            console.trace("[withMaven] Ignore unsupported Maven SettingsProvider " + settingsProvider);
         }
 
         return null;
@@ -816,7 +810,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         // Global settings from Config File Provider
         if (StringUtils.isNotEmpty(step.getGlobalMavenSettingsConfig())) {
             if (LOGGER.isLoggable(Level.FINE)) {
-                console.format("[withMaven] using Maven global settings provided by the Jenkins Managed Configuration File '%s' %n", step.getGlobalMavenSettingsConfig());
+                console.formatTrace("[withMaven] using Maven global settings provided by the Jenkins Managed Configuration File '%s' %n", step.getGlobalMavenSettingsConfig());
             }
             globalSettingsFromConfig(step.getGlobalMavenSettingsConfig(), settingsDest, credentials);
             envOverride.put("GLOBAL_MVN_SETTINGS", settingsDest.getRemote());
@@ -830,7 +824,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             if ((settings = ws.child(settingsPath)).exists()) {
                 // Global settings file residing on the agent
                 if (LOGGER.isLoggable(Level.FINE)) {
-                    console.format("[withMaven] using Maven global settings provided on the build agent '%s' %n", settingsPath);
+                    console.formatTrace("[withMaven] using Maven global settings provided on the build agent '%s' %n", settingsPath);
                     LOGGER.log(Level.FINE, "Copying maven global settings file from build agent {0} to {1}", new Object[] { settings, settingsDest });
                 }
                 settings.copyTo(settingsDest);
@@ -853,9 +847,9 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             // Settings provided by the global maven configuration
             globalSettingsProvider = GlobalMavenConfig.get().getGlobalSettingsProvider();
         } else {
-            // Settings overriden by a folder property
+            // Settings overridden by a folder property
             if (LOGGER.isLoggable(Level.FINE)) {
-                mavenSettingsLog.append("[withMaven] using overriden Maven global settings by folder '").append(overrideProperty.getOwner().getDisplayName()).append("'. ");
+                mavenSettingsLog.append("[withMaven] using overridden Maven global settings by folder '").append(overrideProperty.getOwner().getDisplayName()).append("'. ");
             }
             globalSettingsProvider = overrideProperty.getGlobalSettings();
         }
@@ -868,7 +862,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             globalSettingsFromConfig(mvnGlobalSettingsProvider.getSettingsConfigId(), settingsDest, credentials);
             envOverride.put("GLOBAL_MVN_SETTINGS", settingsDest.getRemote());
             if (LOGGER.isLoggable(Level.FINE)) {
-                console.println(mavenSettingsLog);
+                console.trace(mavenSettingsLog);
             }
             return settingsDest.getRemote();
         } else if (globalSettingsProvider instanceof FilePathGlobalSettingsProvider) {
@@ -903,7 +897,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
                 console.println(mavenSettingsLog);
             }
         } else {
-            console.println("[withMaven] Ignore unsupported Maven GlobalSettingsProvider " + globalSettingsProvider);
+            console.trace("[withMaven] Ignore unsupported Maven GlobalSettingsProvider " + globalSettingsProvider);
         }
 
         return null;
@@ -943,14 +937,14 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             if (resolvedCredentialsByMavenServerId.isEmpty()) {
                 mavenSettingsFileContent = mavenSettingsConfig.content;
                 if (LOGGER.isLoggable(Level.FINE)) {
-                    console.println("[withMaven] using Maven settings.xml '" + mavenSettingsConfig.id + "' with NO Maven servers credentials provided by Jenkins");
+                    console.trace("[withMaven] using Maven settings.xml '" + mavenSettingsConfig.id + "' with NO Maven servers credentials provided by Jenkins");
                 }
             } else {
                 credentials.addAll(resolvedCredentialsByMavenServerId.values());
                 List<String> tempFiles = new ArrayList<>();
                 mavenSettingsFileContent = CredentialsHelper.fillAuthentication(mavenSettingsConfig.content, mavenSettingsConfig.isReplaceAll, resolvedCredentialsByMavenServerId, tempBinDir, tempFiles);
                 if (LOGGER.isLoggable(Level.FINE)) {
-                    console.println("[withMaven] using Maven settings.xml '" + mavenSettingsConfig.id + "' with Maven servers credentials provided by Jenkins " +
+                    console.trace("[withMaven] using Maven settings.xml '" + mavenSettingsConfig.id + "' with Maven servers credentials provided by Jenkins " +
                             "(replaceAll: " + mavenSettingsConfig.isReplaceAll + "): " +
                             resolvedCredentialsByMavenServerId.entrySet().stream().map(new MavenServerToCredentialsMappingToStringFunction()).sorted().collect(Collectors.joining(", ")));
                 }
@@ -996,14 +990,14 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             String mavenGlobalSettingsFileContent;
             if (resolvedCredentialsByMavenServerId.isEmpty()) {
                 mavenGlobalSettingsFileContent = mavenGlobalSettingsConfig.content;
-                console.println("[withMaven] using Maven global settings.xml '" + mavenGlobalSettingsConfig.id + "' with NO Maven servers credentials provided by Jenkins");
+                console.trace("[withMaven] using Maven global settings.xml '" + mavenGlobalSettingsConfig.id + "' with NO Maven servers credentials provided by Jenkins");
 
             } else {
                 credentials.addAll(resolvedCredentialsByMavenServerId.values());
 
                 List<String> tempFiles = new ArrayList<>();
                 mavenGlobalSettingsFileContent = CredentialsHelper.fillAuthentication(mavenGlobalSettingsConfig.content, mavenGlobalSettingsConfig.isReplaceAll, resolvedCredentialsByMavenServerId, tempBinDir, tempFiles);
-                console.println("[withMaven] using Maven global settings.xml '" + mavenGlobalSettingsConfig.id + "' with Maven servers credentials provided by Jenkins " +
+                console.trace("[withMaven] using Maven global settings.xml '" + mavenGlobalSettingsConfig.id + "' with Maven servers credentials provided by Jenkins " +
                         "(replaceAll: " + mavenGlobalSettingsConfig.isReplaceAll + "): " +
                         resolvedCredentialsByMavenServerId.entrySet().stream().map(new MavenServerToCredentialsMappingToStringFunction()).sorted().collect(Collectors.joining(", ")));
 
@@ -1054,6 +1048,12 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
                     unresolvedServerCredentialsMappings.stream().map(new ServerCredentialMappingToStringFunction()).collect(Collectors.joining(", ")));
         }
         return mavenServerIdToCredentials;
+    }
+
+    private void ifTraceabilityEnabled(Runnable runnable) {
+        if (step.isTraceability()) {
+            runnable.run();
+        }
     }
 
     /**

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/TaskListenerTraceWrapper.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/TaskListenerTraceWrapper.java
@@ -1,0 +1,95 @@
+package org.jenkinsci.plugins.pipeline.maven.util;
+
+import hudson.model.TaskListener;
+import java.io.IOException;
+import java.io.PrintStream;
+
+/**
+ * This class provides methods which wrap the original {@link TaskListener}.
+ * All {@code trace*} methods check if traceability is enabled before doing anything.
+ */
+public class TaskListenerTraceWrapper {
+
+  private final TaskListener taskListener;
+  private final boolean traceability;
+  private final PrintStream console;
+
+
+  /**
+   * Wrap the given TaskListener.
+   *
+   * @param taskListener the wrapped listener
+   * @param traceability the boolean flag for traceability
+   */
+  public TaskListenerTraceWrapper(final TaskListener taskListener, final boolean traceability) {
+    this.taskListener = taskListener;
+    this.traceability = traceability;
+    this.console = taskListener.getLogger();
+  }
+
+
+  /**
+   * Prints the given String to the underlying TaskListener if traceability is enabled.
+   * @param s the string to print
+   */
+  public void trace(final String s) {
+    if (traceability) {
+      console.println(s);
+    }
+  }
+
+  /**
+   * Prints the given Object to the underlying TaskListener if traceability is enabled.
+   * @param o the object to print
+   */
+  public void trace(final Object o) {
+    if (traceability) {
+      console.println(o);
+    }
+  }
+
+  /**
+   * Wraps the {@link TaskListener#hyperlink(String, String)} function. If traceability is disabled do nothing.
+   * @param url {@link TaskListener#hyperlink}
+   * @param text {@link TaskListener#hyperlink}
+   */
+
+  public void traceHyperlink(final String url, final String text) throws IOException {
+    if (traceability) {
+      taskListener.hyperlink(url, text);
+    }
+  }
+
+  /**
+   * Wraps {@link TaskListener#getLogger()} println calls.
+   * @param s
+   */
+  public void println(final CharSequence s) {
+      console.println(s);
+  }
+
+  /**
+   * Wraps {@link TaskListener#getLogger()} format calls.
+   * @param format
+   * @param args
+   * @return
+   */
+  public PrintStream format(final String format, Object ... args ) {
+      return console.format(format, args);
+  }
+
+
+  /**
+   * Wraps {@link TaskListener#getLogger()} format calls.
+   * If traceability is disabled do nothing.
+   * @param format
+   * @param args
+   * @return
+   */
+  public PrintStream formatTrace(final String format,Object ... args ) {
+    if (traceability) {
+      return console.format(format, args);
+    }
+    return console;
+  }
+}

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/config.jelly
@@ -53,6 +53,10 @@ THE SOFTWARE.
         <f:textbox/>
     </f:entry>
 
+    <f:entry title="${%Maven Traceability}" field="traceability">
+        <f:checkbox default="true"/>
+    </f:entry>
+
     <f:entry title="${%Maven Local Repository}" field="mavenLocalRepo">
         <f:textbox/>
     </f:entry>

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-traceability.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/WithMavenStep/help-traceability.html
@@ -1,0 +1,5 @@
+<div>
+    Should additional information be added to the script execution.
+    <p>
+    <strong>Note</strong>: This option adds <code>--show-version</code> to the maven execution and marks the beginning of the maven wrapper script with  <code>----- withMaven Wrapper script -----</code>.
+</div>

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepOnMasterTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepOnMasterTest.java
@@ -684,7 +684,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
             pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
             WorkflowRun build = jenkinsRule.assertBuildStatus(Result.SUCCESS, pipeline.scheduleBuild2(0));
             jenkinsRule.assertLogContains(
-                "[withMaven] using overriden Maven global settings by folder 'folder'. Config File Provider maven global settings file 'maven-global-config-test-folder'",
+                "[withMaven] using overridden Maven global settings by folder 'folder'. Config File Provider maven global settings file 'maven-global-config-test-folder'",
                 build);
             jenkinsRule.assertLogContains("<id>id-global-settings-test-from-config-file-provider-on-a-folder</id>", build);
         } finally {
@@ -921,7 +921,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
             WorkflowJob pipeline = folder.createProject(WorkflowJob.class, "build-on-master-with-maven-settings-defined-in-jenkins-global-config-with-config-file-provider");
             pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
             WorkflowRun build = jenkinsRule.assertBuildStatus(Result.SUCCESS, pipeline.scheduleBuild2(0));
-            jenkinsRule.assertLogContains("[withMaven] using overriden Maven settings by folder 'folder'. Config File Provider maven settings file 'maven-config-test-folder'",
+            jenkinsRule.assertLogContains("[withMaven] using overridden Maven settings by folder 'folder'. Config File Provider maven settings file 'maven-config-test-folder'",
                 build);
             jenkinsRule.assertLogContains("<id>id-settings-test-through-config-file-provider-on-a-folder</id>", build);
         } finally {


### PR DESCRIPTION
Adds a verbose parameter to the step execution, defaults to true, so the initial behaviour is not changed.
Can turn of the version info and the `----- withMaven Wrapper script -----` line

 Fixes https://issues.jenkins.io/browse/JENKINS-58425 