### PR TITLE
Stop excluding ASM via the plugin system

### DIFF
--- a/pipeline-maven/pom.xml
+++ b/pipeline-maven/pom.xml
@@ -153,18 +153,6 @@
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpcore</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm-commons</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm-tree</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
When running Plugin Compatibility Tester (PCT) against a version of Jenkins core with ASM removed and against a JaCoCo plugin with a dependency on the ASM library plugin in https://github.com/jenkinsci/bom/pull/3019, `org.jenkinsci.plugins.pipeline.maven.publishers.JacocoReportPublisherTest` failed with

```
java.lang.NoClassDefFoundError: org/objectweb/asm/ClassVisitor
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1027)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at hudson.plugins.jacoco.ExecutionFileLoader.analyzeStructure(ExecutionFileLoader.java:108)
	at hudson.plugins.jacoco.ExecutionFileLoader.loadBundleCoverage(ExecutionFileLoader.java:138)
	at hudson.plugins.jacoco.JacocoReportDir.parse(JacocoReportDir.java:110)
	at hudson.plugins.jacoco.JacocoBuildAction.loadRatios(JacocoBuildAction.java:331)
	at hudson.plugins.jacoco.JacocoBuildAction.load(JacocoBuildAction.java:321)
	at hudson.plugins.jacoco.JacocoPublisher.perform(JacocoPublisher.java:678)
	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:91)
	at org.jenkinsci.plugins.pipeline.maven.publishers.JacocoReportPublisher.process(JacocoReportPublisher.java:273)
	at org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor.processMavenSpyLogs(MavenSpyLogProcessor.java:172)
	at org.jenkinsci.plugins.pipeline.maven.WithMavenStepExecution2$WithMavenStepExecutionCallBack.finished(WithMavenStepExecution2.java:1352)
	at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution$TailCall.lambda$onSuccess$0(GeneralNonBlockingStepExecution.java:140)
	at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution.lambda$run$0(GeneralNonBlockingStepExecution.java:77)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

Even though JaCoCo plugin was linking against ASM library plugin in the above test (and would also be doing so in production), the test environment was unrealistic in that it was excluding the ASM JARs from the dependency declaration for JaCoCo plugin. Fixed by removing the exclusion, bringing the test environment closer to production.

### Testing done

To guard against regressions, ran `mvn clean verify` in both Java 17 and 21 Docker containers. Also compared `META-INF/MANIFEST.MF` and `WEB-INF/lib` before and after these changes; it was identical.

To verify this change fixes the PCT issue mentioned above, ran `mvn clean verify -Dtest=org.jenkinsci.plugins.pipeline.maven.publishers.JacocoReportPublisherTest -Djth.jenkins-war.path=/home/basil/src/jenkinsci/bom/target/megawar-weekly.war -DoverrideWar=/home/basil/src/jenkinsci/bom/target/megawar-weekly.war -Djenkins.version=2.450-rc34727.247345c76382` before and after this PR with a megawar from https://github.com/jenkinsci/bom/pull/3019. Before this PR, failed with the stack trace given above; after, it passed.