### PR TITLE
fix JENKINS-72386: withMaven exits with unrecognized option --no-transfer-progress when using maven < 3.6.1

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersion.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersion.java
@@ -1,0 +1,64 @@
+package org.jenkinsci.plugins.pipeline.maven.util;
+
+import java.util.Objects;
+
+public class MavenVersion {
+
+    public static final MavenVersion UNKNOWN = new MavenVersion(-1, -1, -1);
+
+    public static MavenVersion fromString(String str) {
+        try {
+            String[] parts = str.split("\\.");
+            return new MavenVersion(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]));
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("'" + str + "' is not a valid maven version", ex);
+        }
+    }
+
+    private int major;
+
+    private int minor;
+
+    private int increment;
+
+    public MavenVersion(int major, int minor, int increment) {
+        this.major = major;
+        this.minor = minor;
+        this.increment = increment;
+    }
+
+    public boolean isAtLeast(int wantedMajor, int wantedMinor) {
+        return major > wantedMajor || (major == wantedMajor && minor >= wantedMinor);
+    }
+
+    public boolean isAtLeast(int wantedMajor, int wantedMinor, int wantedIncrement) {
+        return major > wantedMajor
+                || (major == wantedMajor && minor > wantedMinor)
+                || (major == wantedMajor && minor == wantedMinor && increment >= wantedIncrement);
+    }
+
+    @Override
+    public String toString() {
+        return major == -1 ? "UNKNOWN" : (major + "." + minor + "." + increment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(increment, major, minor);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        MavenVersion other = (MavenVersion) obj;
+        return increment == other.increment && major == other.major && minor == other.minor;
+    }
+}

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionUtils.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionUtils.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.pipeline.maven.util;
+
+import java.util.function.Predicate;
+
+public class MavenVersionUtils {
+
+    public static Predicate<String> containsMavenVersion() {
+        return string -> string != null && string.matches("Apache Maven \\d+\\.\\d+\\.\\d+ \\(.*\\)");
+    }
+
+    public static MavenVersion parseMavenVersion(String outputLine) {
+        int prefixLength = "Apache Maven ".length();
+        int startHashIndex = outputLine.indexOf("(");
+        String version = startHashIndex != -1
+                ? outputLine.substring(prefixLength, startHashIndex)
+                : outputLine.substring(prefixLength);
+        return MavenVersion.fromString(version.trim());
+    }
+}

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/MavenUtil.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/MavenUtil.java
@@ -2,7 +2,12 @@ package org.jenkinsci.plugins.pipeline.maven.util;
 
 import hudson.FilePath;
 import hudson.tasks.Maven;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.channels.Channels;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import jenkins.model.Jenkins;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -12,16 +17,29 @@ public class MavenUtil {
     public static final String MAVEN_VERSION = System.getProperty("maven.version", "3.8.8");
 
     public static Maven.MavenInstallation configureDefaultMaven(FilePath agentRootPath) throws Exception {
-        String mavenVersion = MAVEN_VERSION;
+        return configureMaven(agentRootPath, MAVEN_VERSION, "default");
+    }
+
+    public static Maven.MavenInstallation configureMaven(FilePath agentRootPath, String mavenVersion, String toolName)
+            throws Exception {
+        Path mavenArchive =
+                Paths.get(System.getProperty("buildDirectory", "target"), "apache-maven-" + mavenVersion + "-bin.zip");
+        if (!mavenArchive.toFile().exists()) {
+            URL mavenArchiveUrl = new URL("https://archive.apache.org/dist/maven/maven-3/" + mavenVersion
+                    + "/binaries/apache-maven-" + mavenVersion + "-bin.zip");
+            try (InputStream is = mavenArchiveUrl.openStream();
+                    FileOutputStream os = new FileOutputStream(mavenArchive.toFile())) {
+                os.getChannel().transferFrom(Channels.newChannel(is), 0, Long.MAX_VALUE);
+            }
+        }
         FilePath mvnHome = agentRootPath.child("apache-maven-" + mavenVersion);
         if (!mvnHome.exists()) {
             FilePath mvn = agentRootPath.createTempFile("maven", "zip");
-            mvn.copyFrom(Files.newInputStream(Paths.get(
-                    System.getProperty("buildDirectory", "target"), "apache-maven-" + mavenVersion + "-bin.zip")));
+            mvn.copyFrom(Files.newInputStream(mavenArchive));
             mvn.unzip(agentRootPath);
         }
         Maven.MavenInstallation mavenInstallation =
-                new Maven.MavenInstallation("default", mvnHome.getRemote(), JenkinsRule.NO_PROPERTIES);
+                new Maven.MavenInstallation(toolName, mvnHome.getRemote(), JenkinsRule.NO_PROPERTIES);
         Jenkins.get().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(mavenInstallation);
 
         return mavenInstallation;

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionTest.java
@@ -1,0 +1,41 @@
+package org.jenkinsci.plugins.pipeline.maven.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class MavenVersionTest {
+
+    @Test
+    public void should_parse_version_from_string() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            MavenVersion.fromString(null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            MavenVersion.fromString("");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            MavenVersion.fromString("not a version");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            MavenVersion.fromString("1.2");
+        });
+
+        assertThat(MavenVersion.fromString("3.9.6")).isEqualTo(new MavenVersion(3, 9, 6));
+    }
+
+    @Test
+    public void should_compare() {
+        assertThat(new MavenVersion(3, 9, 6).isAtLeast(3, 9, 7)).isFalse();
+        assertThat(new MavenVersion(3, 9, 6).isAtLeast(3, 9, 6)).isTrue();
+        assertThat(new MavenVersion(3, 9, 6).isAtLeast(3, 9, 5)).isTrue();
+        assertThat(new MavenVersion(3, 9, 6).isAtLeast(3, 8, 8)).isTrue();
+
+        assertThat(new MavenVersion(3, 9, 6).isAtLeast(4, 0)).isFalse();
+        assertThat(new MavenVersion(3, 9, 6).isAtLeast(3, 10)).isFalse();
+        assertThat(new MavenVersion(3, 9, 6).isAtLeast(3, 9)).isTrue();
+        assertThat(new MavenVersion(3, 9, 6).isAtLeast(3, 8)).isTrue();
+        assertThat(new MavenVersion(3, 9, 6).isAtLeast(2, 0)).isTrue();
+    }
+}

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionUtilsTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionUtilsTest.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins.pipeline.maven.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MavenVersionUtilsTest {
+
+    @Test
+    public void should_detect_maven_version() {
+        assertThat(MavenVersionUtils.containsMavenVersion().test(null)).isFalse();
+        assertThat(MavenVersionUtils.containsMavenVersion().test("")).isFalse();
+        assertThat(MavenVersionUtils.containsMavenVersion().test("   ")).isFalse();
+        assertThat(MavenVersionUtils.containsMavenVersion().test("not a version"))
+                .isFalse();
+        assertThat(MavenVersionUtils.containsMavenVersion().test("3.8.6")).isFalse();
+        assertThat(MavenVersionUtils.containsMavenVersion().test("Apache Maven 3.9.6"))
+                .isFalse();
+
+        assertThat(MavenVersionUtils.containsMavenVersion()
+                        .test("Apache Maven 3.9.6 (bc0240f3c744dd6b6ec2920b3cd08dcc295161ae)"))
+                .isTrue();
+    }
+
+    @Test
+    public void should_parse_maven_version() {
+        assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 3.9.6 (bc0240f3c744dd6b6ec2920b3cd08dcc295161ae)"))
+                .isEqualTo(new MavenVersion(3, 9, 6));
+        assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 3.8.8 (4c87b05d9aedce574290d1acc98575ed5eb6cd39)"))
+                .isEqualTo(new MavenVersion(3, 8, 8));
+        assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 3.6.1")).isEqualTo(new MavenVersion(3, 6, 1));
+        assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 3.5.4")).isEqualTo(new MavenVersion(3, 5, 4));
+    }
+}


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-72386

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
