### PR TITLE
Reduce usage of Guice

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/cli/TriggerDownstreamPipelinesCommand.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/cli/TriggerDownstreamPipelinesCommand.java
@@ -46,9 +46,6 @@ public class TriggerDownstreamPipelinesCommand extends CLICommand {
 
     @Override
     protected int run() throws Exception {
-        /*
-         * @Inject does NOT work to inject GlobalPipelineMavenConfig in the TriggerDownstreamPipelinesCommand instance, use static code :-(
-         */
         PipelineTriggerService pipelineTriggerService =
                 GlobalPipelineMavenConfig.get().getPipelineTriggerService();
 

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncItemListener.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncItemListener.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pipeline.maven.listeners;
 
+import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
@@ -17,15 +18,17 @@ import org.jenkinsci.plugins.workflow.flow.BlockableResume;
  */
 @Extension
 public class DatabaseSyncItemListener extends ItemListener {
+
     private static final Logger LOGGER = Logger.getLogger(DatabaseSyncItemListener.class.getName());
 
     private GlobalPipelineMavenConfig globalPipelineMavenConfig;
 
-    public GlobalPipelineMavenConfig getGlobalPipelineMavenConfig() {
-        return globalPipelineMavenConfig != null ? globalPipelineMavenConfig : GlobalPipelineMavenConfig.get();
+    public DatabaseSyncItemListener() {
+        this(GlobalPipelineMavenConfig.get());
     }
 
-    public void setGlobalPipelineMavenConfig(GlobalPipelineMavenConfig globalPipelineMavenConfig) {
+    @VisibleForTesting
+    DatabaseSyncItemListener(GlobalPipelineMavenConfig globalPipelineMavenConfig) {
         this.globalPipelineMavenConfig = globalPipelineMavenConfig;
     }
 
@@ -33,7 +36,7 @@ public class DatabaseSyncItemListener extends ItemListener {
     public void onDeleted(Item item) {
         if (item instanceof BlockableResume) {
             LOGGER.log(Level.FINE, "onDeleted({0})", item);
-            getGlobalPipelineMavenConfig().getDao().deleteJob(item.getFullName());
+            globalPipelineMavenConfig.getDao().deleteJob(item.getFullName());
         } else {
             LOGGER.log(Level.FINE, "Ignore onDeleted({0})", new Object[] {item});
         }
@@ -52,7 +55,7 @@ public class DatabaseSyncItemListener extends ItemListener {
                 oldFullName = parent.getFullName() + "/" + oldName;
             }
             String newFullName = item.getFullName();
-            getGlobalPipelineMavenConfig().getDao().renameJob(oldFullName, newFullName);
+            globalPipelineMavenConfig.getDao().renameJob(oldFullName, newFullName);
         } else {
             LOGGER.log(Level.FINE, "Ignore onRenamed({0}, {1}, {2})", new Object[] {item, oldName, newName});
         }
@@ -62,7 +65,7 @@ public class DatabaseSyncItemListener extends ItemListener {
     public void onLocationChanged(Item item, String oldFullName, String newFullName) {
         if (item instanceof BlockableResume) {
             LOGGER.log(Level.FINE, "onLocationChanged({0}, {1}, {2})", new Object[] {item, oldFullName, newFullName});
-            getGlobalPipelineMavenConfig().getDao().renameJob(oldFullName, newFullName);
+            globalPipelineMavenConfig.getDao().renameJob(oldFullName, newFullName);
         } else {
             LOGGER.log(
                     Level.FINE, "Ignore onLocationChanged({0}, {1}, {2})", new Object[] {item, oldFullName, newFullName

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncItemListener.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncItemListener.java
@@ -6,7 +6,6 @@ import hudson.model.ItemGroup;
 import hudson.model.listeners.ItemListener;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.inject.Inject;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.pipeline.maven.GlobalPipelineMavenConfig;
 import org.jenkinsci.plugins.workflow.flow.BlockableResume;
@@ -20,14 +19,21 @@ import org.jenkinsci.plugins.workflow.flow.BlockableResume;
 public class DatabaseSyncItemListener extends ItemListener {
     private static final Logger LOGGER = Logger.getLogger(DatabaseSyncItemListener.class.getName());
 
-    @Inject
-    public GlobalPipelineMavenConfig globalPipelineMavenConfig;
+    private GlobalPipelineMavenConfig globalPipelineMavenConfig;
+
+    public GlobalPipelineMavenConfig getGlobalPipelineMavenConfig() {
+        return globalPipelineMavenConfig != null ? globalPipelineMavenConfig : GlobalPipelineMavenConfig.get();
+    }
+
+    public void setGlobalPipelineMavenConfig(GlobalPipelineMavenConfig globalPipelineMavenConfig) {
+        this.globalPipelineMavenConfig = globalPipelineMavenConfig;
+    }
 
     @Override
     public void onDeleted(Item item) {
         if (item instanceof BlockableResume) {
             LOGGER.log(Level.FINE, "onDeleted({0})", item);
-            globalPipelineMavenConfig.getDao().deleteJob(item.getFullName());
+            getGlobalPipelineMavenConfig().getDao().deleteJob(item.getFullName());
         } else {
             LOGGER.log(Level.FINE, "Ignore onDeleted({0})", new Object[] {item});
         }
@@ -46,7 +52,7 @@ public class DatabaseSyncItemListener extends ItemListener {
                 oldFullName = parent.getFullName() + "/" + oldName;
             }
             String newFullName = item.getFullName();
-            globalPipelineMavenConfig.getDao().renameJob(oldFullName, newFullName);
+            getGlobalPipelineMavenConfig().getDao().renameJob(oldFullName, newFullName);
         } else {
             LOGGER.log(Level.FINE, "Ignore onRenamed({0}, {1}, {2})", new Object[] {item, oldName, newName});
         }
@@ -56,7 +62,7 @@ public class DatabaseSyncItemListener extends ItemListener {
     public void onLocationChanged(Item item, String oldFullName, String newFullName) {
         if (item instanceof BlockableResume) {
             LOGGER.log(Level.FINE, "onLocationChanged({0}, {1}, {2})", new Object[] {item, oldFullName, newFullName});
-            globalPipelineMavenConfig.getDao().renameJob(oldFullName, newFullName);
+            getGlobalPipelineMavenConfig().getDao().renameJob(oldFullName, newFullName);
         } else {
             LOGGER.log(
                     Level.FINE, "Ignore onLocationChanged({0}, {1}, {2})", new Object[] {item, oldFullName, newFullName

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncRunListener.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncRunListener.java
@@ -6,7 +6,6 @@ import hudson.model.Cause;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import javax.inject.Inject;
 import org.jenkinsci.plugins.pipeline.maven.GlobalPipelineMavenConfig;
 
 /**
@@ -15,12 +14,19 @@ import org.jenkinsci.plugins.pipeline.maven.GlobalPipelineMavenConfig;
 @Extension
 public class DatabaseSyncRunListener extends AbstractWorkflowRunListener {
 
-    @Inject
-    public GlobalPipelineMavenConfig globalPipelineMavenConfig;
+    private GlobalPipelineMavenConfig globalPipelineMavenConfig;
+
+    public GlobalPipelineMavenConfig getGlobalPipelineMavenConfig() {
+        return globalPipelineMavenConfig != null ? globalPipelineMavenConfig : GlobalPipelineMavenConfig.get();
+    }
+
+    public void setGlobalPipelineMavenConfig(GlobalPipelineMavenConfig globalPipelineMavenConfig) {
+        this.globalPipelineMavenConfig = globalPipelineMavenConfig;
+    }
 
     @Override
     public void onDeleted(Run<?, ?> run) {
-        globalPipelineMavenConfig.getDao().deleteBuild(run.getParent().getFullName(), run.getNumber());
+        getGlobalPipelineMavenConfig().getDao().deleteBuild(run.getParent().getFullName(), run.getNumber());
     }
 
     @Override
@@ -33,7 +39,7 @@ public class DatabaseSyncRunListener extends AbstractWorkflowRunListener {
 
                 String upstreamJobName = upstreamCause.getUpstreamProject();
                 int upstreamBuildNumber = upstreamCause.getUpstreamBuild();
-                globalPipelineMavenConfig
+                getGlobalPipelineMavenConfig()
                         .getDao()
                         .recordBuildUpstreamCause(
                                 upstreamJobName,
@@ -60,7 +66,7 @@ public class DatabaseSyncRunListener extends AbstractWorkflowRunListener {
         if (result == null) {
             result = Result.SUCCESS; // FIXME more elegant handling
         }
-        globalPipelineMavenConfig
+        getGlobalPipelineMavenConfig()
                 .getDao()
                 .updateBuildOnCompletion(
                         workflowRun.getParent().getFullName(),

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncRunListener.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncRunListener.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pipeline.maven.listeners;
 
+import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Cause;
@@ -16,17 +17,18 @@ public class DatabaseSyncRunListener extends AbstractWorkflowRunListener {
 
     private GlobalPipelineMavenConfig globalPipelineMavenConfig;
 
-    public GlobalPipelineMavenConfig getGlobalPipelineMavenConfig() {
-        return globalPipelineMavenConfig != null ? globalPipelineMavenConfig : GlobalPipelineMavenConfig.get();
+    public DatabaseSyncRunListener() {
+        this(GlobalPipelineMavenConfig.get());
     }
 
-    public void setGlobalPipelineMavenConfig(GlobalPipelineMavenConfig globalPipelineMavenConfig) {
+    @VisibleForTesting
+    DatabaseSyncRunListener(GlobalPipelineMavenConfig globalPipelineMavenConfig) {
         this.globalPipelineMavenConfig = globalPipelineMavenConfig;
     }
 
     @Override
     public void onDeleted(Run<?, ?> run) {
-        getGlobalPipelineMavenConfig().getDao().deleteBuild(run.getParent().getFullName(), run.getNumber());
+        globalPipelineMavenConfig.getDao().deleteBuild(run.getParent().getFullName(), run.getNumber());
     }
 
     @Override
@@ -39,7 +41,7 @@ public class DatabaseSyncRunListener extends AbstractWorkflowRunListener {
 
                 String upstreamJobName = upstreamCause.getUpstreamProject();
                 int upstreamBuildNumber = upstreamCause.getUpstreamBuild();
-                getGlobalPipelineMavenConfig()
+                globalPipelineMavenConfig
                         .getDao()
                         .recordBuildUpstreamCause(
                                 upstreamJobName,
@@ -66,7 +68,7 @@ public class DatabaseSyncRunListener extends AbstractWorkflowRunListener {
         if (result == null) {
             result = Result.SUCCESS; // FIXME more elegant handling
         }
-        getGlobalPipelineMavenConfig()
+        globalPipelineMavenConfig
                 .getDao()
                 .updateBuildOnCompletion(
                         workflowRun.getParent().getFullName(),

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncRunListenerTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncRunListenerTest.java
@@ -15,16 +15,15 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class DatabaseSyncRunListenerTest {
 
-    @InjectMocks
     private DatabaseSyncRunListener listener;
 
     @Mock
@@ -47,6 +46,12 @@ public class DatabaseSyncRunListenerTest {
 
     @Mock
     private FlowNode flowNode;
+
+    @BeforeEach
+    public void configureMocks() {
+        listener = new DatabaseSyncRunListener();
+        listener.setGlobalPipelineMavenConfig(config);
+    }
 
     @Test
     public void test_abort_when_step_not_run() throws Exception {

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncRunListenerTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/listeners/DatabaseSyncRunListenerTest.java
@@ -49,8 +49,7 @@ public class DatabaseSyncRunListenerTest {
 
     @BeforeEach
     public void configureMocks() {
-        listener = new DatabaseSyncRunListener();
-        listener.setGlobalPipelineMavenConfig(config);
+        listener = new DatabaseSyncRunListener(config);
     }
 
     @Test

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListenerTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListenerTest.java
@@ -99,8 +99,7 @@ public class DownstreamPipelineTriggerRunListenerTest {
 
     @BeforeEach
     public void configureMocks() throws Exception {
-        listener = new DownstreamPipelineTriggerRunListener();
-        listener.setGlobalPipelineMavenConfig(config);
+        listener = new DownstreamPipelineTriggerRunListener(config);
         when(config.getTriggerDownstreamBuildsResultsCriteria()).thenReturn(Collections.singleton(Result.SUCCESS));
         when(config.getPipelineTriggerService()).thenReturn(service);
         when(config.getDao()).thenReturn(dao);

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListenerTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/listeners/DownstreamPipelineTriggerRunListenerTest.java
@@ -43,7 +43,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -54,7 +53,6 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class DownstreamPipelineTriggerRunListenerTest {
 
-    @InjectMocks
     private DownstreamPipelineTriggerRunListener listener;
 
     @Mock
@@ -101,6 +99,8 @@ public class DownstreamPipelineTriggerRunListenerTest {
 
     @BeforeEach
     public void configureMocks() throws Exception {
+        listener = new DownstreamPipelineTriggerRunListener();
+        listener.setGlobalPipelineMavenConfig(config);
         when(config.getTriggerDownstreamBuildsResultsCriteria()).thenReturn(Collections.singleton(Result.SUCCESS));
         when(config.getPipelineTriggerService()).thenReturn(service);
         when(config.getDao()).thenReturn(dao);


### PR DESCRIPTION
While Jenkins core technically supports Guice, it is not recommended as it is used by a very small number of plugins and the Guice integration with the Jenkins extension subsystem is very complex and fragile. To make matters worse, a future version of Guice (version 7) will drop support for `javax.inject` imports in favor of `jakarta.inject` imports. To prepare for this inevitable migration, this PR drops usage of Guice in favor of traditional static injection, which is the common pattern throughout the Jenkins ecosystem. In this way, this plugin will stop being dependent on a particular version of Guice, enabling us to eventually upgrade Guice in Jenkins core to version 7 without impacting this plugin. This PR does make the Mockito tests a little less elegant, but the Jenkins project discourages the use of Mockito. Our general response to complaints about Mockito tests is to delete them. An alternative to this PR would be to increase the Jenkins core baseline to one with Guice 6 support and then change the imports from `javax.inject` to `jakarta.inject`, but we explicitly decline to implement this approach.