### PR TITLE
Bump Jenkins core requirement from 2.204.6 to 2.277.1

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -74,7 +74,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.235.x</artifactId>
+        <artifactId>bom-2.277.x</artifactId>
         <version>876.vc43b4c6423b6</version>
         <type>pom</type>
         <scope>import</scope>
@@ -144,6 +144,11 @@
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>annotations</artifactId>
         <version>3.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.fusesource.jansi</groupId>
+        <artifactId>jansi</artifactId>
+        <version>1.15</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -387,6 +392,18 @@
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-commons</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-tree</artifactId>
         </exclusion>
       </exclusions>
       <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <properties>
         <revision>3.11.0</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.235.5</jenkins.version>
+        <jenkins.version>2.277.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 


### PR DESCRIPTION
https://www.jenkins.io/changelog-stable/ (2021-03-10)