### PR TITLE
JENKINS-65001: add test for CasC

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -430,6 +430,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
       <scope>test</scope>

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/ConfigurationAsCodeTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/ConfigurationAsCodeTest.java
@@ -1,0 +1,117 @@
+package org.jenkinsci.plugins.pipeline.maven;
+
+import static io.jenkins.plugins.casc.misc.Util.getToolRoot;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
+import static org.hamcrest.core.IsNull.nullValue;
+
+import org.jenkinsci.plugins.pipeline.maven.publishers.MavenLinkerPublisher2;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+
+public class ConfigurationAsCodeTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code_default.yml")
+    public void should_support_default_configuration() throws Exception {
+        GlobalPipelineMavenConfig config = r.jenkins.getExtensionList(GlobalPipelineMavenConfig.class).get(0);
+
+        assertThat(config.getJdbcUrl(), nullValue());
+        assertThat(config.getJdbcCredentialsId(), nullValue());
+        assertThat(config.getProperties(), nullValue());
+        assertThat(config.isTriggerDownstreamUponResultAborted(), is(false));
+        assertThat(config.isTriggerDownstreamUponResultFailure(), is(false));
+        assertThat(config.isTriggerDownstreamUponResultNotBuilt(), is(false));
+        assertThat(config.isTriggerDownstreamUponResultUnstable(), is(false));
+        assertThat(config.isTriggerDownstreamUponResultSuccess(), is(true));
+        assertThat(config.getPublisherOptions(), nullValue());
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        String exported = toYamlString(getToolRoot(context).get("pipelineMaven"));
+        String expected = toStringFromYamlFile(this, "expected_output_default.yml");
+
+        assertThat(exported, is(expected));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code_triggers.yml")
+    public void should_support_triggers_configuration() throws Exception {
+        GlobalPipelineMavenConfig config = r.jenkins.getExtensionList(GlobalPipelineMavenConfig.class).get(0);
+
+        assertThat(config.isTriggerDownstreamUponResultAborted(), is(true));
+        assertThat(config.isTriggerDownstreamUponResultFailure(), is(true));
+        assertThat(config.isTriggerDownstreamUponResultNotBuilt(), is(true));
+        assertThat(config.isTriggerDownstreamUponResultUnstable(), is(true));
+        assertThat(config.isTriggerDownstreamUponResultSuccess(), is(false));
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        String exported = toYamlString(getToolRoot(context).get("pipelineMaven"));
+        String expected = toStringFromYamlFile(this, "expected_output_triggers.yml");
+
+        assertThat(exported, is(expected));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code_mysql.yml")
+    public void should_support_mysql_configuration() throws Exception {
+        GlobalPipelineMavenConfig config = r.jenkins.getExtensionList(GlobalPipelineMavenConfig.class).get(0);
+
+        assertThat(config.getJdbcUrl(), is("jdbc:mysql://dbserver/jenkinsdb"));
+        assertThat(config.getProperties(), is("dataSource.cachePrepStmts=true\ndataSource.prepStmtCacheSize=250\n"));
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        String exported = toYamlString(getToolRoot(context).get("pipelineMaven"));
+        String expected = toStringFromYamlFile(this, "expected_output_mysql.yml");
+
+        assertThat(exported, is(expected));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code_postgresql.yml")
+    public void should_support_postgresql_configuration() throws Exception {
+        GlobalPipelineMavenConfig config = r.jenkins.getExtensionList(GlobalPipelineMavenConfig.class).get(0);
+
+        assertThat(config.getJdbcUrl(), is("jdbc:postgresql://dbserver/jenkinsdb"));
+        assertThat(config.getJdbcCredentialsId(), is("pg-creds"));
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        String exported = toYamlString(getToolRoot(context).get("pipelineMaven"));
+        String expected = toStringFromYamlFile(this, "expected_output_postgresql.yml");
+
+        assertThat(exported, is(expected));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code_publishers.yml")
+    public void should_support_publishers_configuration() throws Exception {
+        GlobalPipelineMavenConfig config = r.jenkins.getExtensionList(GlobalPipelineMavenConfig.class).get(0);
+
+        assertThat(config.getPublisherOptions(), hasSize(1));
+        assertThat(config.getPublisherOptions().get(0), isA(MavenLinkerPublisher2.class));
+        MavenLinkerPublisher2 publisher = (MavenLinkerPublisher2) config.getPublisherOptions().get(0);
+        assertThat(publisher.isDisabled(), is(true));
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        String exported = toYamlString(getToolRoot(context).get("pipelineMaven"));
+        String expected = toStringFromYamlFile(this, "expected_output_publishers.yml");
+
+        assertThat(exported, is(expected));
+    }
+}

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/configuration-as-code_default.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/configuration-as-code_default.yml
@@ -1,0 +1,2 @@
+jenkins:
+  systemMessage: "Hello World"

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/configuration-as-code_mysql.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/configuration-as-code_mysql.yml
@@ -1,0 +1,9 @@
+jenkins:
+  systemMessage: "Hello World"
+
+tool:
+  pipelineMaven:
+    jdbcUrl: jdbc:mysql://dbserver/jenkinsdb
+    properties: |
+      dataSource.cachePrepStmts=true
+      dataSource.prepStmtCacheSize=250

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/configuration-as-code_postgresql.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/configuration-as-code_postgresql.yml
@@ -1,0 +1,7 @@
+jenkins:
+  systemMessage: "Hello World"
+
+tool:
+  pipelineMaven:
+    jdbcUrl: jdbc:postgresql://dbserver/jenkinsdb
+    JdbcCredentialsId: pg-creds

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/configuration-as-code_publishers.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/configuration-as-code_publishers.yml
@@ -1,0 +1,8 @@
+jenkins:
+  systemMessage: "Hello World"
+
+tool:
+  pipelineMaven:
+    publisherOptions:
+    - mavenLinkerPublisher:
+        disabled: true

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/configuration-as-code_triggers.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/configuration-as-code_triggers.yml
@@ -1,0 +1,10 @@
+jenkins:
+  systemMessage: "Hello World"
+
+tool:
+  pipelineMaven:
+    triggerDownstreamUponResultAborted: true
+    triggerDownstreamUponResultFailure: true
+    triggerDownstreamUponResultNotBuilt: true
+    triggerDownstreamUponResultSuccess: false
+    triggerDownstreamUponResultUnstable: true

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_default.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_default.yml
@@ -1,0 +1,5 @@
+triggerDownstreamUponResultAborted: false
+triggerDownstreamUponResultFailure: false
+triggerDownstreamUponResultNotBuilt: false
+triggerDownstreamUponResultSuccess: true
+triggerDownstreamUponResultUnstable: false

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_mysql.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_mysql.yml
@@ -1,0 +1,9 @@
+jdbcUrl: "jdbc:mysql://dbserver/jenkinsdb"
+properties: |
+  dataSource.cachePrepStmts=true
+  dataSource.prepStmtCacheSize=250
+triggerDownstreamUponResultAborted: false
+triggerDownstreamUponResultFailure: false
+triggerDownstreamUponResultNotBuilt: false
+triggerDownstreamUponResultSuccess: true
+triggerDownstreamUponResultUnstable: false

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_postgresql.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_postgresql.yml
@@ -1,0 +1,7 @@
+jdbcCredentialsId: "pg-creds"
+jdbcUrl: "jdbc:postgresql://dbserver/jenkinsdb"
+triggerDownstreamUponResultAborted: false
+triggerDownstreamUponResultFailure: false
+triggerDownstreamUponResultNotBuilt: false
+triggerDownstreamUponResultSuccess: true
+triggerDownstreamUponResultUnstable: false

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_publishers.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_publishers.yml
@@ -1,0 +1,8 @@
+publisherOptions:
+- mavenLinkerPublisher:
+    disabled: true
+triggerDownstreamUponResultAborted: false
+triggerDownstreamUponResultFailure: false
+triggerDownstreamUponResultNotBuilt: false
+triggerDownstreamUponResultSuccess: true
+triggerDownstreamUponResultUnstable: false

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_triggers.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_triggers.yml
@@ -1,0 +1,5 @@
+triggerDownstreamUponResultAborted: true
+triggerDownstreamUponResultFailure: true
+triggerDownstreamUponResultNotBuilt: true
+triggerDownstreamUponResultSuccess: false
+triggerDownstreamUponResultUnstable: true


### PR DESCRIPTION
Pipeline maven plugin can be configured through Configuration as Code. We should submit examples on the CasC repository, but for that, we should prove that we support such configurations.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
