### PR TITLE
Build using container agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,8 @@
 /*
 * `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library
 */
-buildPlugin(platforms: ['linux'], jdkVersions: ['11'])
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 11]
+])


### PR DESCRIPTION
Container agents are usually faster to provision than a VM and generate less cost for the project.