### PR TITLE
Fix url to download Apache Maven binary

### DIFF
--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
@@ -99,7 +99,7 @@ public abstract class AbstractIntegrationTest {
         File mvnHome = new File(buildDirectory, "apache-maven-" + mavenVersion);
         if (!mvnHome.exists()) {
             FilePath mvn = Jenkins.get().getRootPath().createTempFile("maven", "zip");
-            mvn.copyFrom(new URL("https://dlcdn.apache.org/maven/maven-3/" + mavenVersion + "/binaries/apache-maven-" + mavenVersion + "-bin.tar.gz"));
+            mvn.copyFrom(new URL("https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" + mavenVersion + "/apache-maven-" + mavenVersion + "-bin.tar.gz"));
             mvn.untar(new FilePath(buildDirectory), FilePath.TarCompression.GZIP);
         }
         Maven.MavenInstallation mavenInstallation = new Maven.MavenInstallation("default", mvnHome.getAbsolutePath(), JenkinsRule.NO_PROPERTIES);

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepNoOptionalsTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepNoOptionalsTest.java
@@ -80,7 +80,7 @@ public class WithMavenStepNoOptionalsTest {
         FilePath buildDirectory = agent.getRootPath(); // No need of MasterToSlaveCallable because agent is a dumb, thus sharing file system with controller
         FilePath mvnHome = buildDirectory.child("apache-maven-" + mavenVersion);
         FilePath mvn = buildDirectory.createTempFile("maven", "zip");
-        mvn.copyFrom(new URL("https://dlcdn.apache.org/maven/maven-3/" + mavenVersion + "/binaries/apache-maven-" + mavenVersion + "-bin.tar.gz"));
+        mvn.copyFrom(new URL("https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" + mavenVersion + "/apache-maven-" + mavenVersion + "-bin.tar.gz"));
         mvn.untar(buildDirectory, FilePath.TarCompression.GZIP);
         Maven.MavenInstallation mavenInstallation = new Maven.MavenInstallation("default", mvnHome.getRemote(), JenkinsRule.NO_PROPERTIES);
         Jenkins.get().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(mavenInstallation);


### PR DESCRIPTION
The previous url may contain only 3 maintained versions of Apache products. So it's not guarantee to contains old versions. And I did some cleanup on the dist area and removed few versions. sorry for that. But now I fix this here :)

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
