### PR TITLE
chore(Jenkinsfile) stop using highmem for the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 /*
 * `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library
 */
-buildPlugin(platforms: ['highmem'])
+buildPlugin()


### PR DESCRIPTION
The "standard" VM agent have 4 vCPUs and 16 Gb so that should be ok.

Highmem instance are expensive and should be used only if required (such as the Jenkins Acceptance Test Harness).