### PR TITLE
[JENKINS-72529] write settings file always in UTF-8 encoding

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -1146,8 +1146,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
                 }
             }
 
-            mavenSettingsFile.write(
-                    mavenSettingsFileContent, getComputer().getDefaultCharset().name());
+            mavenSettingsFile.write(mavenSettingsFileContent, "UTF-8");
         } catch (Exception e) {
             throw new IllegalStateException(
                     "Exception injecting Maven settings.xml " + mavenSettingsConfig.id + " during the build: " + build
@@ -1217,9 +1216,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
                                 .collect(Collectors.joining(", ")));
             }
 
-            mavenGlobalSettingsFile.write(
-                    mavenGlobalSettingsFileContent,
-                    getComputer().getDefaultCharset().name());
+            mavenGlobalSettingsFile.write(mavenGlobalSettingsFileContent, "UTF-8");
             LOGGER.log(Level.FINE, "Created global config file {0}", new Object[] {mavenGlobalSettingsFile});
         } catch (Exception e) {
             throw new IllegalStateException(


### PR DESCRIPTION
Otherwise reading the generated files by maven may fail on platforms as z/OS. Furthermore, by default maven assumes UTF-8 when reading settings.

<!-- Please describe your pull request here. -->
Summary:  Maven fails to read platform encoded settings files on z/OS but should always (platform independent) succeed reading UTF-8 encoded setting files. Hence, let pipeline-maven-plugin write with UTF-8 encoding instead of platform encoding.

For a detailed problem description see [Jenkins-72529](https://issues.jenkins.io/browse/JENKINS-72529). 

### Testing done

- successfully run withMaven(mavenSettingsConfig: '...', ... ) step on z/OS node
- mvn verify on linux - no failing tests

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The <F5>template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

