### PR TITLE
Attempt to use Docker on Unix systems only when Docker is running

### DIFF
--- a/pipeline-maven/pom.xml
+++ b/pipeline-maven/pom.xml
@@ -508,6 +508,9 @@
         <os>
           <family>unix</family>
         </os>
+        <file>
+          <exists>/var/run/docker.sock</exists>
+        </file>
       </activation>
       <build>
         <plugins>

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/DependencyGraphTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/DependencyGraphTest.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.pipeline.maven;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jenkinsci.plugins.pipeline.maven.TestUtils.runAfterMethod;
 import static org.jenkinsci.plugins.pipeline.maven.TestUtils.runBeforeMethod;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 
 import hudson.ExtensionList;
@@ -34,13 +33,14 @@ import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
-@EnabledOnOs(LINUX) // "fatal error: aux_index does not match even or odd indices" on Windows JDK 19
+@EnabledOnOs(value = LINUX, disabledReason = "'fatal error: aux_index does not match even or odd indices' on Windows JDK 19")
 public class DependencyGraphTest extends AbstractIntegrationTest {
 
     public GitSampleRepoRule downstreamArtifactRepoRule;
@@ -504,10 +504,13 @@ public class DependencyGraphTest extends AbstractIntegrationTest {
         assertThat(upstreamCause).isNotNull();
     }
 
+    public boolean checkIsLinuxAndDockerSocketExists() {
+        return OS.current() == OS.LINUX && Files.exists(Paths.get("/var/run/docker.sock"));
+    }
+
     @Test
-    @EnabledOnOs(OS.LINUX) // Docker does not work on Windows 2019 servers CI agents
+    @EnabledIf(value = "checkIsLinuxAndDockerSocketExists", disabledReason = "Needs Docker and Docker does not work on Windows 2019 servers CI agents")
     public void verify_docker_downstream_simple_pipeline_trigger() throws Exception {
-        assumeTrue(Files.exists(Paths.get("/var/run/docker.sock")));
         System.out.println("gitRepoRule: " + gitRepoRule);
         loadSourceCodeInGitRepository(
                 this.gitRepoRule,

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/DependencyGraphTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/DependencyGraphTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.pipeline.maven;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jenkinsci.plugins.pipeline.maven.TestUtils.runAfterMethod;
 import static org.jenkinsci.plugins.pipeline.maven.TestUtils.runBeforeMethod;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 
 import hudson.ExtensionList;
@@ -10,6 +11,8 @@ import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Result;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -504,6 +507,7 @@ public class DependencyGraphTest extends AbstractIntegrationTest {
     @Test
     @EnabledOnOs(OS.LINUX) // Docker does not work on Windows 2019 servers CI agents
     public void verify_docker_downstream_simple_pipeline_trigger() throws Exception {
+        assumeTrue(Files.exists(Paths.get("/var/run/docker.sock")));
         System.out.println("gitRepoRule: " + gitRepoRule);
         loadSourceCodeInGitRepository(
                 this.gitRepoRule,

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/DependencyGraphTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/DependencyGraphTest.java
@@ -40,7 +40,9 @@ import org.junit.jupiter.api.condition.OS;
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
-@EnabledOnOs(value = LINUX, disabledReason = "'fatal error: aux_index does not match even or odd indices' on Windows JDK 19")
+@EnabledOnOs(
+        value = LINUX,
+        disabledReason = "'fatal error: aux_index does not match even or odd indices' on Windows JDK 19")
 public class DependencyGraphTest extends AbstractIntegrationTest {
 
     public GitSampleRepoRule downstreamArtifactRepoRule;
@@ -509,7 +511,9 @@ public class DependencyGraphTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledIf(value = "checkIsLinuxAndDockerSocketExists", disabledReason = "Needs Docker and Docker does not work on Windows 2019 servers CI agents")
+    @EnabledIf(
+            value = "checkIsLinuxAndDockerSocketExists",
+            disabledReason = "Needs Docker and Docker does not work on Windows 2019 servers CI agents")
     public void verify_docker_downstream_simple_pipeline_trigger() throws Exception {
         System.out.println("gitRepoRule: " + gitRepoRule);
         loadSourceCodeInGitRepository(

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepOnMasterTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepOnMasterTest.java
@@ -681,7 +681,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledOnOs(LINUX) // bat step get stuck on Windows 2019 CI agents
+    @EnabledOnOs(value = LINUX, disabledReason = "bat step get stuck on Windows 2019 CI agents")
     public void maven_global_settings_path_defined_through_jenkins_global_config() throws Exception {
 
         File mavenGlobalSettingsFile = new File(jenkinsRule.jenkins.getRootDir(), "maven-global-settings.xml");
@@ -742,7 +742,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledOnOs(LINUX) // bat step get stuck on Windows 2019 CI agents
+    @EnabledOnOs(value = LINUX, disabledReason = "bat step get stuck on Windows 2019 CI agents")
     public void maven_global_settings_defined_through_jenkins_global_config_and_config_file_provider()
             throws Exception {
 
@@ -807,7 +807,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledOnOs(LINUX) // bat step get stuck on Windows 2019 CI agents
+    @EnabledOnOs(value = LINUX, disabledReason = "bat step get stuck on Windows 2019 CI agents")
     public void maven_global_settings_defined_through_folder_config_and_config_file_provider() throws Exception {
 
         // @formatter:off
@@ -881,7 +881,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledOnOs(LINUX) // bat step get stuck on Windows 2019 CI agents
+    @EnabledOnOs(value = LINUX, disabledReason = "bat step get stuck on Windows 2019 CI agents")
     public void maven_global_settings_path_defined_through_pipeline_attribute() throws Exception {
 
         // @formatter:off
@@ -930,7 +930,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
 
     @Issue("JENKINS-42565")
     @Test
-    @EnabledOnOs(LINUX) // bat step get stuck on Windows 2019 CI agents
+    @EnabledOnOs(value = LINUX, disabledReason = "bat step get stuck on Windows 2019 CI agents")
     public void maven_settings_path_defined_through_pipeline_attribute() throws Exception {
 
         // @formatter:off
@@ -978,7 +978,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledOnOs(LINUX) // bat step get stuck on Windows 2019 CI agents
+    @EnabledOnOs(value = LINUX, disabledReason = "bat step get stuck on Windows 2019 CI agents")
     public void maven_settings_defined_through_jenkins_global_config() throws Exception {
 
         File mavenSettingsFile = new File(jenkinsRule.jenkins.getRootDir(), "maven-settings.xml");
@@ -1037,7 +1037,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledOnOs(LINUX) // bat step get stuck on Windows 2019 CI agents
+    @EnabledOnOs(value = LINUX, disabledReason = "bat step get stuck on Windows 2019 CI agents")
     public void maven_settings_defined_through_jenkins_global_config_and_config_file_provider() throws Exception {
 
         // @formatter:off
@@ -1098,7 +1098,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledOnOs(LINUX) // bat step get stuck on Windows 2019 CI agents
+    @EnabledOnOs(value = LINUX, disabledReason = "bat step get stuck on Windows 2019 CI agents")
     public void maven_settings_defined_through_folder_config_and_config_file_provider() throws Exception {
 
         // @formatter:off
@@ -1167,7 +1167,7 @@ public class WithMavenStepOnMasterTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @EnabledOnOs(LINUX) // bat step get stuck on Windows 2019 CI agents
+    @EnabledOnOs(value = LINUX, disabledReason = "bat step get stuck on Windows 2019 CI agents")
     public void maven_settings_defined_through_pipeline_attribute_and_config_file_provider() throws Exception {
 
         // @formatter:off


### PR DESCRIPTION
`jenkinsci/bom` builds run without Docker, but this plugin assumes that Docker is available in all Unix environments. Our general pattern in Jenkins plugins is to use Docker when it is available, but otherwise to skip the tests when Docker is not available rather than to fail: this pattern is employed by lots of other plugins that use Docker and allows us to run at least the majority of tests in `jenkinsci/bom` builds without having to resort to expensive VMs. This PR makes this plugin consistent with other plugins by skipping the Docker tests when running on a Unix system without Docker (e.g., our `jenkinsci/bom` builds).

<!-- Please describe your pull request here. -->

### Testing done

Ran `mvn clean verify` in a Java 11 Docker container (i.e., an environment without Docker). Before this PR, the build failed; after this PR, it passes.