### PR TITLE
Replace deprecated 'hamcrest-*' modules with 'hamcrest'

### DIFF
--- a/maven-spy/pom.xml
+++ b/maven-spy/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <findbugs-annotation.version>3.0.1</findbugs-annotation.version>
     <groovy.version>2.4.21</groovy.version>
     <gson.version>2.10.1</gson.version>
-    <hamcrest.version>1.3</hamcrest.version>
+    <hamcrest.version>2.2</hamcrest.version>
     <hikaricp.version>4.0.3</hikaricp.version>
     <jansi.version>2.4.0</jansi.version>
     <jenkins-annotation-indexer.version>1.17</jenkins-annotation-indexer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-all</artifactId>
+        <artifactId>hamcrest</artifactId>
         <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
_🤖 This is an automatic PR for replacing the deprecated 'hamcrest-*' modules with 'hamcrest'._

  All deprecated modules' code has been merged into 'hamcrest'.
  Consumers of `hamcrest-*` should replace the dependency with `hamcrest`, which is the drop-in module containing the code of the deprecated `hamcrest-*` modules.

  Ping `@NotMyFault` if you have questions.

  _[script source](https://github.com/NotMyFault/jenkins-version-updater)_