### PR TITLE
JENKINS-72386: replace --no-transfer-progress option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -168,9 +168,9 @@ https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos/pipe
 [#feature-sensible-default-maven-settings]
 === Sensible default Maven parameters
 
-The Maven parameters that are useful on a build server, `--batch-mode` (`-B`) and `--no-transfer-progress` (`-ntp`) are enable by default, no need to add them in your mvn invocations.
+The Maven parameters that are useful on a build server, `--batch-mode` (`-B`) is enable by default and transfer output is suppressed, no need to add them in your mvn invocations.
 
-if **<<feature-traceability>>** is enabled, `--no-transfer-progress` (`-ntp`) option is removed, and `--show-version` (`-V`) is added.
+if **<<feature-traceability>>** is enabled, `--show-version` (`-V`) is added and transfer output is enabled.
 
 [#feature-maven-integration-global-settings]
 === Maven Settings Support

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -364,7 +364,13 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         boolean isUnix = Boolean.TRUE.equals(getComputer().isUnix());
         StringBuilder mavenConfig = new StringBuilder();
         mavenConfig.append("--batch-mode ");
-        ifTraceabilityDisabled(() -> mavenConfig.append("--no-transfer-progress "));
+        ifTraceabilityDisabled(() -> {
+            // In batch-mode transfer output is sent through Slf4jMavenTransferListener
+            // Not using -ntp because it breaks maven <=3.6 which does not support the option
+            // Maven 4.0 supports CI=true to quite transfer output
+            mavenConfig.append(
+                    "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn ");
+        });
         ifTraceabilityEnabled(() -> mavenConfig.append("--show-version "));
         if (StringUtils.isNotEmpty(settingsFilePath)) {
             // JENKINS-57324 escape '%' as '%%'. See


### PR DESCRIPTION
`-ntp` is not supported on versions of maven prior to 3.6.1. Maven does exits with "unrecognized option" when it encounters an option it doesn't know about.

This solution uses replaces the unsupported option with a system property to reduce the transfer logger used for batch mode to WARN only. See [MRELEASE-1048](https://issues.apache.org/jira/browse/MRELEASE-1048)

Fixes [JENKINS-72386](https://issues.jenkins.io/browse/JENKINS-72386) introduced by #716 

### Testing done

Tested 3.6 and 3.9 does not output transfer logs with alternate setting.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
