### PR TITLE
[JENKINS-67507] Artifacts deployed by direct invocation of deploy-file goal don't trigger downstream builds

### DIFF
--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
@@ -118,6 +118,14 @@ public abstract class AbstractIntegrationTest {
         loadSourceCodeInGitRepository(gitRepo, "/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_docker_dependency_project/");
     }
 
+    protected void loadDeployFileBaseMavenProjectInGitRepo(GitSampleRepoRule gitRepo) throws Exception {
+        loadSourceCodeInGitRepository(gitRepo, "/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_deployfile_base_project/");
+    }
+
+    protected void loadDeployFileDependencyMavenJarProjectInGitRepo(GitSampleRepoRule gitRepo) throws Exception {
+        loadSourceCodeInGitRepository(gitRepo, "/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_deployfile_dependency_project/");
+    }
+
     protected void loadSourceCodeInGitRepository(GitSampleRepoRule gitRepo, String name) throws Exception {
         gitRepo.init();
         Path mavenProjectRoot = Paths.get(WithMavenStepOnMasterTest.class.getResource(name).toURI());

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_deployfile_base_project/pom.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_deployfile_base_project/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.deploy.sample</groupId>
+    <artifactId>maven_deployfile_base_project</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <dependencies>
+        <dependency>
+            <groupId>com.deploy.sample</groupId>
+            <artifactId>maven_deployfile_dependency_project</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_deployfile_dependency_project/pom.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_deployfile_dependency_project/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.deploy.sample</groupId>
+    <artifactId>maven_deployfile_dependency_project</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-deploy</id>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>deploy-file</id>
+                        <goals>
+                            <goal>deploy-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}/${project.build.finalName}.jar</file>
+                            <url>file://${project.build.directory}</url>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <groupId>${project.groupId}</groupId>
+                            <version>${project.version}</version>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_deployfile_dependency_project/src/main/java/com/example/App.java
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_deployfile_dependency_project/src/main/java/com/example/App.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class App {
+    public static void main(String[] args) {
+        System.out.println("App");
+    }
+}

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
@@ -24,18 +24,6 @@
 
 package org.jenkinsci.plugins.pipeline.maven.eventspy;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import org.apache.maven.eventspy.AbstractEventSpy;
 import org.apache.maven.eventspy.EventSpy;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -63,6 +51,17 @@ import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.FileMavenEventRepo
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Maven {@link EventSpy} to capture build details consumed by the Jenkins Pipeline Maven Plugin

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/JenkinsMavenEventSpy.java
@@ -24,6 +24,18 @@
 
 package org.jenkinsci.plugins.pipeline.maven.eventspy;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
 import org.apache.maven.eventspy.AbstractEventSpy;
 import org.apache.maven.eventspy.EventSpy;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -33,6 +45,7 @@ import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.DefaultSettingsBuil
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.DependencyResolutionRequestHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.DependencyResolutionResultHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.DeployDeployExecutionHandler;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.DeployDeployFileExecutionHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.FailsafeTestExecutionHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.InvokerRunExecutionHandler;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.handler.InvokerStartExecutionHandler;
@@ -50,17 +63,6 @@ import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.FileMavenEventRepo
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Named;
-import javax.inject.Singleton;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Maven {@link EventSpy} to capture build details consumed by the Jenkins Pipeline Maven Plugin
@@ -131,6 +133,7 @@ public class JenkinsMavenEventSpy extends AbstractEventSpy {
         handlers.add(new MavenExecutionResultHandler(reporter));
         handlers.add(new SessionEndedHandler(reporter));
         handlers.add(new DeployDeployExecutionHandler(reporter));
+        handlers.add(new DeployDeployFileExecutionHandler(reporter));
         handlers.add(new ArtifactDeployedEventHandler(reporter));
 
         handlers.add(new CatchAllExecutionHandler(reporter));

--- a/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/DeployDeployFileExecutionHandler.java
+++ b/maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/DeployDeployFileExecutionHandler.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.plugins.pipeline.maven.eventspy.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.ExecutionEvent.Type;
+import org.apache.maven.plugin.MojoExecution;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Handler to alter the
+ * <code>org.apache.maven.plugins:maven-deploy-plugin:deploy-file</code> goal : it will
+ * set the <code>lifecyclePhase</code> to <code>deploy</code> when no lifecycle is set.
+ *
+ * This can happen when the plugin is invoked directly
+ *
+ * @author <a href="mailto:r.schleuse@gmail.com">René Schleusner</a>
+ *
+ */
+public class DeployDeployFileExecutionHandler extends AbstractExecutionHandler {
+    public DeployDeployFileExecutionHandler(@NonNull MavenEventReporter reporter) {
+        super(reporter);
+    }
+
+    @Override
+    protected List<String> getConfigurationParametersToReport(ExecutionEvent executionEvent) {
+        return new ArrayList<String>();
+    }
+
+    @Override
+    protected void addDetails(@NonNull ExecutionEvent executionEvent, @NonNull Xpp3Dom root) {
+        super.addDetails(executionEvent, root);
+        MojoExecution execution = executionEvent.getMojoExecution();
+        if (execution == null) {
+            return;
+        }
+
+        /*
+         * When Plugin is executed directly the MojoExecution doesn't
+         * contain a lifecyclePhase. For the deploy-file goal we assume
+         * the deploy phase in this case
+         */
+        String lifecyclePhase = execution.getLifecyclePhase();
+        if (lifecyclePhase == null || lifecyclePhase.isEmpty()) {
+            Xpp3Dom plugin = root.getChild("plugin");
+            if (plugin != null) {
+                plugin.setAttribute("lifecyclePhase", "deploy");
+            }
+        }
+    }
+
+    @Override
+    protected Type getSupportedType() {
+        return ExecutionEvent.Type.MojoSucceeded;
+    }
+
+	@Nullable
+    @Override
+    protected String getSupportedPluginGoal() {
+        return "org.apache.maven.plugins:maven-deploy-plugin:deploy-file";
+    }
+}

--- a/maven-spy/src/test/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/DeployDeployFileExecutionHandlerTest.java
+++ b/maven-spy/src/test/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/DeployDeployFileExecutionHandlerTest.java
@@ -1,0 +1,193 @@
+package org.jenkinsci.plugins.pipeline.maven.eventspy.handler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.OutputStreamEventReporter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:r.schleuse@gmail.com">René Schleusner</a>
+ */
+public class DeployDeployFileExecutionHandlerTest {
+
+    DeployDeployFileExecutionHandler handler;
+    MavenProject project;
+    ByteArrayOutputStream eventReportOutputStream;
+    OutputStreamEventReporter reporter;
+
+    @Before
+    public void before() throws Exception {
+        eventReportOutputStream = new ByteArrayOutputStream();
+        reporter = new OutputStreamEventReporter(eventReportOutputStream);
+        handler = new DeployDeployFileExecutionHandler(reporter);
+        project = this.createTestMavenProject();
+    }
+
+    @After
+    public void after() throws IOException {
+        this.eventReportOutputStream.close();
+    }
+
+    @Test
+    public void testWithExistingLifecyclePhase() throws Exception {
+        MojoExecution execution = new MojoExecution(this.createTestingMojoDescriptor());
+        execution.setLifecyclePhase("install");
+        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution);
+
+        this.handler._handle(event);
+
+        Xpp3Dom report = this.closeReporterAndGenerateReport();
+        Xpp3Dom executionReport = report.getChild("ExecutionEvent");
+        Xpp3Dom plugin = executionReport.getChild("plugin");
+
+        assertThat(plugin.getAttribute("lifecyclePhase"), Matchers.equalTo("install"));
+    }
+
+    @Test
+    public void testWithoutExistingLifecyclePhase() throws Exception {
+        MojoExecution execution = new MojoExecution(this.createTestingMojoDescriptor());
+        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution);
+
+        this.handler._handle(event);
+
+        Xpp3Dom report = this.closeReporterAndGenerateReport();
+        Xpp3Dom executionReport = report.getChild("ExecutionEvent");
+        Xpp3Dom plugin = executionReport.getChild("plugin");
+
+        assertThat(plugin.getAttribute("lifecyclePhase"), Matchers.equalTo("deploy"));
+    }
+
+    @Test
+    public void testWithEmptyLifecyclePhase() throws Exception {
+        MojoExecution execution = new MojoExecution(this.createTestingMojoDescriptor());
+        execution.setLifecyclePhase("");
+        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution);
+
+        this.handler._handle(event);
+
+        Xpp3Dom report = this.closeReporterAndGenerateReport();
+        Xpp3Dom executionReport = report.getChild("ExecutionEvent");
+        Xpp3Dom plugin = executionReport.getChild("plugin");
+
+        assertThat(plugin.getAttribute("lifecyclePhase"), Matchers.equalTo("deploy"));
+    }
+
+    @Test
+    public void testWithNullLifecyclePhase() throws Exception {
+        MojoExecution execution = new MojoExecution(this.createTestingMojoDescriptor());
+        execution.setLifecyclePhase(null);
+        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution);
+
+        this.handler._handle(event);
+
+        Xpp3Dom report = this.closeReporterAndGenerateReport();
+        Xpp3Dom executionReport = report.getChild("ExecutionEvent");
+        Xpp3Dom plugin = executionReport.getChild("plugin");
+
+        assertThat(plugin.getAttribute("lifecyclePhase"), Matchers.equalTo("deploy"));
+    }
+
+    /**
+     * Creates a ExecutionEvent which describes a successfull
+     * invocation of passed MojoExecution on a dummy-project
+     * @param mojoExecution
+     * @return
+     */
+    private ExecutionEvent createTestDeployFileExecutionEvent(MojoExecution mojoExecution) {
+        return new ExecutionEvent() {
+            @Override
+            public Type getType() {
+                return Type.MojoSucceeded;
+            }
+
+            @Override
+            public MavenSession getSession() {
+                return null;
+            }
+
+            @Override
+            public MavenProject getProject() {
+                return project;
+            }
+
+            @Override
+            public MojoExecution getMojoExecution() {
+                return mojoExecution;
+            }
+
+            @Override
+            public Exception getException() {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Create a dummy Maven-Projet
+     * @return
+     * @throws IOException
+     * @throws XmlPullParserException
+     */
+    private MavenProject createTestMavenProject() throws Exception {
+        Model model = new Model();
+        model.setGroupId("org.springframework.samples");
+        model.setArtifactId("spring-petclinic");
+        model.setVersion("1.4.2");
+        model.setName("petclinic");
+
+        project = new MavenProject(model);
+        project.setGroupId(model.getGroupId());
+        project.setArtifactId(model.getArtifactId());
+        project.setVersion(model.getVersion());
+        project.setName(model.getName());
+        return project;
+    }
+
+    /**
+     * Creates a MojoDescriptor for an invocation
+     * of maven-deploy-plugin:deploy-file
+     * @return
+     */
+    private MojoDescriptor createTestingMojoDescriptor() {
+        PluginDescriptor plugin = new PluginDescriptor();
+        plugin.setGroupId("org.apache.maven.plugins");
+        plugin.setArtifactId("maven-deploy-plugin");
+        plugin.setVersion("3.0.0-M2");
+
+        MojoDescriptor desc = new MojoDescriptor();
+        desc.setPluginDescriptor(plugin);
+        desc.setGoal("deploy-file");
+
+        return desc;
+    }
+
+    /**
+     * Closes the reporter and returns the resulting
+     * report as a Xpp3Dom object
+     * @return
+     * @throws XmlPullParserException
+     * @throws IOException
+     */
+    private Xpp3Dom closeReporterAndGenerateReport() throws Exception {
+        this.reporter.close();
+        ByteArrayInputStream inp = new ByteArrayInputStream(this.eventReportOutputStream.toByteArray());
+        return Xpp3DomBuilder.build(inp, "UTF-8");
+    }
+}


### PR DESCRIPTION
Adds a new `ExecutionHandler` for the `JenkinsMavenEventSpy` wich checks if the `MojoExecution` of the goal `org.apache.maven.plugins:maven-deploy-plugin:deploy-file` contains a lifecycle. When no lifecycle is present it assumes the `deploy`-Lifecycle.

https://issues.jenkins.io/browse/JENKINS-67507