### PR TITLE
Make the Null Dao as default as H2 is not a production ready database and have a few CVEs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -64,14 +64,20 @@ The Pipeline Maven Plugin works with Linux, Windows and MacOSX build agents.
 .Simple Maven build on a Linux agent.
 [source,groovy]
 ----
-node {
-  stage ('Build') {
-    git url: 'https://github.com/cyrille-leclerc/multi-module-maven-project'
-    withMaven {
-      sh "mvn clean verify"
-    } // withMaven will discover the generated Maven artifacts, JUnit Surefire & FailSafe reports and FindBugs reports
+pipeline {
+  agent any
+  stages {
+    stage("Build") {
+      steps {
+        git url: 'https://github.com/cyrille-leclerc/multi-module-maven-project'
+        withMaven {
+          sh "mvn clean verify"
+        } // withMaven will discover the generated Maven artifacts, JUnit Surefire & FailSafe reports and FindBugs reports
+      }
+    }
   }
 }
+
 ----
 
 It can supports various parameters to fine-tune its behavior.
@@ -118,29 +124,33 @@ TIP: The Pipeline Syntax snippet code generator can be used to assist on generat
 .More complex Maven build on a Windows agent.
 [source,groovy]
 ----
-node ("windows") {
-  stage ('Build') {
+pipeline {
+  agent any
+  stages {
+    stage("Build") {
+      steps {
+        git url: 'https://github.com/cyrille-leclerc/multi-module-maven-project'
 
-    git url: 'https://github.com/cyrille-leclerc/multi-module-maven-project'
+        withMaven(
+            // Maven installation declared in the Jenkins "Global Tool Configuration"
+            maven: 'maven-3', // <1>
+            // Use `$WORKSPACE/.repository` for local repository folder to avoid shared repositories
+            mavenLocalRepo: '.repository', // <2>
+            // Maven settings.xml file defined with the Jenkins Config File Provider Plugin
+            // We recommend to define Maven settings.xml globally at the folder level using
+            // navigating to the folder configuration in the section "Pipeline Maven Configuration / Override global Maven configuration"
+            // or globally to the entire master navigating to  "Manage Jenkins / Global Tools Configuration"
+            mavenSettingsConfig: 'my-maven-settings' // <3>
+        ) {
 
-    withMaven(
-        // Maven installation declared in the Jenkins "Global Tool Configuration"
-        maven: 'maven-3', // <1>
-        // Use `$WORKSPACE/.repository` for local repository folder to avoid shared repositories
-        mavenLocalRepo: '.repository', // <2>
-        // Maven settings.xml file defined with the Jenkins Config File Provider Plugin
-        // We recommend to define Maven settings.xml globally at the folder level using
-        // navigating to the folder configuration in the section "Pipeline Maven Configuration / Override global Maven configuration"
-        // or globally to the entire master navigating to  "Manage Jenkins / Global Tools Configuration"
-        mavenSettingsConfig: 'my-maven-settings' // <3>
-    ) {
+          // Run the maven build
+          sh "mvn clean verify"
 
-      // Run the maven build
-      sh "mvn clean verify"
-
-    } // withMaven will discover the generated Maven artifacts, JUnit Surefire & FailSafe & FindBugs & SpotBugs reports...
+        } // withMaven will discover the generated Maven artifacts, JUnit Surefire & FailSafe & FindBugs & SpotBugs reports...
+    }
   }
 }
+
 ----
 
 In the above example the following parameters are used to configure Maven:
@@ -221,6 +231,21 @@ node {
     }
   }
 }
+
+
+pipeline {
+  agent any
+  stages {
+    stage("Build") {
+      steps {
+        withMaven(traceability: true){
+            .....
+        }
+      }
+    }
+  }
+}
+
 ----
 
 .Logs sample

--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,8 @@ The **<<feature-default-configuration>> can be defined globally or at the folder
 
 This plugin allows transitioning smoothly from the legacy https://plugins.jenkins.io/maven-plugin/[Maven Integration] job type by allowing to reuse **<<feature-maven-integration-global-settings>>** and by proposing the **<<feature-trigger-downstream>>**.
 
+Please note per default some features will not be available and you will have to change/configure a database storage which suits your environment.
+
 toc::[]
 
 [#installation]
@@ -46,8 +48,8 @@ The plugin can be found under the name `Pipeline Maven Integration Plugin` in th
 
 **For tests purposes only**, pre-releases (beta) versions are available in the https://updates.jenkins.io/#experimental-plugin-site[Experimental Plugin Site] and development versions (incremental releases) are archived on every successful build on https://ci.jenkins.io/job/Plugins/job/pipeline-maven-plugin/[our CI environment].
 
-CAUTION: **If you use the feature <<feature-trigger-downstream>> it is critical to <<db-setup,setup a real production database>>** instead of the default embedded H2 instance.
-**If you don't do it, it might degrade your environment stability** (The H2 database is running in your instance JVM and could request too many resources).
+CAUTION: **If you want to use the feature <<feature-trigger-downstream>> it is critical to <<db-setup,setup a database>>** as per default it's not anymore H2.
+**Using H2 might degrade your environment stability** (The H2 database is running in your instance JVM and could request too many resources).
 
 [#changelog]
 == Changelog

--- a/jenkins-plugin/pom.xml
+++ b/jenkins-plugin/pom.xml
@@ -187,6 +187,7 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>h2-api</artifactId>
       <version>${jenkins-plugin-h2.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
@@ -251,6 +251,10 @@ public class GlobalPipelineMavenConfig extends GlobalConfiguration {
         } else if (j.isTerminating()) {
             throw new IllegalStateException("Request to get DAO whilst Jenkins is terminating");
         }
+
+        if (dao != null) {
+            return dao;
+        }
         // if there is no dao and no jdbc url we use NullDao as we do not want to force users
         // to use jdbc driver with possible security issues
         if (dao == null && StringUtils.isBlank(jdbcUrl)) {

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
@@ -105,6 +105,8 @@ public class GlobalPipelineMavenConfig extends GlobalConfiguration {
     private String jdbcCredentialsId;
     private String properties;
 
+    private boolean noDataStorage;
+
     @DataBoundConstructor
     public GlobalPipelineMavenConfig() {
         load();
@@ -181,6 +183,15 @@ public class GlobalPipelineMavenConfig extends GlobalConfiguration {
         this.triggerDownstreamUponResultAborted = triggerDownstreamUponResultAborted;
     }
 
+    public boolean isNoDataStorage() {
+        return noDataStorage;
+    }
+
+    @DataBoundSetter
+    public void setNoDataStorage(boolean noDataStorage) {
+        this.noDataStorage = noDataStorage;
+    }
+
     public synchronized String getJdbcUrl() {
         return jdbcUrl;
     }
@@ -241,6 +252,10 @@ public class GlobalPipelineMavenConfig extends GlobalConfiguration {
             throw new IllegalStateException("Request to get DAO whilst Jenkins is terminating");
         }
         if (dao == null) {
+            if(noDataStorage || Boolean.getBoolean("PipelineMavenPluginDao.noDataStorage")) {
+                dao = new PipelineMavenPluginNullDao();
+                return dao;
+            }
             try {
                 String jdbcUrl, jdbcUserName, jdbcPassword;
                 if (StringUtils.isBlank(this.jdbcUrl)) {

--- a/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
+++ b/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig.java
@@ -251,104 +251,105 @@ public class GlobalPipelineMavenConfig extends GlobalConfiguration {
         } else if (j.isTerminating()) {
             throw new IllegalStateException("Request to get DAO whilst Jenkins is terminating");
         }
-        if (dao == null) {
-            if(noDataStorage || Boolean.getBoolean("PipelineMavenPluginDao.noDataStorage")) {
-                dao = new PipelineMavenPluginNullDao();
-                return dao;
+        // if there is no dao and no jdbc url we use NullDao as we do not want to force users
+        // to use jdbc driver with possible security issues
+        if (dao == null && StringUtils.isBlank(jdbcUrl)) {
+            dao = new PipelineMavenPluginNullDao();
+            return dao;
+        }
+
+        try {
+            String jdbcUrl, jdbcUserName, jdbcPassword;
+            if (StringUtils.isBlank(this.jdbcUrl)) {
+                // default embedded H2 database
+                File databaseRootDir = new File(j.getRootDir(), "jenkins-jobs");
+                if (!databaseRootDir.exists()) {
+                    boolean created = databaseRootDir.mkdirs();
+                    if (!created) {
+                        throw new IllegalStateException("Failure to create database root dir " + databaseRootDir);
+                    }
+                }
+                jdbcUrl = "jdbc:h2:file:" + new File(databaseRootDir, "jenkins-jobs").getAbsolutePath() + ";" +
+                        "AUTO_SERVER=TRUE;MULTI_THREADED=1;QUERY_CACHE_SIZE=25;JMX=TRUE";
+                jdbcUserName = "sa";
+                jdbcPassword = "sa";
+            } else {
+                jdbcUrl = this.jdbcUrl;
+                if (this.jdbcCredentialsId == null)
+                    throw new IllegalStateException("No credentials defined for JDBC URL '" + jdbcUrl + "'");
+
+                UsernamePasswordCredentials jdbcCredentials = (UsernamePasswordCredentials) CredentialsMatchers.firstOrNull(
+                        CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class, j,
+                                ACL.SYSTEM, Collections.EMPTY_LIST),
+                        CredentialsMatchers.withId(this.jdbcCredentialsId));
+                if (jdbcCredentials == null) {
+                    throw new IllegalStateException("Credentials '" + jdbcCredentialsId + "' defined for JDBC URL '" + jdbcUrl + "' NOT found");
+                }
+                jdbcUserName = jdbcCredentials.getUsername();
+                jdbcPassword = Secret.toString(jdbcCredentials.getPassword());
+            }
+
+            HikariConfig dsConfig = createHikariConfig(properties, jdbcUrl, jdbcUserName, jdbcPassword);
+            dsConfig.setAutoCommit(false);
+
+            // TODO cleanup this quick fix for JENKINS-54587, we should have a better solution with the JDBC driver loaded by the DAO itself
+            try {
+                DriverManager.getDriver(jdbcUrl);
+            } catch (SQLException e) {
+                if ("08001".equals(e.getSQLState()) && 0 == e.getErrorCode()) {
+                    // if it's a "No suitable driver" exception, we try to load the jdbc driver and retry
+                    if (jdbcUrl.startsWith("jdbc:h2:")) {
+                        try {
+                            Class.forName("org.h2.Driver");
+                        } catch (ClassNotFoundException cnfe) {
+                            throw new IllegalStateException("H2 driver should be bundled with this plugin");
+                        }
+                    } else if (jdbcUrl.startsWith("jdbc:mysql:")) {
+                        try {
+                            Class.forName("com.mysql.cj.jdbc.Driver");
+                        } catch (ClassNotFoundException cnfe) {
+                            throw new RuntimeException("MySql driver 'com.mysql.cj.jdbc.Driver' not found. Please install the 'MySQL Database Plugin' to install the MySql driver");
+                        }
+                    } else if (jdbcUrl.startsWith("jdbc:postgresql:")) {
+                        try {
+                            Class.forName("org.postgresql.Driver");
+                        } catch (ClassNotFoundException cnfe) {
+                            throw new RuntimeException("PostgreSQL driver 'org.postgresql.Driver' not found. Please install the 'PostgreSQL Database Plugin' to install the PostgreSQL driver");
+                        }
+                    } else {
+                        throw new IllegalArgumentException("Unsupported database type in JDBC URL " + jdbcUrl);
+                    }
+                    DriverManager.getDriver(jdbcUrl);
+                } else {
+                    throw e;
+                }
+            }
+
+            LOGGER.log(Level.INFO, "Connect to database {0} with username {1}", new Object[]{jdbcUrl, jdbcUserName});
+            DataSource ds = new HikariDataSource(dsConfig);
+
+            Class<? extends PipelineMavenPluginDao> daoClass;
+            if (jdbcUrl.startsWith("jdbc:h2:")) {
+                daoClass = PipelineMavenPluginH2Dao.class;
+            } else if (jdbcUrl.startsWith("jdbc:mysql:")) {
+                daoClass = PipelineMavenPluginMySqlDao.class;
+            } else if (jdbcUrl.startsWith("jdbc:postgresql:")) {
+                daoClass = PipelineMavenPluginPostgreSqlDao.class;
+            } else {
+                throw new IllegalArgumentException("Unsupported database type in JDBC URL " + jdbcUrl);
             }
             try {
-                String jdbcUrl, jdbcUserName, jdbcPassword;
-                if (StringUtils.isBlank(this.jdbcUrl)) {
-                    // default embedded H2 database
-                    File databaseRootDir = new File(j.getRootDir(), "jenkins-jobs");
-                    if (!databaseRootDir.exists()) {
-                        boolean created = databaseRootDir.mkdirs();
-                        if (!created) {
-                            throw new IllegalStateException("Failure to create database root dir " + databaseRootDir);
-                        }
-                    }
-                    jdbcUrl = "jdbc:h2:file:" + new File(databaseRootDir, "jenkins-jobs").getAbsolutePath() + ";" +
-                            "AUTO_SERVER=TRUE;MULTI_THREADED=1;QUERY_CACHE_SIZE=25;JMX=TRUE";
-                    jdbcUserName = "sa";
-                    jdbcPassword = "sa";
-                } else {
-                    jdbcUrl = this.jdbcUrl;
-                    if (this.jdbcCredentialsId == null)
-                        throw new IllegalStateException("No credentials defined for JDBC URL '" + jdbcUrl + "'");
-
-                    UsernamePasswordCredentials jdbcCredentials = (UsernamePasswordCredentials) CredentialsMatchers.firstOrNull(
-                            CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class, j,
-                                    ACL.SYSTEM, Collections.EMPTY_LIST),
-                            CredentialsMatchers.withId(this.jdbcCredentialsId));
-                    if (jdbcCredentials == null) {
-                        throw new IllegalStateException("Credentials '" + jdbcCredentialsId + "' defined for JDBC URL '" + jdbcUrl + "' NOT found");
-                    }
-                    jdbcUserName = jdbcCredentials.getUsername();
-                    jdbcPassword = Secret.toString(jdbcCredentials.getPassword());
-                }
-
-                HikariConfig dsConfig = createHikariConfig(properties, jdbcUrl, jdbcUserName, jdbcPassword);
-                dsConfig.setAutoCommit(false);
-
-                // TODO cleanup this quick fix for JENKINS-54587, we should have a better solution with the JDBC driver loaded by the DAO itself
-                try {
-                    DriverManager.getDriver(jdbcUrl);
-                } catch (SQLException e) {
-                    if ("08001".equals(e.getSQLState()) && 0 == e.getErrorCode()) {
-                        // if it's a "No suitable driver" exception, we try to load the jdbc driver and retry
-                        if (jdbcUrl.startsWith("jdbc:h2:")) {
-                            try {
-                                Class.forName("org.h2.Driver");
-                            } catch (ClassNotFoundException cnfe) {
-                                throw new IllegalStateException("H2 driver should be bundled with this plugin");
-                            }
-                        } else if (jdbcUrl.startsWith("jdbc:mysql:")) {
-                            try {
-                                Class.forName("com.mysql.cj.jdbc.Driver");
-                            } catch (ClassNotFoundException cnfe) {
-                                throw new RuntimeException("MySql driver 'com.mysql.cj.jdbc.Driver' not found. Please install the 'MySQL Database Plugin' to install the MySql driver");
-                            }
-                        } else if (jdbcUrl.startsWith("jdbc:postgresql:")) {
-                            try {
-                                Class.forName("org.postgresql.Driver");
-                            } catch (ClassNotFoundException cnfe) {
-                                throw new RuntimeException("PostgreSQL driver 'org.postgresql.Driver' not found. Please install the 'PostgreSQL Database Plugin' to install the PostgreSQL driver");
-                            }
-                        } else {
-                            throw new IllegalArgumentException("Unsupported database type in JDBC URL " + jdbcUrl);
-                        }
-                        DriverManager.getDriver(jdbcUrl);
-                    } else {
-                        throw e;
-                    }
-                }
-
-                LOGGER.log(Level.INFO, "Connect to database {0} with username {1}", new Object[]{jdbcUrl, jdbcUserName});
-                DataSource ds = new HikariDataSource(dsConfig);
-
-                Class<? extends PipelineMavenPluginDao> daoClass;
-                if (jdbcUrl.startsWith("jdbc:h2:")) {
-                    daoClass = PipelineMavenPluginH2Dao.class;
-                } else if (jdbcUrl.startsWith("jdbc:mysql:")) {
-                    daoClass = PipelineMavenPluginMySqlDao.class;
-                } else if (jdbcUrl.startsWith("jdbc:postgresql:")) {
-                    daoClass = PipelineMavenPluginPostgreSqlDao.class;
-                } else {
-                    throw new IllegalArgumentException("Unsupported database type in JDBC URL " + jdbcUrl);
-                }
-                try {
-                    dao = new MonitoringPipelineMavenPluginDaoDecorator(new CustomTypePipelineMavenPluginDaoDecorator(daoClass.getConstructor(DataSource.class).newInstance(ds)));
-                } catch (Exception e) {
-                    throw new SQLException(
-                            "Exception connecting to '" + this.jdbcUrl + "' with credentials '" + this.jdbcCredentialsId + "' (" +
-                                    jdbcUserName + "/***) and DAO " + daoClass.getSimpleName(), e);
-                }
-
-
-            } catch (RuntimeException | SQLException e) {
-                LOGGER.log(Level.WARNING, "Exception creating database dao, skip", e);
-                dao = new PipelineMavenPluginNullDao();
+                dao = new MonitoringPipelineMavenPluginDaoDecorator(new CustomTypePipelineMavenPluginDaoDecorator(daoClass.getConstructor(DataSource.class).newInstance(ds)));
+            } catch (Exception e) {
+                throw new SQLException(
+                        "Exception connecting to '" + this.jdbcUrl + "' with credentials '" + this.jdbcCredentialsId + "' (" +
+                                jdbcUserName + "/***) and DAO " + daoClass.getSimpleName(), e);
             }
+
+
+        } catch (RuntimeException | SQLException e) {
+            LOGGER.log(Level.WARNING, "Exception creating database dao, skip", e);
+            dao = new PipelineMavenPluginNullDao();
         }
         return dao;
     }

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/config.jelly
@@ -30,8 +30,8 @@ THE SOFTWARE.
         <f:entry title="${%DAO}">
             <pre><code>${instance.dao.toPrettyString()}</code></pre>
         </f:entry>
-        <f:entry title="${%No Data Storage}">
-            <f:checkbox title="${%Do not store any data}" field="noDataStorage"/>
+        <f:entry title="${%No Data Storage}" field="noDataStorage">
+            <f:checkbox title="${%Do not store any data}" />
         </f:entry>
         <f:entry title="${%Database Configuration}">
             <f:entry title="${%JDBC URL}" field="jdbcUrl"

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/config.jelly
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/config.jelly
@@ -30,6 +30,9 @@ THE SOFTWARE.
         <f:entry title="${%DAO}">
             <pre><code>${instance.dao.toPrettyString()}</code></pre>
         </f:entry>
+        <f:entry title="${%No Data Storage}">
+            <f:checkbox title="${%Do not store any data}" field="noDataStorage"/>
+        </f:entry>
         <f:entry title="${%Database Configuration}">
             <f:entry title="${%JDBC URL}" field="jdbcUrl"
                      description="JDBC URL. For production workloads, use MySQL (incl. Amazon Aurora for MySQL, MariaDB...) or PostgreSQL. If empty, then a non production grade H2 embedded database will be used.">

--- a/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/help-noDataStorage.html
+++ b/jenkins-plugin/src/main/resources/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfig/help-noDataStorage.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Using this option means you will not store some data and disable some feature such snapshot downstream triggering (when using deploy phase)
+    </p>
+</div>

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
@@ -84,22 +84,26 @@ public abstract class AbstractIntegrationTest {
 
     }
 
+    public static void initializeH2(Jenkins jenkins) throws Exception {
+        File databaseRootDir = new File("target", "h2-test");
+        String jdbcUrl = "jdbc:h2:file:" + new File(databaseRootDir, "jenkins-jobs").getAbsolutePath() + ";" +
+                "AUTO_SERVER=TRUE;MULTI_THREADED=1;QUERY_CACHE_SIZE=25;JMX=TRUE";
+        GlobalPipelineMavenConfig.get().setJdbcUrl(jdbcUrl);
+
+        String credsId = "jdbcCredsId";
+        UsernamePasswordCredentialsImpl c =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credsId, "sample", "sa", "sa");
+        CredentialsProvider.lookupStores(jenkins).iterator().next().addCredentials(Domain.global(), c);
+        GlobalPipelineMavenConfig.get().setJdbcCredentialsId(credsId);
+    }
+
     @BeforeEach
     public void setup(JenkinsRule r) throws Exception {
 
         jenkinsRule = r;
 
         if (StringUtils.isBlank(GlobalPipelineMavenConfig.get().getJdbcUrl())) {
-            File databaseRootDir = new File("target", "h2-test");
-            String jdbcUrl = "jdbc:h2:file:" + new File(databaseRootDir, "jenkins-jobs").getAbsolutePath() + ";" +
-                    "AUTO_SERVER=TRUE;MULTI_THREADED=1;QUERY_CACHE_SIZE=25;JMX=TRUE";
-            GlobalPipelineMavenConfig.get().setJdbcUrl(jdbcUrl);
-
-            String credsId = "jdbcCredsId";
-            UsernamePasswordCredentialsImpl c =
-                    new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credsId, "sample", "sa", "sa");
-            CredentialsProvider.lookupStores(jenkinsRule.getInstance()).iterator().next().addCredentials(Domain.global(), c);
-            GlobalPipelineMavenConfig.get().setJdbcCredentialsId(credsId);
+            initializeH2(jenkinsRule.getInstance());
         }
 
         gitRepoRule = new GitSampleRepoRule();

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/DependencyGraphTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/DependencyGraphTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.jenkinsci.plugins.pipeline.maven.TestUtils.runAfterMethod;
 import static org.jenkinsci.plugins.pipeline.maven.TestUtils.runBeforeMethod;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -50,6 +51,7 @@ public class DependencyGraphTest extends AbstractIntegrationTest {
             publisherOptions = new ArrayList<>();
             GlobalPipelineMavenConfig.get().setPublisherOptions(publisherOptions);
         }
+
         publisherOptions.add(publisher);
     }
 

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfigTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfigTest.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.pipeline.maven.dao.MonitoringPipelineMavenPluginDao
 import org.jenkinsci.plugins.pipeline.maven.dao.PipelineMavenPluginDao;
 import org.jenkinsci.plugins.pipeline.maven.dao.PipelineMavenPluginH2Dao;
 import org.jenkinsci.plugins.pipeline.maven.dao.PipelineMavenPluginMySqlDao;
+import org.jenkinsci.plugins.pipeline.maven.dao.PipelineMavenPluginNullDao;
 import org.jenkinsci.plugins.pipeline.maven.dao.PipelineMavenPluginPostgreSqlDao;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -79,14 +80,9 @@ public class GlobalPipelineMavenConfigTest {
     private GlobalPipelineMavenConfig config = new GlobalPipelineMavenConfig();
 
     @Test
-    public void shouldBuildH2Dao() throws Exception {
+    public void shouldBuildPipelineMavenPluginNullDao() throws Exception {
         PipelineMavenPluginDao dao = config.getDao();
-
-        assertThat(dao).isInstanceOf(MonitoringPipelineMavenPluginDaoDecorator.class);
-        Object innerDao = getField(dao, "delegate");
-        assertThat(innerDao).isInstanceOf(CustomTypePipelineMavenPluginDaoDecorator.class);
-        innerDao = getField(innerDao, "delegate");
-        assertThat(innerDao).isInstanceOf(PipelineMavenPluginH2Dao.class);
+        assertThat(dao).isInstanceOf(PipelineMavenPluginNullDao.class);
     }
 
     @Test

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/NonProductionGradeDatabaseWarningAdministrativeMonitorIntegrationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/NonProductionGradeDatabaseWarningAdministrativeMonitorIntegrationTest.java
@@ -57,6 +57,7 @@ public class NonProductionGradeDatabaseWarningAdministrativeMonitorIntegrationTe
 
     @Test
     public void shouldMitigateComputationWithH2Database(JenkinsRule j) throws Exception {
+
         NonProductionGradeDatabaseWarningAdministrativeMonitor monitor = j.getInstance().getExtensionList(AdministrativeMonitor.class)
                 .get(NonProductionGradeDatabaseWarningAdministrativeMonitor.class);
         assertThat(monitor).isNotNull();
@@ -69,15 +70,10 @@ public class NonProductionGradeDatabaseWarningAdministrativeMonitorIntegrationTe
         assertThat(GlobalPipelineMavenConfig.get().isDaoInitialized()).isFalse();
         assertThat(monitor.isActivated()).isTrue();
 
-        GlobalPipelineMavenConfig.get().setJdbcUrl(null);
-
-        assertThat(GlobalPipelineMavenConfig.get().isDaoInitialized()).isFalse();
-        assertThat(monitor.isActivated()).isFalse();
-
         GlobalPipelineMavenConfig.get().getDao();
 
         assertThat(GlobalPipelineMavenConfig.get().isDaoInitialized()).isTrue();
-        assertThat(monitor.isActivated()).isFalse();
+        assertThat(monitor.isActivated()).isTrue();
 
         for (int i = 1; i <= 101; i++) {
             GlobalPipelineMavenConfig.get().getDao().recordGeneratedArtifact("a job", i, "a.group.id", "anArtifactId", "1.0.0-SNAPSHOT", "jar",

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_default.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_default.yml
@@ -1,4 +1,5 @@
 globalTraceability: false
+noDataStorage: false
 triggerDownstreamUponResultAborted: false
 triggerDownstreamUponResultFailure: false
 triggerDownstreamUponResultNotBuilt: false

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_mysql.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_mysql.yml
@@ -1,5 +1,6 @@
 globalTraceability: false
 jdbcUrl: "jdbc:mysql://dbserver/jenkinsdb"
+noDataStorage: false
 properties: |
   dataSource.cachePrepStmts=true
   dataSource.prepStmtCacheSize=250

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_postgresql.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_postgresql.yml
@@ -1,6 +1,7 @@
 globalTraceability: false
 jdbcCredentialsId: "pg-creds"
 jdbcUrl: "jdbc:postgresql://dbserver/jenkinsdb"
+noDataStorage: false
 triggerDownstreamUponResultAborted: false
 triggerDownstreamUponResultFailure: false
 triggerDownstreamUponResultNotBuilt: false

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_publishers.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_publishers.yml
@@ -1,4 +1,5 @@
 globalTraceability: false
+noDataStorage: false
 publisherOptions:
 - mavenLinkerPublisher:
     disabled: true

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_traceability.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_traceability.yml
@@ -1,4 +1,5 @@
 globalTraceability: true
+noDataStorage: false
 triggerDownstreamUponResultAborted: false
 triggerDownstreamUponResultFailure: false
 triggerDownstreamUponResultNotBuilt: false

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_triggers.yml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/expected_output_triggers.yml
@@ -1,4 +1,5 @@
 globalTraceability: false
+noDataStorage: false
 triggerDownstreamUponResultAborted: true
 triggerDownstreamUponResultFailure: true
 triggerDownstreamUponResultNotBuilt: true


### PR DESCRIPTION
The current design makes H2 database choice, whereas it's finally not recommended as not production grade (this is a bit confusing...).
Furthermore, this makes a required dependency on H2 driver which presents the following CVEs records!

- [CVE-2022-23221](https://nvd.nist.gov/vuln/detail/CVE-2022-23221): h2-api@11.1.4.199-999999-SNAPSHOT > com.h2database:h2@1.4.199, Upgrade com.h2database:h2 to version 2.1.210 or higher.
- [CVE-2021-23463](https://nvd.nist.gov/vuln/detail/CVE-2021-23463): h2-api@11.1.4.199-999999-SNAPSHOT > com.h2database:h2@1.4.199, Upgrade com.h2database:h2 to version 2.0.202 or higher.
- [CVE-2021-42392](https://nvd.nist.gov/vuln/detail/CVE-2021-42392): h2-api@11.1.4.199-999999-SNAPSHOT > com.h2database:h2@1.4.199, Upgrade com.h2database:h2 to version 2.0.206 or higher.
- [CVE-2018-10054](https://nvd.nist.gov/vuln/detail/CVE-2018-10054): h2-api@11.1.4.199-999999-SNAPSHOT > com.h2database:h2@1.4.199, There is no fixed version for com.h2database:h2.
- [CVE-2022-45868](https://nvd.nist.gov/vuln/detail/CVE-2022-45868): h2-api@11.1.4.199-999999-SNAPSHOT > com.h2database:h2@1.4.199, There is no fixed version for com.h2database:h2.

A better design could be having the dao as extension point and so use the available one.
But this will have the disadvantage of being non backward compatible.
The current PR will be backward compatible for users who were using H2 as it will be still installed.
