### PR TITLE
Revert to 1376.v18876d10ce9c detectWithContainer logic

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -111,6 +111,8 @@ import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.springframework.util.ClassUtils;
 
 @SuppressFBWarnings(
@@ -257,36 +259,54 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         Launcher launcher1 = launcher;
         while (launcher1 instanceof Launcher.DecoratedLauncher) {
             String launcherClassName = launcher1.getClass().getName();
-            // kubernetes-plugin container step execution does not require special container handling
-            if (launcherClassName.contains("org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator")) {
-                LOGGER.log(Level.FINE, "Step running within Kubernetes withContainer(): {1}", launcherClassName);
-                return false;
+            Optional<Boolean> withContainer = isWithContainerLauncher(launcherClassName);
+            if (withContainer.isPresent()) {
+                boolean result = withContainer.get();
+                if (result) {
+                    console.trace(
+                            "[withMaven] IMPORTANT \"withMaven(){...}\" step running within a Docker container. See ");
+                    console.traceHyperlink(
+                            "https://github.com/jenkinsci/pipeline-maven-plugin/blob/master/FAQ.adoc#how-to-use-the-pipeline-maven-plugin-with-docker",
+                            "Pipeline Maven Plugin FAQ");
+                    console.trace(" in case of problem.");
+                }
+
+                return result;
             }
 
-            // for plugins that require special container handling should include this name launcher naming convention
-            // since there is no common interface to detect if a step is running within a container
-            if (launcherClassName.contains("ContainerExecDecorator")) {
-                LOGGER.log(Level.FINE, "Step running within container exec decorator: {0}", launcherClassName);
-                console.traceHyperlink(
-                        "https://github.com/jenkinsci/pipeline-maven-plugin/blob/master/FAQ.adoc#how-to-use-the-pipeline-maven-plugin-with-docker",
-                        "Pipeline Maven Plugin FAQ");
-                return true;
-            }
-
-            if (launcherClassName.contains("WithContainerStep")) {
-                LOGGER.log(Level.FINE, "Step running within docker.image(): {0}", launcherClassName);
-
-                console.trace(
-                        "[withMaven] IMPORTANT \"withMaven(){...}\" step running within a Docker container. See ");
-                console.traceHyperlink(
-                        "https://github.com/jenkinsci/pipeline-maven-plugin/blob/master/FAQ.adoc#how-to-use-the-pipeline-maven-plugin-with-docker",
-                        "Pipeline Maven Plugin FAQ");
-                console.trace(" in case of problem.");
-                return true;
-            }
             launcher1 = ((Launcher.DecoratedLauncher) launcher1).getInner();
         }
         return false;
+    }
+
+    /**
+     * Check if the launcher class name is a known container launcher.
+     * @param launcherClassName launcher class name
+     * @return empty if unknown and should keep checking, true if it is a container launcher, false if it is not.
+     */
+    @Restricted(NoExternalUse.class)
+    protected static Optional<Boolean> isWithContainerLauncher(String launcherClassName) {
+        // kubernetes-plugin container step execution does not require special container handling
+        if (launcherClassName.contains("org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator")) {
+            LOGGER.log(Level.FINE, "Step running within Kubernetes withContainer(): {1}", launcherClassName);
+            return Optional.of(false);
+        }
+
+        // for plugins that require special container handling should include this name launcher naming convention
+        // since there is no common interface to detect if a step is running within a container
+        if (launcherClassName.contains("ContainerExecDecorator")) {
+            LOGGER.log(Level.FINE, "Step running within container exec decorator: {0}", launcherClassName);
+            return Optional.of(true);
+        }
+
+        // detect docker.image().inside {} or withDockerContainer step from docker-workflow-plugin, which has the
+        // launcher name org.jenkinsci.plugins.docker.workflow.WithContainerStep.Decorator
+        if (launcherClassName.contains("WithContainerStep")) {
+            LOGGER.log(Level.FINE, "Step running within docker.image(): {0}", launcherClassName);
+            return Optional.of(true);
+        }
+
+        return Optional.empty();
     }
 
     /**

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2.java
@@ -257,7 +257,22 @@ class WithMavenStepExecution2 extends GeneralNonBlockingStepExecution {
         Launcher launcher1 = launcher;
         while (launcher1 instanceof Launcher.DecoratedLauncher) {
             String launcherClassName = launcher1.getClass().getName();
-            // ToDo: add support for container() step (ContainerExecDecorator) from Kubernetes plugin
+            // kubernetes-plugin container step execution does not require special container handling
+            if (launcherClassName.contains("org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator")) {
+                LOGGER.log(Level.FINE, "Step running within Kubernetes withContainer(): {1}", launcherClassName);
+                return false;
+            }
+
+            // for plugins that require special container handling should include this name launcher naming convention
+            // since there is no common interface to detect if a step is running within a container
+            if (launcherClassName.contains("ContainerExecDecorator")) {
+                LOGGER.log(Level.FINE, "Step running within container exec decorator: {0}", launcherClassName);
+                console.traceHyperlink(
+                        "https://github.com/jenkinsci/pipeline-maven-plugin/blob/master/FAQ.adoc#how-to-use-the-pipeline-maven-plugin-with-docker",
+                        "Pipeline Maven Plugin FAQ");
+                return true;
+            }
+
             if (launcherClassName.contains("WithContainerStep")) {
                 LOGGER.log(Level.FINE, "Step running within docker.image(): {0}", launcherClassName);
 

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2Test.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2Test.java
@@ -31,4 +31,26 @@ public class WithMavenStepExecution2Test {
 
         assertThat(actualEscapedMavenConfig).isEqualTo(expectedEscapedMavenConfig);
     }
+
+    @Test
+    public void testIsWithContainerLauncherUnknown() {
+        assertThat(WithMavenStepExecution2.isWithContainerLauncher("hudson.SomeUnknownLauncher")).isEmpty();
+    }
+
+    @Test
+    public void testIsWithContainerLauncherWithContainerStep() {
+        assertThat(WithMavenStepExecution2.isWithContainerLauncher("org.jenkinsci.plugins.docker.workflow.WithContainerStep.Decorator")).contains(true);
+    }
+
+    @Test
+    public void testIsWithContainerLauncherKubernetesPluginContainerExecDecorator() {
+        assertThat(WithMavenStepExecution2.isWithContainerLauncher("org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator")).contains(false);
+    }
+
+    @Test
+    public void testIsWithContainerLauncherCustomContainerExecDecorator() {
+        // for plugins that supporting launching their own containerized steps
+        assertThat(WithMavenStepExecution2.isWithContainerLauncher("com.jenkins.plugins.custom.ContainerExecDecorator")).contains(true);
+        assertThat(WithMavenStepExecution2.isWithContainerLauncher("com.jenkins.plugins.kubernetes.pipeline.MyContainerExecDecorator.MyContainerDecoratedLauncher")).contains(true);
+    }
 }

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2Test.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepExecution2Test.java
@@ -34,23 +34,32 @@ public class WithMavenStepExecution2Test {
 
     @Test
     public void testIsWithContainerLauncherUnknown() {
-        assertThat(WithMavenStepExecution2.isWithContainerLauncher("hudson.SomeUnknownLauncher")).isEmpty();
+        assertThat(WithMavenStepExecution2.isWithContainerLauncher("hudson.SomeUnknownLauncher"))
+                .isEmpty();
     }
 
     @Test
     public void testIsWithContainerLauncherWithContainerStep() {
-        assertThat(WithMavenStepExecution2.isWithContainerLauncher("org.jenkinsci.plugins.docker.workflow.WithContainerStep.Decorator")).contains(true);
+        assertThat(WithMavenStepExecution2.isWithContainerLauncher(
+                        "org.jenkinsci.plugins.docker.workflow.WithContainerStep.Decorator"))
+                .contains(true);
     }
 
     @Test
     public void testIsWithContainerLauncherKubernetesPluginContainerExecDecorator() {
-        assertThat(WithMavenStepExecution2.isWithContainerLauncher("org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator")).contains(false);
+        assertThat(WithMavenStepExecution2.isWithContainerLauncher(
+                        "org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator"))
+                .contains(false);
     }
 
     @Test
     public void testIsWithContainerLauncherCustomContainerExecDecorator() {
         // for plugins that supporting launching their own containerized steps
-        assertThat(WithMavenStepExecution2.isWithContainerLauncher("com.jenkins.plugins.custom.ContainerExecDecorator")).contains(true);
-        assertThat(WithMavenStepExecution2.isWithContainerLauncher("com.jenkins.plugins.kubernetes.pipeline.MyContainerExecDecorator.MyContainerDecoratedLauncher")).contains(true);
+        assertThat(WithMavenStepExecution2.isWithContainerLauncher("com.jenkins.plugins.custom.ContainerExecDecorator"))
+                .contains(true);
+        assertThat(
+                        WithMavenStepExecution2.isWithContainerLauncher(
+                                "com.jenkins.plugins.kubernetes.pipeline.MyContainerExecDecorator.MyContainerDecoratedLauncher"))
+                .contains(true);
     }
 }


### PR DESCRIPTION
Restores with container detection handling back to 1376.v18876d10ce9c. This version contained special handling for kubernetes-plugin as well as naming convention for other plugins to trigger special with container handling.

This fixes a regression introduced by #774 for plugins using the `ContainerExecDecorator` detection path, not including
kubernetes-plugin container step. Without this special handling steps that use maven inside a container cause the agent to quit unexpectedly. 

### Testing done

Tested with local plugin build.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
