### PR TITLE
chore(Jenkinsfile): stop using highmem for the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 /*
 * `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library
 */
-buildPlugin(platforms: ['highmem'])
+buildPlugin(platforms: ['linux'])


### PR DESCRIPTION
Replace https://github.com/jenkinsci/pipeline-maven-plugin/pull/473, to let Jenkins build with the modified (trusted) Jenkinsfile