### PR TITLE
Use pre build docker images to avoid costly and long re build of images

### DIFF
--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
@@ -24,6 +24,7 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -38,6 +39,7 @@ import jenkins.mvn.DefaultSettingsProvider;
 import jenkins.mvn.GlobalMavenConfig;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.scm.impl.mock.GitSampleRepoRuleUtils;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
@@ -46,18 +48,48 @@ import jenkins.scm.impl.mock.GitSampleRepoRuleUtils;
 @WithJenkins
 public abstract class AbstractIntegrationTest {
 
+//    To build this image
+//    sha1sum jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
+//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:JavaGitContainer-19c965b94d49ac3af6bb58fcb7a3d9c2f480e9e7
+//    docker push olamy/pipeline-maven-plugin:JavaGitContainer-19c965b94d49ac3af6bb58fcb7a3d9c2f480e9e7
     @Container
-    public GenericContainer<?> javaGitContainerRule = new GenericContainer<>(new ImageFromDockerfile("jenkins/pipeline-maven-java-git", true)
-            .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile")).withExposedPorts(22);
+    public GenericContainer<?> javaGitContainerRule =
+            new GenericContainer<>(DockerImageName.parse("olamy/pipeline-maven-plugin:JavaGitContainer-19c965b94d49ac3af6bb58fcb7a3d9c2f480e9e7"))
+                .withExposedPorts(22);
+
+//    to run from classpath file
+//    @Container
+//    public GenericContainer<?> javaGitContainerRule = new GenericContainer<>(new ImageFromDockerfile("jenkins/pipeline-maven-java-git", true)
+//            .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile")).withExposedPorts(22);
+
+    // To build this image
+//    sha1sum jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
+//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:NonMavenJavaContainer-b570d89a92b2403d493a3e557083219b0522e25c
+//    docker push olamy/pipeline-maven-plugin:NonMavenJavaContainer-b570d89a92b2403d493a3e557083219b0522e25c
+    @Container
+    public GenericContainer<?> nonMavenContainerRule =
+            new GenericContainer<>(DockerImageName.parse("olamy/pipeline-maven-plugin:NonMavenJavaContainer-b570d89a92b2403d493a3e557083219b0522e25c"))
+                    .withExposedPorts(22);
+//    to run from classpath file
+//    public GenericContainer<?> nonMavenContainerRule =
+//            new GenericContainer<>(new ImageFromDockerfile("jenkins/pipeline-maven-non-maven", true)
+//                    .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile")).withExposedPorts(22);
+
+
+//    To build this image
+//    sha1sum jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile
+//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:MavenWithMavenHomeJavaContainer-e3e86a51761591f6036c6d5daf19d13284b5f205
+//    docker push olamy/pipeline-maven-plugin:MavenWithMavenHomeJavaContainer-e3e86a51761591f6036c6d5daf19d13284b5f205
 
     @Container
-    public GenericContainer<?> nonMavenContainerRule = new GenericContainer<>(new ImageFromDockerfile("jenkins/pipeline-maven-non-maven", true)
-            .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile")).withExposedPorts(22);
-
-    @Container
-    public GenericContainer<?> mavenWithMavenHomeContainerRule = new GenericContainer<>(new ImageFromDockerfile("jenkins/pipeline-maven-java", true)
-            .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile"))
-            .withExposedPorts(22);
+    public GenericContainer<?> mavenWithMavenHomeContainerRule =
+            new GenericContainer<>(DockerImageName.parse("olamy/pipeline-maven-plugin:MavenWithMavenHomeJavaContainer-e3e86a51761591f6036c6d5daf19d13284b5f205"))
+                    .withExposedPorts(22);
+//    to run from classpath file
+//    @Container
+//    public GenericContainer<?> mavenWithMavenHomeContainerRule = new GenericContainer<>(new ImageFromDockerfile("jenkins/pipeline-maven-java", true)
+//            .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile"))
+//            .withExposedPorts(22);
 
     public static BuildWatcher buildWatcher;
 

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
@@ -48,13 +48,19 @@ import org.testcontainers.utility.DockerImageName;
 @WithJenkins
 public abstract class AbstractIntegrationTest {
 
+//    To build the parent image
+//    sha1sum jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/SshdContainer/Dockerfile
+//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/SshdContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:SshdContainer-32edfdd581112ff75ef6bbd6b0e576371f0089e3
+//    docker push olamy/pipeline-maven-plugin:SshdContainer-32edfdd581112ff75ef6bbd6b0e576371f0089e3
+
+
 //    To build this image
 //    sha1sum jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
-//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:JavaGitContainer-19c965b94d49ac3af6bb58fcb7a3d9c2f480e9e7
-//    docker push olamy/pipeline-maven-plugin:JavaGitContainer-19c965b94d49ac3af6bb58fcb7a3d9c2f480e9e7
+//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:JavaGitContainer-fe3065996fcbb067d17b078f414020db1d63afcc
+//    docker push olamy/pipeline-maven-plugin:JavaGitContainer-fe3065996fcbb067d17b078f414020db1d63afcc
     @Container
     public GenericContainer<?> javaGitContainerRule =
-            new GenericContainer<>(DockerImageName.parse("olamy/pipeline-maven-plugin:JavaGitContainer-19c965b94d49ac3af6bb58fcb7a3d9c2f480e9e7"))
+            new GenericContainer<>(DockerImageName.parse("olamy/pipeline-maven-plugin:JavaGitContainer-fe3065996fcbb067d17b078f414020db1d63afcc"))
                 .withExposedPorts(22);
 
 //    to run from classpath file
@@ -62,10 +68,10 @@ public abstract class AbstractIntegrationTest {
 //    public GenericContainer<?> javaGitContainerRule = new GenericContainer<>(new ImageFromDockerfile("jenkins/pipeline-maven-java-git", true)
 //            .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile")).withExposedPorts(22);
 
-    // To build this image
+//    To build this image
 //    sha1sum jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
-//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:NonMavenJavaContainer-b13715c6c45cf3c01bc8a9340abd4017396e30bb
-//    docker push olamy/pipeline-maven-plugin:NonMavenJavaContainer-b13715c6c45cf3c01bc8a9340abd4017396e30bb
+//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:NonMavenJavaContainer-4810152e3b5d42b3ea25bfc7dc08cdd4da6aaf51
+//    docker push olamy/pipeline-maven-plugin:NonMavenJavaContainer-4810152e3b5d42b3ea25bfc7dc08cdd4da6aaf51
     @Container
     public GenericContainer<?> nonMavenContainerRule =
             new GenericContainer<>(DockerImageName.parse("olamy/pipeline-maven-plugin:NonMavenJavaContainer-b13715c6c45cf3c01bc8a9340abd4017396e30bb"))
@@ -78,8 +84,8 @@ public abstract class AbstractIntegrationTest {
 
 //    To build this image
 //    sha1sum jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile
-//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:MavenWithMavenHomeJavaContainer-e3e86a51761591f6036c6d5daf19d13284b5f205
-//    docker push olamy/pipeline-maven-plugin:MavenWithMavenHomeJavaContainer-e3e86a51761591f6036c6d5daf19d13284b5f205
+//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:MavenWithMavenHomeJavaContainer-8883e396ed7837d2b712865ffd460ef190dee600
+//    docker push olamy/pipeline-maven-plugin:MavenWithMavenHomeJavaContainer-8883e396ed7837d2b712865ffd460ef190dee600
 
     @Container
     public GenericContainer<?> mavenWithMavenHomeContainerRule =

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/AbstractIntegrationTest.java
@@ -64,11 +64,11 @@ public abstract class AbstractIntegrationTest {
 
     // To build this image
 //    sha1sum jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
-//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:NonMavenJavaContainer-b570d89a92b2403d493a3e557083219b0522e25c
-//    docker push olamy/pipeline-maven-plugin:NonMavenJavaContainer-b570d89a92b2403d493a3e557083219b0522e25c
+//    docker build -f jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/ -t olamy/pipeline-maven-plugin:NonMavenJavaContainer-b13715c6c45cf3c01bc8a9340abd4017396e30bb
+//    docker push olamy/pipeline-maven-plugin:NonMavenJavaContainer-b13715c6c45cf3c01bc8a9340abd4017396e30bb
     @Container
     public GenericContainer<?> nonMavenContainerRule =
-            new GenericContainer<>(DockerImageName.parse("olamy/pipeline-maven-plugin:NonMavenJavaContainer-b570d89a92b2403d493a3e557083219b0522e25c"))
+            new GenericContainer<>(DockerImageName.parse("olamy/pipeline-maven-plugin:NonMavenJavaContainer-b13715c6c45cf3c01bc8a9340abd4017396e30bb"))
                     .withExposedPorts(22);
 //    to run from classpath file
 //    public GenericContainer<?> nonMavenContainerRule =

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepMavenExecResolutionTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepMavenExecResolutionTest.java
@@ -30,8 +30,10 @@ import java.util.Collections;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.LoggerRule;
 import org.testcontainers.containers.GenericContainer;
 
 import com.cloudbees.plugins.credentials.Credentials;
@@ -51,6 +53,9 @@ import hudson.tools.InstallSourceProperty;
 
 @Issue("JENKINS-43651")
 public class WithMavenStepMavenExecResolutionTest extends AbstractIntegrationTest {
+
+    @Rule
+    public final LoggerRule loggerRule = new LoggerRule();
 
     private static final String SSH_CREDENTIALS_ID = "test";
     private static final String AGENT_NAME = "remote";

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepMavenExecResolutionTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepMavenExecResolutionTest.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.maven;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
+import java.util.logging.Level;
 
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -69,6 +70,7 @@ public class WithMavenStepMavenExecResolutionTest extends AbstractIntegrationTes
 
     @Test
     public void testMavenGlobalToolRecognizedInScriptedPipeline() throws Exception {
+        loggerRule.record("hudson.plugins.sshslaves", Level.FINEST);
         registerAgentForContainer(nonMavenContainerRule);
         String version = registerLatestMavenVersionAsGlobalTool();
 

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
@@ -2,37 +2,15 @@
 # Container for running Jenkins builds using Git
 #
 
-FROM ubuntu:bionic
+FROM olamy/pipeline-maven-plugin:SshdContainer-32edfdd581112ff75ef6bbd6b0e576371f0089e3
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         software-properties-common \
         openjdk-11-jdk-headless \
-        curl \
-        ant \
         maven \
         git
 
-# install SSHD
-RUN apt-get install -y \
-        openssh-server \
-        locales
-RUN mkdir -p /var/run/sshd
-
-# create a test user
-RUN useradd test -d /home/test && \
-    mkdir -p /home/test/.ssh && \
-    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDzpxmTW9mH87DMkMSqBrSecoSHVCkKbW5IOO+4unak8M8cyn+b0iX07xkBn4hUJRfKA7ezUG8EX9ru5VinteqMOJOPknCuzmUS2Xj/WJdcq3BukBxuyiIRoUOXsCZzilR/DOyNqpjjI3iNb4los5//4aoKPCmLInFnQ3Y42VaimH1298ckEr4tRxsoipsEAANPXZ3p48gGwOf1hp56bTFImvATNwxMViPpqyKcyVaA7tXCBnEk/GEwb6MiroyHbS0VvBz9cZOpJv+8yQnyLndGdibk+hPbGp5iVAIsm28FEF+4FvlYlpBwq9OYuhOCREJvH9CxDMhbOXgwKPno9GyN kohsuke@atlas' > /home/test/.ssh/authorized_keys && \
-    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDagNSCDst/8z5oH9S5QWr+QNdx+haImY0FD3IQvKdD+eWI9zUbBgtoo/yYEbLvpTWiKsgT3Hw1F8mZ+/bd2Uv3lPyoG+TSzrHL4gSal6d1RWVjCOzSosciXVm4gRUvJjKXzaz8dOg+ii9yIrbeONNK0nlDUCAKy5YXSEl0avcPdUDyR3cStL6870SyanxAzktDw0n8xMq4F/alF3PZ002bcZJrmDeNVAwkP+uO2Tf8pN37SU+nApotZmlmZR32xYHnx+/OiQ7gOAVYmgNRMg0Kwh6Q73FcY3ZWCeNHwLnr95LoEAdj3On8Qr62VhGThuQNVCqBc6SeYjArfjijpcW9 jenkins-ci@localhost' >> /home/test/.ssh/authorized_keys && \
-    chown -R test:test /home/test && \
-    chmod 0600 /home/test/.ssh/authorized_keys && \
-    echo "test:test" | chpasswd
-
-# https://stackoverflow.com/a/38553499/12916
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8
-ENV LANG en_US.UTF-8
 
 # run SSHD in the foreground with error messages to stderr
 ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e"]

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/MavenWithMavenHomeJavaContainer/Dockerfile
@@ -1,33 +1,10 @@
-FROM ubuntu:bionic
+FROM olamy/pipeline-maven-plugin:SshdContainer-32edfdd581112ff75ef6bbd6b0e576371f0089e3
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         software-properties-common \
         openjdk-11-jdk-headless \
-        curl \
-        ant \
-        maven \
-        git
-
-# install SSHD
-RUN apt-get install -y \
-        openssh-server \
-        locales
-RUN mkdir -p /var/run/sshd
-
-# create a test user
-RUN useradd test -d /home/test && \
-    mkdir -p /home/test/.ssh && \
-    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDzpxmTW9mH87DMkMSqBrSecoSHVCkKbW5IOO+4unak8M8cyn+b0iX07xkBn4hUJRfKA7ezUG8EX9ru5VinteqMOJOPknCuzmUS2Xj/WJdcq3BukBxuyiIRoUOXsCZzilR/DOyNqpjjI3iNb4los5//4aoKPCmLInFnQ3Y42VaimH1298ckEr4tRxsoipsEAANPXZ3p48gGwOf1hp56bTFImvATNwxMViPpqyKcyVaA7tXCBnEk/GEwb6MiroyHbS0VvBz9cZOpJv+8yQnyLndGdibk+hPbGp5iVAIsm28FEF+4FvlYlpBwq9OYuhOCREJvH9CxDMhbOXgwKPno9GyN kohsuke@atlas' > /home/test/.ssh/authorized_keys && \
-    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDagNSCDst/8z5oH9S5QWr+QNdx+haImY0FD3IQvKdD+eWI9zUbBgtoo/yYEbLvpTWiKsgT3Hw1F8mZ+/bd2Uv3lPyoG+TSzrHL4gSal6d1RWVjCOzSosciXVm4gRUvJjKXzaz8dOg+ii9yIrbeONNK0nlDUCAKy5YXSEl0avcPdUDyR3cStL6870SyanxAzktDw0n8xMq4F/alF3PZ002bcZJrmDeNVAwkP+uO2Tf8pN37SU+nApotZmlmZR32xYHnx+/OiQ7gOAVYmgNRMg0Kwh6Q73FcY3ZWCeNHwLnr95LoEAdj3On8Qr62VhGThuQNVCqBc6SeYjArfjijpcW9 jenkins-ci@localhost' >> /home/test/.ssh/authorized_keys && \
-    chown -R test:test /home/test && \
-    chmod 0600 /home/test/.ssh/authorized_keys && \
-    echo "test:test" | chpasswd
-
-# https://stackoverflow.com/a/38553499/12916
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8
+        maven
 
 ENV MAVEN_HOME="/usr/share/maven"
 

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
@@ -1,16 +1,12 @@
+#
+# Runs sshd and allow the 'test' user to login
+#
+
 FROM ubuntu:bionic
 
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
-        software-properties-common \
-        openjdk-11-jdk-headless \
-        curl \
-        ant \
-        maven \
-        git
-
 # install SSHD
-RUN apt-get install -y \
+RUN apt-get update -y && \
+    apt-get install -y \
         openssh-server \
         locales
 RUN mkdir -p /var/run/sshd
@@ -28,10 +24,15 @@ RUN useradd test -d /home/test && \
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
 
-RUN apt-get remove maven -y
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        software-properties-common \
+        openjdk-11-jdk-headless \
+        curl \
+        ant
 
 # run SSHD in the foreground with error messages to stderr
 ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e"]
-
 

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/NonMavenJavaContainer/Dockerfile
@@ -2,36 +2,12 @@
 # Runs sshd and allow the 'test' user to login
 #
 
-FROM ubuntu:bionic
-
-# install SSHD
-RUN apt-get update -y && \
-    apt-get install -y \
-        openssh-server \
-        locales
-RUN mkdir -p /var/run/sshd
-
-# create a test user
-RUN useradd test -d /home/test && \
-    mkdir -p /home/test/.ssh && \
-    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDzpxmTW9mH87DMkMSqBrSecoSHVCkKbW5IOO+4unak8M8cyn+b0iX07xkBn4hUJRfKA7ezUG8EX9ru5VinteqMOJOPknCuzmUS2Xj/WJdcq3BukBxuyiIRoUOXsCZzilR/DOyNqpjjI3iNb4los5//4aoKPCmLInFnQ3Y42VaimH1298ckEr4tRxsoipsEAANPXZ3p48gGwOf1hp56bTFImvATNwxMViPpqyKcyVaA7tXCBnEk/GEwb6MiroyHbS0VvBz9cZOpJv+8yQnyLndGdibk+hPbGp5iVAIsm28FEF+4FvlYlpBwq9OYuhOCREJvH9CxDMhbOXgwKPno9GyN kohsuke@atlas' > /home/test/.ssh/authorized_keys && \
-    echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDagNSCDst/8z5oH9S5QWr+QNdx+haImY0FD3IQvKdD+eWI9zUbBgtoo/yYEbLvpTWiKsgT3Hw1F8mZ+/bd2Uv3lPyoG+TSzrHL4gSal6d1RWVjCOzSosciXVm4gRUvJjKXzaz8dOg+ii9yIrbeONNK0nlDUCAKy5YXSEl0avcPdUDyR3cStL6870SyanxAzktDw0n8xMq4F/alF3PZ002bcZJrmDeNVAwkP+uO2Tf8pN37SU+nApotZmlmZR32xYHnx+/OiQ7gOAVYmgNRMg0Kwh6Q73FcY3ZWCeNHwLnr95LoEAdj3On8Qr62VhGThuQNVCqBc6SeYjArfjijpcW9 jenkins-ci@localhost' >> /home/test/.ssh/authorized_keys && \
-    chown -R test:test /home/test && \
-    chmod 0600 /home/test/.ssh/authorized_keys && \
-    echo "test:test" | chpasswd
-
-# https://stackoverflow.com/a/38553499/12916
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8
-ENV LANG en_US.UTF-8
+FROM olamy/pipeline-maven-plugin:SshdContainer-32edfdd581112ff75ef6bbd6b0e576371f0089e3
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         software-properties-common \
-        openjdk-11-jdk-headless \
-        curl \
-        ant
+        openjdk-11-jdk-headless
 
 # run SSHD in the foreground with error messages to stderr
 ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e"]


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
