### PR TITLE
Use BOM versions when available

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -168,7 +168,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-multibranch</artifactId>
-      <version>2.22</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -225,7 +224,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>htmlpublisher</artifactId>
-      <version>1.23</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
@@ -342,7 +340,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-stage-step</artifactId>
-      <version>2.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
These dependencies are now using the version available in the BOM
* org.jenkins-ci.plugins.workflow:workflow-multibranch:jar:2.22:test
* org.jenkins-ci.plugins:htmlpublisher:jar:1.23:compile (optional)
* org.jenkins-ci.plugins:pipeline-stage-step:jar:2.5:test