### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
     <hamcrest.version>1.3</hamcrest.version>
     <hikaricp.version>4.0.3</hikaricp.version>
     <jansi.version>2.4.0</jansi.version>
-    <java.level>8</java.level>
     <jenkins-annotation-indexer.version>1.16</jenkins-annotation-indexer.version>
     <jenkins-credentials.version>1087.1089.v2f1b_9a_b_040e4</jenkins-credentials.version>
     <jenkins-docker-fixtures.version>1.12</jenkins-docker-fixtures.version>


### PR DESCRIPTION
The `java.level` property was deprecated in [plugin parent POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed from this plugin's POM. In the future this warning will be changed to an error and will break the build. See https://github.com/jenkinsci/plugin-pom/pull/522 for details.