### PR TITLE
chore: temporarily pin `mysql` image to avoid test regressions

### DIFF
--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/ConfigurationAsCodeNeedDockerTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/ConfigurationAsCodeNeedDockerTest.java
@@ -33,7 +33,7 @@ public class ConfigurationAsCodeNeedDockerTest {
 
     @Container
     public static MySQLContainer<?> MYSQL_DB =
-            new MySQLContainer<>(MySQLContainer.NAME).withUsername("aUser").withPassword("aPass");
+            new MySQLContainer<>("mysql:8.2.0").withUsername("aUser").withPassword("aPass");
 
     @Container
     public static PostgreSQLContainer<?> POSTGRE_DB = new PostgreSQLContainer<>(PostgreSQLContainer.IMAGE)

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfigTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/GlobalPipelineMavenConfigTest.java
@@ -34,7 +34,7 @@ public class GlobalPipelineMavenConfigTest {
 
     @Container
     public static MySQLContainer<?> MYSQL_DB =
-            new MySQLContainer<>(MySQLContainer.NAME).withUsername("aUser").withPassword("aPass");
+            new MySQLContainer<>("mysql:8.2.0").withUsername("aUser").withPassword("aPass");
 
     @Container
     public static PostgreSQLContainer<?> POSTGRE_DB = new PostgreSQLContainer<>(PostgreSQLContainer.IMAGE)


### PR DESCRIPTION
As seen in #754 this is necessary to make tests pass. Broken by https://github.com/docker-library/mysql/pull/1024 / https://github.com/docker-library/official-images/pull/16088 AFAICT. Detected by a @cloudbees PCT regression. In case anyone cares

```
[main] ERROR tc.mysql:8.3.0 - Log output from the failed container:
2024-01-19 17:54:12+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.3.0-1.el8 started.
2024-01-19 17:54:12+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2024-01-19 17:54:12+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.3.0-1.el8 started.
2024-01-19 17:54:12+00:00 [Note] [Entrypoint]: Initializing database files
2024-01-19T17:54:12.538592Z 0 [System] [MY-015017] [Server] MySQL Server Initialization - start.
2024-01-19T17:54:12.540062Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.3.0) initializing of server in progress as process 80
2024-01-19T17:54:12.556365Z 0 [Warning] [MY-013907] [InnoDB] Deprecated configuration parameters innodb_log_file_size and/or innodb_log_files_in_group have been used to compute innodb_redo_log_capacity=10485760. Please use innodb_redo_log_capacity instead.
2024-01-19T17:54:12.557316Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
2024-01-19T17:54:14.535305Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
2024-01-19T17:54:20.853605Z 0 [ERROR] [MY-000068] [Server] unknown option '--skip-host-cache'.
2024-01-19T17:54:20.854009Z 0 [ERROR] [MY-013236] [Server] The designated data directory /var/lib/mysql/ is unusable. You can remove all files that the server added to it.
2024-01-19T17:54:20.854017Z 0 [ERROR] [MY-010119] [Server] Aborting
2024-01-19T17:54:23.609569Z 0 [System] [MY-015018] [Server] MySQL Server Initialization - end.

[main] INFO tc.mysql:8.3.0 - Creating container for image: mysql:8.3.0
[main] INFO tc.mysql:8.3.0 - Container mysql:8.3.0 is starting: 4353dc4237f9b0ef7606b23ac7463439fa149b3c20b0ca054795a25d29312ebc
[main] INFO tc.mysql:8.3.0 - Waiting for database connection to become available at jdbc:mysql://localhost:32781/test using query 'SELECT 1'
[main] ERROR tc.mysql:8.3.0 - Could not start container
```

suggesting an incompatibility with `mysql-default-conf/my.cnf` in `org/testcontainers/mysql/1.19.3/mysql-1.19.3.jar`:

```ini
[mysqld]
user = mysql
datadir = /var/lib/mysql
port   		= 3306
#socket 		= /tmp/mysql.sock
skip-external-locking
key_buffer_size = 16K
max_allowed_packet = 1M
table_open_cache = 4
sort_buffer_size = 64K
read_buffer_size = 256K
read_rnd_buffer_size = 256K
net_buffer_length = 2K
skip-host-cache
skip-name-resolve
# …
```

Ah Google to the rescue! https://github.com/testcontainers/testcontainers-java/issues/8130