### PR TITLE
Do not rely on `FilePathPickle`

### DIFF
--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -1087,7 +1087,10 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
      * Callback to cleanup tmp script after finishing the job
      */
     private class WithMavenStepExecutionCallBack extends TailCall {
-        private final FilePath tempBinDir;
+        @Deprecated
+        private FilePath tempBinDir;
+
+        private final String tempBinDirPath;
 
         private final MavenPublisherStrategy mavenPublisherStrategy;
 
@@ -1097,13 +1100,17 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
 
         private WithMavenStepExecutionCallBack(@NonNull FilePath tempBinDir, @NonNull List<MavenPublisher> options,
                                               @NonNull MavenPublisherStrategy mavenPublisherStrategy) {
-            this.tempBinDir = tempBinDir;
+            this.tempBinDirPath = tempBinDir.getRemote();
             this.options = options;
             this.mavenPublisherStrategy = mavenPublisherStrategy;
         }
 
         @Override
         protected void finished(StepContext context) throws Exception {
+            if (tempBinDir == null) { // normal case
+                tempBinDir = context.get(FilePath.class).child(tempBinDirPath);
+            } // else resuming old build
+
             mavenSpyLogProcessor.processMavenSpyLogs(context, tempBinDir, options, mavenPublisherStrategy);
 
             try {


### PR DESCRIPTION
As of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180, `FilePath` is not supposed to be directly serialized in program state, because it is tricky to resume a Java object referring to a live agent channel. `WithMavenStepExecutionCallBack` unfortunately did so, unlike say https://github.com/jenkinsci/credentials-binding-plugin/blob/8c080630bc65ef1eb1183d0e5cc179dc486122c0/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UnbindableDir.java#L72 which would be used in

```groovy
node(…) {
  withCredentials([file(…)]) {
    sh '…'
  }
}
```

This could mean that if an agent failed to reattach to the controller after a restart, a build could hang indefinitely with a message like

```
Still trying to load Looking for path named ‘/home/jenkins/agent/workspace/…@tmp/withMaven276c1fbe’ on computer named ‘…’
```

(And if you were using the new `retry`-with-`conditions` idiom, it could be aborted but not successfully resumed on a fresh agent.)

You can see in the virtual thread dump why the program does not load:

```
Program is not yet loaded
	SettableFuture@29c83fa0[status=SUCCESS, result=[org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.None@61b7b33e]] (complete)
	SettableFuture@5282f2e8[status=SUCCESS, result=[org.csanchez.jenkins.plugins.kubernetes.PodTemplate@3b66bb3b]] (complete)
	SettableFuture@533ba6c8[status=SUCCESS, result=[org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.None@fc9d1d2]] (complete)
	SettableFuture@4a997771[status=SUCCESS, result=[org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStep@44a8a27a]] (complete)
	SettableFuture@4aab51c1[status=SUCCESS, result=[org.csanchez.jenkins.plugins.kubernetes.pipeline.KubernetesAgentErrorCondition@bad4e07]] (complete)
	SettableFuture@a0e82fc[status=SUCCESS, result=[org.jenkinsci.plugins.workflow.steps.SynchronousResumeNotSupportedErrorCondition@b344ab5]] (complete)
	SettableFuture@1b81274b[status=SUCCESS, result=[org.jenkinsci.plugins.workflow.support.steps.ExecutorStep@7abd8f4a]] (complete)
	SettableFuture@4daeb83[status=SUCCESS, result=[org.jenkinsci.plugins.pipeline.maven.publishers.GeneratedArtifactsPublisher@2d92784f]] (complete)
	Looking for path named ‘/home/jenkins/agent/workspace/…@tmp/withMaven276c1fbe’ on computer named ‘…’
	SettableFuture@3f3ba9c9[status=SUCCESS, result=[hudson.util.Secret@29eaa6bb]] (complete)
```

Filed https://github.com/jenkinsci/workflow-cps-plugin/pull/755 in the course of identifying the `withMaven` step as the culprit.
