### PR TITLE
Add the missing agent-prepare-integration goals to the jacoco publisher list

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JacocoReportPublisher.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JacocoReportPublisher.java
@@ -127,6 +127,8 @@ public class JacocoReportPublisher extends MavenPublisher {
         Launcher launcher = context.get(Launcher.class);
 
         List<Element> jacocoPrepareAgentEvents = XmlUtils.getExecutionEventsByPlugin(mavenSpyLogsElt, "org.jacoco", "jacoco-maven-plugin", "prepare-agent", "MojoSucceeded", "MojoFailed");
+        List<Element> jacocoPrepareAgentEvents2 = XmlUtils.getExecutionEventsByPlugin(mavenSpyLogsElt, "org.jacoco", "jacoco-maven-plugin", "prepare-agent-integration", "MojoSucceeded", "MojoFailed");
+        jacocoPrepareAgentEvents.addAll(jacocoPrepareAgentEvents2); // add integration tests agents
 
         if (jacocoPrepareAgentEvents.isEmpty()) {
             LOGGER.log(Level.FINE, "No org.jacoco:jacoco-maven-plugin:prepare-agent execution found");

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JacocoReportPublisher.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JacocoReportPublisher.java
@@ -168,6 +168,7 @@ public class JacocoReportPublisher extends MavenPublisher {
             String destFile = destFileElt.getTextContent().trim();
             if (destFile.equals("${jacoco.destFile}")) {
                 destFile = "${project.build.directory}/jacoco.exec";
+                if ("prepare-agent-integration".equals(pluginInvocation.goal)) destFile = "${project.build.directory}/jacoco-it.exec";
                 String projectBuildDirectory = XmlUtils.getProjectBuildDirectory(projectElt);
                 if (projectBuildDirectory == null || projectBuildDirectory.isEmpty()) {
                     listener.getLogger().println("[withMaven] '${project.build.directory}' found for <project> in " + XmlUtils.toString(jacocoPrepareAgentEvent));

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JacocoReportPublisher.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JacocoReportPublisher.java
@@ -128,7 +128,7 @@ public class JacocoReportPublisher extends MavenPublisher {
 
         List<Element> jacocoPrepareAgentEvents = XmlUtils.getExecutionEventsByPlugin(mavenSpyLogsElt, "org.jacoco", "jacoco-maven-plugin", "prepare-agent", "MojoSucceeded", "MojoFailed");
         List<Element> jacocoPrepareAgentEvents2 = XmlUtils.getExecutionEventsByPlugin(mavenSpyLogsElt, "org.jacoco", "jacoco-maven-plugin", "prepare-agent-integration", "MojoSucceeded", "MojoFailed");
-        jacocoPrepareAgentEvents.addAll(jacocoPrepareAgentEvents2); // add integration tests agents
+        jacocoPrepareAgentEvents.addAll(jacocoPrepareAgentEvents2); // add prepare-agent-integration goals
 
         if (jacocoPrepareAgentEvents.isEmpty()) {
             LOGGER.log(Level.FINE, "No org.jacoco:jacoco-maven-plugin:prepare-agent execution found");

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JacocoReportPublisher.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JacocoReportPublisher.java
@@ -127,8 +127,8 @@ public class JacocoReportPublisher extends MavenPublisher {
         Launcher launcher = context.get(Launcher.class);
 
         List<Element> jacocoPrepareAgentEvents = XmlUtils.getExecutionEventsByPlugin(mavenSpyLogsElt, "org.jacoco", "jacoco-maven-plugin", "prepare-agent", "MojoSucceeded", "MojoFailed");
-        List<Element> jacocoPrepareAgentEvents2 = XmlUtils.getExecutionEventsByPlugin(mavenSpyLogsElt, "org.jacoco", "jacoco-maven-plugin", "prepare-agent-integration", "MojoSucceeded", "MojoFailed");
-        jacocoPrepareAgentEvents.addAll(jacocoPrepareAgentEvents2); // add prepare-agent-integration goals
+        List<Element> jacocoPrepareAgentIntegrationEvents = XmlUtils.getExecutionEventsByPlugin(mavenSpyLogsElt, "org.jacoco", "jacoco-maven-plugin", "prepare-agent-integration", "MojoSucceeded", "MojoFailed");
+        jacocoPrepareAgentEvents.addAll(jacocoPrepareAgentIntegrationEvents); // add prepare-agent-integration goals
 
         if (jacocoPrepareAgentEvents.isEmpty()) {
             LOGGER.log(Level.FINE, "No org.jacoco:jacoco-maven-plugin:prepare-agent execution found");


### PR DESCRIPTION
The current pipeline-maven-plugin currently does not support/include any prepare-agent-integration goals created output files to the list of jacoco destination files that will be included in the jacoco published results when doing

withMaven(..., options: [jacocoPublisher(disabled: false)])

This pull request will add the destination files created as a result of prepare-agent-integration goals.