### PR TITLE
[JENKINS-43651] allow recognizing Maven through non-system-wide defined MAVEN_HOME env var

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -421,6 +421,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
       <scope>test</scope>

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -481,11 +481,10 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         } else {
             // if not on docker we can use the computer environment
             LOGGER.fine("Using computer environment...");
-            EnvVars agentEnv = getComputer().getEnvironment();
-            LOGGER.log(Level.FINE, "Agent env: {0}", agentEnv);
-            String mavenHome = agentEnv.get(MAVEN_HOME);
+            LOGGER.log(Level.FINE, "Agent env: {0}", env);
+            String mavenHome = env.get(MAVEN_HOME);
             if (mavenHome == null) {
-                mavenHome = agentEnv.get(M2_HOME);
+                mavenHome = env.get(M2_HOME);
                 if (StringUtils.isNotEmpty(mavenHome)) {
                     consoleMessage.append(" with the environment variable M2_HOME=").append(mavenHome);
                 }

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepGlobalToolTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepGlobalToolTest.java
@@ -1,0 +1,173 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.pipeline.maven;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.model.DownloadService;
+import hudson.model.Result;
+import hudson.plugins.sshslaves.SSHLauncher;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.RetentionStrategy;
+import hudson.tasks.Maven;
+import hudson.tasks.Maven.MavenInstallation;
+import hudson.tools.InstallSourceProperty;
+import org.jenkinsci.plugins.pipeline.maven.docker.NonMavenJavaContainer;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.test.acceptance.docker.DockerRule;
+import org.jenkinsci.test.acceptance.docker.fixtures.SshdContainer;
+import org.jenkinsci.utils.process.CommandBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Issue("JENKINS-43651")
+public class WithMavenStepGlobalToolTest extends AbstractIntegrationTest {
+
+    private static final String SSH_CREDENTIALS_ID = "test";
+    private static final String AGENT_NAME = "remote";
+    private static final String MAVEN_GLOBAL_TOOL_NAME = "maven";
+    private static final String MAVEN_HOME_BASE_PATH = "/home/test/slave";
+
+    @Rule
+    public DockerRule<NonMavenJavaContainer> slaveRule = new DockerRule<>(NonMavenJavaContainer.class);
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+
+        registerNonMavenAgent();
+        registerLatestMavenVersionAsGlobalTool();
+    }
+
+    @Test
+    public void testMavenNotInstalledInDockerImage() throws Exception {
+        assertThat(slaveRule.get().popen(new CommandBuilder("mvn", "--version")).asText(), containsString("sh: 1: mvn: not found"));
+    }
+
+    @Test
+    public void testMavenGlobalToolRecognizedInScriptedPipeline() throws Exception {
+        assertMavenGlobalToolRecognized("" +
+                "node('" + AGENT_NAME + "') {\n" +
+                "  def mavenHome = tool '" + MAVEN_GLOBAL_TOOL_NAME + "'\n" +
+                "  withEnv([\"MAVEN_HOME=${mavenHome}\"]) {\n" +
+                "    withMaven() {\n" +
+                "      sh \"mvn --version\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+    }
+
+    @Test
+    public void testMavenGlobalToolRecognizedInDeclarativePipeline() throws Exception {
+        assertMavenGlobalToolRecognized("" +
+                "pipeline {\n" +
+                "  agent { label '" + AGENT_NAME + "' }\n" +
+                "  tools {\n" +
+                "    maven '" + MAVEN_GLOBAL_TOOL_NAME + "'\n" +
+                "  }\n" +
+                "  stages {\n" +
+                "    stage('Build') {\n" +
+                "      steps {\n" +
+                "        withMaven() {\n" +
+                "          sh \"mvn --version\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+    }
+
+    private void assertMavenGlobalToolRecognized(String pipelineScript) throws Exception {
+        WorkflowJob p = jenkinsRule.createProject(WorkflowJob.class, "project");
+        p.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+
+        WorkflowRun run = jenkinsRule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
+        jenkinsRule.assertLogContains("Apache Maven " + getLatestMavenVersion(), run);
+        jenkinsRule.assertLogContains("using Maven installation provided by the build agent with the environment variable MAVEN_HOME=" + MAVEN_HOME_BASE_PATH, run);
+    }
+
+    private void registerNonMavenAgent() throws Exception {
+        SshdContainer slaveContainer = slaveRule.get();
+        addTestSshCredentials();
+        registerAgentForSlaveContainer(slaveContainer);
+    }
+
+    private void addTestSshCredentials() {
+        Credentials credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, SSH_CREDENTIALS_ID, null, "test", "test");
+
+        SystemCredentialsProvider.getInstance()
+                .getDomainCredentialsMap()
+                .put(Domain.global(), Collections.singletonList(credentials));
+    }
+
+    private void registerAgentForSlaveContainer(SshdContainer slaveContainer) throws Exception {
+        SSHLauncher sshLauncher = new SSHLauncher(slaveContainer.ipBound(22), slaveContainer.port(22), SSH_CREDENTIALS_ID);
+
+        DumbSlave agent = new DumbSlave(AGENT_NAME, MAVEN_HOME_BASE_PATH, sshLauncher);
+        agent.setNumExecutors(1);
+        agent.setRetentionStrategy(RetentionStrategy.INSTANCE);
+
+        jenkinsRule.jenkins.addNode(agent);
+    }
+
+    private void registerLatestMavenVersionAsGlobalTool() throws Exception {
+        updateAvailableMavenVersions();
+        String latestMavenVersion = getLatestMavenVersion();
+
+        registerMavenVersionAsGlobalTool(latestMavenVersion);
+    }
+
+    private void updateAvailableMavenVersions() throws Exception {
+        getMavenDownloadable().updateNow();
+    }
+
+    private String getLatestMavenVersion() throws Exception {
+        return getMavenDownloadable().getData().getJSONArray("list").getJSONObject(0).getString("id");
+    }
+
+    private DownloadService.Downloadable getMavenDownloadable() {
+        return DownloadService.Downloadable.get(Maven.MavenInstaller.class);
+    }
+
+    private void registerMavenVersionAsGlobalTool(String version) throws Exception {
+        String mavenHome = "maven-" + version.replace(".", "-");
+
+        InstallSourceProperty installSourceProperty = new InstallSourceProperty(Collections.singletonList(new Maven.MavenInstaller(version)));
+        MavenInstallation mavenInstallation = new MavenInstallation(MAVEN_GLOBAL_TOOL_NAME, mavenHome, Collections.singletonList(installSourceProperty));
+        jenkinsRule.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(mavenInstallation);
+    }
+
+}

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
@@ -37,7 +37,6 @@ import hudson.slaves.RetentionStrategy;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.pipeline.maven.docker.JavaGitContainer;
-import org.jenkinsci.plugins.pipeline.maven.docker.MavenWithMavenHomeJavaContainer;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -59,13 +58,9 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
     private static final String AGENT_NAME = "remote";
     private static final String SLAVE_BASE_PATH = "/home/test/slave";
     private static final String COMMONS_LANG3_FINGERPRINT = "780b5a8b72eebe6d0dbff1c11b5658fa";
-    private static final String MAVEN_VERSION_INFO = "Apache Maven 3.6.0";
 
     @Rule
     public DockerRule<JavaGitContainer> javaGitContainerRule = new DockerRule<>(JavaGitContainer.class);
-
-    @Rule
-    public DockerRule<MavenWithMavenHomeJavaContainer> mavenWithMavenHomeJavaContainerRule = new DockerRule<>(MavenWithMavenHomeJavaContainer.class);
 
     @Issue("SECURITY-441")
     @Test
@@ -100,35 +95,6 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
                 "}");
 
         assertFingerprintDoesNotExist(COMMONS_LANG3_FINGERPRINT);
-    }
-
-    @Test
-    public void testPreInstalledMavenRecognizedWithoutMavenHome() throws Exception {
-        registerAgentForContainer(javaGitContainerRule.get());
-        WorkflowRun run = runPipeline(Result.SUCCESS, "" +
-                "node('" + AGENT_NAME + "') {\n" +
-                "  withMaven() {\n" +
-                "    sh \"mvn --version\"\n" +
-                "  }\n" +
-                "}");
-
-        jenkinsRule.assertLogContains(MAVEN_VERSION_INFO, run);
-        jenkinsRule.assertLogContains("using Maven installation provided by the build agent with executable /usr/bin/mvn", run);
-    }
-
-    @Test
-    public void testPreInstalledMavenRecognizedWithMavenHome() throws Exception {
-        registerAgentForContainer(mavenWithMavenHomeJavaContainerRule.get());
-        WorkflowRun run = runPipeline(Result.SUCCESS, "" +
-                "node('" + AGENT_NAME + "') {\n" +
-                "  sh 'echo $MAVEN_HOME'\n" +
-                "  withMaven() {\n" +
-                "    sh \"mvn --version\"\n" +
-                "  }\n" +
-                "}");
-
-        jenkinsRule.assertLogContains(MAVEN_VERSION_INFO, run);
-        jenkinsRule.assertLogContains("using Maven installation provided by the build agent with the environment variable MAVEN_HOME=/usr/share/maven", run);
     }
 
     private WorkflowRun runPipeline(Result expectedResult, String pipelineScript) throws Exception {

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer.java
@@ -3,6 +3,6 @@ package org.jenkinsci.plugins.pipeline.maven.docker;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
 
-@DockerFixture(id = "non-maven-java", ports = {22, 8080})
-public class NonMavenJavaContainer extends JavaContainer {
+@DockerFixture(id = "maven-with-maven-home-java", ports = {22, 8080})
+public class MavenWithMavenHomeJavaContainer extends JavaContainer {
 }

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer.java
@@ -1,0 +1,8 @@
+package org.jenkinsci.plugins.pipeline.maven.docker;
+
+import org.jenkinsci.test.acceptance.docker.DockerFixture;
+import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
+
+@DockerFixture(id = "nonmavenjava", ports = {22, 8080})
+public class NonMavenJavaContainer extends JavaContainer {
+}

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM jenkins/java:d93654cc6239
+
+ENV MAVEN_HOME="/usr/share/maven"
+
+# see https://www.jenkins.io/doc/book/using/using-agents/ and https://github.com/jenkinsci/docker-ssh-agent/issues/33
+# probably, it would be better to use the official image docker-ssh-agent as a base
+RUN VARS1="HOME=|USER=|MAIL=|LC_ALL=|LS_COLORS=|LANG=" \
+    VARS2="HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=" \
+    VARS="${VARS1}|${VARS2}" \
+    env | egrep -v '^(${VARS})' >> /etc/environment

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
@@ -1,3 +1,3 @@
 FROM jenkins/java:d93654cc6239
 
-RUN apt-get remove maven -y maven
+RUN apt-get remove maven -y

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM jenkins/java:d93654cc6239
+
+RUN apt-get remove maven -y maven


### PR DESCRIPTION
allow recognizing Maven through non-system-wide defined MAVEN_HOME env var (fixes JENKINS-43651)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
