### PR TITLE
Ensure the H2 DB is shutdown on Jenkins termination

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
@@ -31,6 +31,7 @@ import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import hudson.Extension;
+import hudson.init.Terminator;
 import hudson.model.Result;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
@@ -582,6 +583,19 @@ public class GlobalPipelineMavenConfig extends GlobalConfiguration {
             return FormValidation.error(e, "Failed to test JDBC connection '" + jdbcUrl + "'");
         } catch (ClassNotFoundException e) {
             return FormValidation.error(e, "Failed to load JDBC driver '" + driverClass + "' for JDBC connection '" + jdbcUrl + "'");
+        }
+
+    }
+    
+    @Terminator
+    public void closeDatasource() {
+        PipelineMavenPluginDao dao = this.dao;
+        if (dao instanceof Closeable) {
+            try {
+                ((Closeable) dao).close();
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Exception shutting down the DAO", e);
+            }
         }
 
     }

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
@@ -89,7 +89,7 @@ public class GlobalPipelineMavenConfig extends GlobalConfiguration {
 
     private final static Logger LOGGER = Logger.getLogger(GlobalPipelineMavenConfig.class.getName());
 
-    private transient PipelineMavenPluginDao dao;
+    private transient volatile PipelineMavenPluginDao dao;
 
     private transient PipelineTriggerService pipelineTriggerService;
 
@@ -241,12 +241,18 @@ public class GlobalPipelineMavenConfig extends GlobalConfiguration {
 
     @Nonnull
     public synchronized PipelineMavenPluginDao getDao() {
+        Jenkins j = Jenkins.getInstanceOrNull();
+        if (j == null) {
+            throw new IllegalStateException("Request to get DAO whilst Jenkins is shutting down or starting up");
+        } else if (j.isTerminating()) {
+            throw new IllegalStateException("Request to get DAO whilst Jenkins is terminating");
+        }
         if (dao == null) {
             try {
                 String jdbcUrl, jdbcUserName, jdbcPassword;
                 if (StringUtils.isBlank(this.jdbcUrl)) {
                     // default embedded H2 database
-                    File databaseRootDir = new File(Jenkins.get().getRootDir(), "jenkins-jobs");
+                    File databaseRootDir = new File(j.getRootDir(), "jenkins-jobs");
                     if (!databaseRootDir.exists()) {
                         boolean created = databaseRootDir.mkdirs();
                         if (!created) {
@@ -263,7 +269,7 @@ public class GlobalPipelineMavenConfig extends GlobalConfiguration {
                         throw new IllegalStateException("No credentials defined for JDBC URL '" + jdbcUrl + "'");
 
                     UsernamePasswordCredentials jdbcCredentials = (UsernamePasswordCredentials) CredentialsMatchers.firstOrNull(
-                            CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class, Jenkins.get(),
+                            CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class, j,
                                     ACL.SYSTEM, Collections.EMPTY_LIST),
                             CredentialsMatchers.withId(this.jdbcCredentialsId));
                     if (jdbcCredentials == null) {
@@ -588,15 +594,14 @@ public class GlobalPipelineMavenConfig extends GlobalConfiguration {
     }
     
     @Terminator
-    public void closeDatasource() {
+    public synchronized void closeDatasource() {
         PipelineMavenPluginDao dao = this.dao;
         if (dao instanceof Closeable) {
             try {
                 ((Closeable) dao).close();
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Exception shutting down the DAO", e);
+                LOGGER.log(Level.WARNING, "Exception closing the DAO", e);
             }
         }
-
     }
 }


### PR DESCRIPTION
If the H2 db has been started to use a local DB server (inside this JVM)
then we need to ensure it is shutdown.

The database would only be cleanly shutdown previously on a clean JVM
shutdown which caused issues if

1. Jenkins was running in a web container and the webapp was restarted
   rather than the whole app
2. Jenkins tests where the plugin was present.

Additionally it seems that in some cases (pipeline jobs?) `RunListeners` can be fired after Jenkins starts shutting down, which resulted in the database being opened (and prevented tests from terminating)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
