### PR TITLE
Fix detection if withMaven is executed within container()

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -261,7 +261,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         Launcher launcher1 = launcher;
         while (launcher1 instanceof Launcher.DecoratedLauncher) {
             String launcherClassName = launcher1.getClass().getName();
-            if (launcherClassName.contains("org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator")) {
+            if (launcherClassName.contains("ContainerExecDecorator")) {
                 LOGGER.log(Level.FINE, "Step running within Kubernetes withContainer(): {0}", launcherClassName);
                 return true;
             }

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -270,14 +270,14 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         while (launcher1 instanceof Launcher.DecoratedLauncher) {
             String launcherClassName = launcher1.getClass().getName();
             if (launcherClassName.contains("org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator")) {
-                LOGGER.log(Level.FINE, "Step running within Kubernetes withContainer(): {1}", launcherClassName);
+                LOGGER.log(Level.FINE, "Step running within Kubernetes withContainer(): {0}", launcherClassName);
                 return false;
             }
             if (launcherClassName.contains("WithContainerStep")) {
-                LOGGER.log(Level.FINE, "Step running within docker.image(): {1}", launcherClassName);
+                LOGGER.log(Level.FINE, "Step running within docker.image(): {0}", launcherClassName);
                 return true;
             } else if (launcherClassName.contains("ContainerExecDecorator")) {
-                LOGGER.log(Level.FINE, "Step running within docker.image(): {1}", launcherClassName);
+                LOGGER.log(Level.FINE, "Step running within docker.image(): {0}", launcherClassName);
                 return true;
             }
             launcher1 = ((Launcher.DecoratedLauncher) launcher1).getInner();

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -262,7 +262,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         while (launcher1 instanceof Launcher.DecoratedLauncher) {
             String launcherClassName = launcher1.getClass().getName();
             if (launcherClassName.contains("ContainerExecDecorator")) {
-                LOGGER.log(Level.FINE, "Step running within Kubernetes withContainer(): {0}", launcherClassName);
+                LOGGER.log(Level.FINE, "Step running within Kubernetes container(): {0}", launcherClassName);
                 return true;
             }
             if (launcherClassName.contains("WithContainerStep")) {

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -197,14 +197,6 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
 
         withContainer = detectWithContainer();
 
-        if (withContainer) {
-            console.trace("[withMaven] IMPORTANT \"withMaven(){...}\" step running within a Docker container. See ");
-            console.traceHyperlink(
-                    "https://github.com/jenkinsci/pipeline-maven-plugin/blob/master/FAQ.adoc#how-to-use-the-pipeline-maven-plugin-with-docker",
-                    "Pipeline Maven Plugin FAQ");
-            console.trace(" in case of problem.");
-        }
-
         setupJDK();
 
         // list of credentials injected by withMaven. They will be tracked and masked in the logs
@@ -265,7 +257,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
      * "https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/pipeline/ContainerStep.java">
      * ContainerStep</a>
      */
-    private boolean detectWithContainer() {
+    private boolean detectWithContainer() throws IOException {
         Launcher launcher1 = launcher;
         while (launcher1 instanceof Launcher.DecoratedLauncher) {
             String launcherClassName = launcher1.getClass().getName();
@@ -275,6 +267,13 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             }
             if (launcherClassName.contains("WithContainerStep")) {
                 LOGGER.log(Level.FINE, "Step running within docker.image(): {0}", launcherClassName);
+
+                console.trace(
+                        "[withMaven] IMPORTANT \"withMaven(){...}\" step running within a Docker container. See ");
+                console.traceHyperlink(
+                        "https://github.com/jenkinsci/pipeline-maven-plugin/blob/master/FAQ.adoc#how-to-use-the-pipeline-maven-plugin-with-docker",
+                        "Pipeline Maven Plugin FAQ");
+                console.trace(" in case of problem.");
                 return true;
             }
             launcher1 = ((Launcher.DecoratedLauncher) launcher1).getInner();

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -276,9 +276,6 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             if (launcherClassName.contains("WithContainerStep")) {
                 LOGGER.log(Level.FINE, "Step running within docker.image(): {0}", launcherClassName);
                 return true;
-            } else if (launcherClassName.contains("ContainerExecDecorator")) {
-                LOGGER.log(Level.FINE, "Step running within docker.image(): {0}", launcherClassName);
-                return true;
             }
             launcher1 = ((Launcher.DecoratedLauncher) launcher1).getInner();
         }

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -271,7 +271,7 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
             String launcherClassName = launcher1.getClass().getName();
             if (launcherClassName.contains("org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator")) {
                 LOGGER.log(Level.FINE, "Step running within Kubernetes withContainer(): {0}", launcherClassName);
-                return false;
+                return true;
             }
             if (launcherClassName.contains("WithContainerStep")) {
                 LOGGER.log(Level.FINE, "Step running within docker.image(): {0}", launcherClassName);


### PR DESCRIPTION
The **detectWithContainer** method within **WithMavenStepExecution2** that detects whether a withMaven step is called inside a container (inside the **docker.image()** block from the [Docker Pipeline plugin](https://plugins.jenkins.io/docker-workflow) or the **container()** block from the [Kubernetes plugin](https://plugins.jenkins.io/kubernetes)) does not work as described for the **container()** step.

Console log of the withMaven execution inside container() block (with WithMavenStepExecution2 FINEST logging level):

Before:
```
[withMaven] Options: []
[withMaven] Available options: 
[withMaven] using JDK installation provided by the build agent
[withMaven] using Maven settings provided by the Jenkins Managed Configuration File 'maven-settings' 
[withMaven] using Maven settings.xml 'maven-settings' with NO Maven servers credentials provided by Jenkins
[withMaven] using Maven global settings provided by the Jenkins global configuration. Maven global settings defined by 'DefaultSettingsProvider', NOT overriding it.
[withMaven] No Maven Installation or MAVEN_HOME found, looking for mvn executable by using which/where command
Executing sh script inside container container-name of pod pod-name
Executing command: "/bin/sh" "-c" "which mvn" 
exit
/usr/bin/mvn
[withMaven] using Maven installation provided by the build agent with executable /usr/bin/mvn
[withMaven] failed to read Maven version: null
[withMaven] WARNING: You are running an old version of Maven (UNKNOWN), you should update to at least 3.8.x
```

**/usr/bin/mvn** isn't real Maven location path from desired container.

After:
```
[withMaven] Options: []
[withMaven] Available options: 
[withMaven] using JDK installation provided by the build agent
[withMaven] using Maven settings provided by the Jenkins Managed Configuration File 'maven-settings' 
[withMaven] using Maven settings.xml 'maven-settings' with NO Maven servers credentials provided by Jenkins
[withMaven] using Maven global settings provided by the Jenkins global configuration. Maven global settings defined by 'DefaultSettingsProvider', NOT overriding it.
Executing sh script inside container container-name of pod pod-name
Executing command: "printenv" "MAVEN_HOME" 
exit
/opt/maven/current
[withMaven] using Maven installation provided by the build agent with the environment variable MAVEN_HOME=/opt/maven/current
[withMaven] failed to read Maven version: null
[withMaven] WARNING: You are running an old version of Maven (UNKNOWN), you should update to at least 3.8.x
```