### PR TITLE
Set `safe.directory` in `WithMavenStepTest.tesWithDifferentJavasForBuild`

### DIFF
--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepTest.java
@@ -58,6 +58,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.jvnet.hudson.test.Issue;
+import org.testcontainers.containers.ExecConfig;
+import org.testcontainers.containers.ExecInContainerPattern;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.MountableFile;
 
@@ -142,6 +144,15 @@ public class WithMavenStepTest extends AbstractIntegrationTest {
             String gitRepoPath = this.gitRepoRule.toString();
             javasContainerRule.copyFileToContainer(MountableFile.forHostPath(gitRepoPath), "/tmp/gitrepo");
             javasContainerRule.execInContainer("chmod", "-R", "777", "/tmp/gitrepo");
+            System.out.println(ExecInContainerPattern.execInContainer(
+                    javasContainerRule.getDockerClient(),
+                    javasContainerRule.getContainerInfo(),
+                    ExecConfig.builder()
+                            .user("test")
+                            .command(new String[] {
+                                "git", "config", "--global", "--add", "safe.directory", "/tmp/gitrepo/.git"
+                            })
+                            .build()));
             registerAgentForContainer(javasContainerRule);
             ToolLocationNodeProperty.ToolLocation toolLocation =
                     new ToolLocationNodeProperty.ToolLocation(new JDK.DescriptorImpl(), jdkName, jdkPath);


### PR DESCRIPTION
This test started failing recently, at least in CI (cannot yet reproduce locally); see https://github.com/jenkinsci/pipeline-maven-plugin/pull/795/checks?check_run_id=25521476848 for an example. Possibly due to https://github.com/git/git/commit/9e65df5eab274bf74c7b570107aacd1303a1e703 (thx @cathychan) https://github.blog/2024-05-14-securing-git-addressing-5-new-vulnerabilities/