### PR TITLE
Fix URL linking

### DIFF
--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -37,7 +37,7 @@
   <name>Pipeline Maven Integration Plugin</name>
   <description>This plugin provides integration with Pipeline, configures maven environment to use within a pipeline job by calling sh mvn or bat mvn.
     The selected maven installation will be configured and prepended to the path.</description>
-  <url>https://github.com/jenkinsci/pipeline-maven-plugin/blob/master/README.adoc</url>
+  <url>https://github.com/jenkinsci/pipeline-maven-plugin/</url>
 
   <properties>
     <hpi.pluginChangelogUrl>https://github.com/jenkinsci/pipeline-maven-plugin/releases</hpi.pluginChangelogUrl>


### PR DESCRIPTION
README's are detected automatically by the update center or plugins.jenkins.io, directly linking to the readme breaks file references.