### PR TITLE
JENKINS-71949 : restore Java 6/7/8 compatibility

### DIFF
--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
@@ -24,12 +24,14 @@
 package org.jenkinsci.plugins.pipeline.maven;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import hudson.model.JDK;
 import hudson.tools.ToolLocationNodeProperty;
@@ -38,6 +40,9 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.jvnet.hudson.test.Issue;
 import org.testcontainers.containers.GenericContainer;
 
@@ -101,24 +106,33 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
         assertFingerprintDoesNotExist(COMMONS_LANG3_FINGERPRINT);
     }
 
-    @Test
-    public void tesWithJava8ForBuild() throws Exception {
+    // the jdk path is configured in Dockerfile
+    private static Stream<Arguments> jdkMapProvider() {
+        return Stream.of(
+                arguments("jdk8", "/opt/java/jdk8"),
+                arguments("jdk11", "/opt/java/jdk11")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("jdkMapProvider")
+    public void tesWithDifferentJavasForBuild(String jdkName, String jdkPath) throws Exception {
         loadMonoDependencyMavenProjectInGitRepo(this.gitRepoRule);
         String gitRepoPath = this.gitRepoRule.toString();
         javaGitContainerRule.copyFileToContainer(MountableFile.forHostPath(gitRepoPath), "/tmp/gitrepo");
         registerAgentForContainer(javaGitContainerRule);
         ToolLocationNodeProperty.ToolLocation toolLocation =
-                new ToolLocationNodeProperty.ToolLocation(new JDK.DescriptorImpl(), "jdk8", "/opt/java/jdk8");
+                new ToolLocationNodeProperty.ToolLocation(new JDK.DescriptorImpl(), jdkName, jdkPath);
         ToolLocationNodeProperty toolLocationNodeProperty = new ToolLocationNodeProperty(toolLocation);
         Objects.requireNonNull(jenkinsRule.jenkins.getNode(AGENT_NAME)).getNodeProperties().add(toolLocationNodeProperty);
 
-        jenkinsRule.jenkins.getJDKs().add(new JDK("jdk8", "/opt/java/jdk8"));
+        jenkinsRule.jenkins.getJDKs().add(new JDK(jdkName, jdkPath));
 
         //@formatter:off
         WorkflowRun run = runPipeline(Result.SUCCESS,
                 "node('" + AGENT_NAME + "') {\n" +
                 "  git('/tmp/gitrepo')\n" +
-                "  withMaven(jdk: 'jdk8') {\n" +
+                "  withMaven(jdk: '" + jdkName + "') {\n" +
                 "    sh 'mvn package'\n" +
                 "  }\n" +
                 "}");

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
@@ -121,6 +121,7 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
         loadMonoDependencyMavenProjectInGitRepo(this.gitRepoRule);
         String gitRepoPath = this.gitRepoRule.toString();
         javaGitContainerRule.copyFileToContainer(MountableFile.forHostPath(gitRepoPath), "/tmp/gitrepo");
+        javaGitContainerRule.execInContainer("chmod", "-R", "777", "/tmp/gitrepo");
         registerAgentForContainer(javaGitContainerRule);
         ToolLocationNodeProperty.ToolLocation toolLocation =
                 new ToolLocationNodeProperty.ToolLocation(new JDK.DescriptorImpl(), jdkName, jdkPath);
@@ -132,7 +133,7 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
         //@formatter:off
         WorkflowRun run = runPipeline(Result.SUCCESS,
                 "node('" + AGENT_NAME + "') {\n" +
-                "  sh 'ls -alrt /tmp/gitrepo'\n" +
+                "  sh 'ls -alrt /tmp'\n" +
                 "  git('/tmp/gitrepo')\n" +
                 "  withMaven(jdk: '" + jdkName + "') {\n" +
                 "    sh 'mvn package'\n" +

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
@@ -132,6 +132,7 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
         //@formatter:off
         WorkflowRun run = runPipeline(Result.SUCCESS,
                 "node('" + AGENT_NAME + "') {\n" +
+                "  sh 'ls -alrt /tmp/gitrepo'\n" +
                 "  git('/tmp/gitrepo')\n" +
                 "  withMaven(jdk: '" + jdkName + "') {\n" +
                 "    sh 'mvn package'\n" +

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
@@ -116,6 +116,7 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("jdkMapProvider")
+    @Issue("JENKINS-71949")
     public void tesWithDifferentJavasForBuild(String jdkName, String jdkPath) throws Exception {
         loadMonoDependencyMavenProjectInGitRepo(this.gitRepoRule);
         String gitRepoPath = this.gitRepoRule.toString();

--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
@@ -133,7 +133,6 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
         //@formatter:off
         WorkflowRun run = runPipeline(Result.SUCCESS,
                 "node('" + AGENT_NAME + "') {\n" +
-                "  sh 'ls -alrt /tmp'\n" +
                 "  git('/tmp/gitrepo')\n" +
                 "  withMaven(jdk: '" + jdkName + "') {\n" +
                 "    sh 'mvn package'\n" +

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
@@ -34,6 +34,8 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     update-locale LANG=en_US.UTF-8
 ENV LANG en_US.UTF-8
 
+COPY --from=eclipse-temurin:8u345-b01-jdk /opt/java/openjdk /opt/java/jdk8
+
 # run SSHD in the foreground with error messages to stderr
 ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e"]
 

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
@@ -35,6 +35,7 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
 ENV LANG en_US.UTF-8
 
 COPY --from=eclipse-temurin:8u345-b01-jdk /opt/java/openjdk /opt/java/jdk8
+COPY --from=eclipse-temurin:11.0.16.1_1-jdk /opt/java/openjdk /opt/java/jdk11
 
 # run SSHD in the foreground with error messages to stderr
 ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e"]

--- a/maven-spy/pom.xml
+++ b/maven-spy/pom.xml
@@ -67,8 +67,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <release>8</release>
         </configuration>
       </plugin>
       <plugin>

--- a/maven-spy/pom.xml
+++ b/maven-spy/pom.xml
@@ -67,7 +67,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <release>8</release>
+          <release>6</release>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
not sure if java 1.6 is really the goal but since the parent pom upgrade the compilation was made using release flag 11 so this will not work on older java versions (due to https://github.com/jenkinsci/pipeline-maven-plugin/commit/81e7ff8d6f2d3af48566f4054803488ea1390e66)

fix https://issues.jenkins.io/browse/JENKINS-71949

Signed-off-by: Olivier Lamy <olamy@apache.org>
