### PR TITLE
Document MVN_CMD as an alternative to MVN_CMD_DIR and mvnw

### DIFF
--- a/FAQ.adoc
+++ b/FAQ.adoc
@@ -20,7 +20,8 @@ NOTE: Since version 3.0.3
 
 Since the version 1.14 of the Docker Pipeline plugin, `withMaven` requires to
 
-* Either prepend the `MVN_CMD_DIR` environment variable to the `PATH` environment variable in every `sh` step that invokes `mvn` (e.g. `sh 'export PATH=$MVN_CMD_DIR:$PATH && mvn clean deploy`).
+* Either prepend the `MVN_CMD_DIR` environment variable to the `PATH` environment variable in every `sh` step that invokes `mvn` (e.g. `sh 'export PATH=$MVN_CMD_DIR:$PATH && mvn clean deploy'`).
+* Or call the generated script directly via `MVN_CMD` (e.g. `sh '$MVN_CMD clean deploy'`)
 * Or use Takari's Maven Wrapper (e.g. `sh './mvnw clean deploy'`)
 
 If omitted, the Maven settings file and Mven global settings file will not be injected in the Maven execution.


### PR DESCRIPTION
Added a third way to the FAQ under _How to use the Pipeline Maven Plugin with Docker?_: `MVN_CMD` 
I also fixed a missing `'` in the `MVN_CMD_DIR` example.

I consider `MVN_CMD` the least intrusive way.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
