### PR TITLE
chore: add myself as reviewer for dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,6 @@ updates:
       interval: "weekly"
     reviewers:
       - "aheritier"
+      - "bguerin"
     # Allow up to 10 open pull requests for maven dependencies
     open-pull-requests-limit: 10


### PR DESCRIPTION
Add myself to dependabot pull requests reviewers, to be notified

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [N/A] Link to relevant issues in GitHub or Jira
- [N/A] Link to relevant pull requests, esp. upstream and downstream changes
- [N/A] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
