### PR TITLE
Replace deprecated Takari wrapper with official one

### DIFF
--- a/FAQ.adoc
+++ b/FAQ.adoc
@@ -24,7 +24,7 @@ Since the version 1.14 of the Docker Pipeline plugin, `withMaven` requires to
 * Or call the generated script directly via `MVN_CMD` (e.g. `sh '$MVN_CMD clean deploy'`)
 * Or use https://maven.apache.org/wrapper/[Maven Wrapper] (e.g. `sh './mvnw clean deploy'`)
 
-If omitted, the Maven settings file and Mven global settings file will not be injected in the Maven execution.
+If omitted, the Maven settings file and Maven global settings file will not be injected in the Maven execution.
 
 === Using `withMaven` with `docker.image(...).inside{...}` and a Jenkins Scripted Pipeline
 
@@ -42,7 +42,7 @@ node("linux-agent-running-docker") { // Linux agent with the Docker daemon
 }
 ----
 
-**Using Takari's Maven Wrapper mvnw**
+**Using Maven Wrapper mvnw**
 
 [source,groovy]
 ----
@@ -81,18 +81,6 @@ pipeline {
 ----
 
 Note: In Declarative Pipelines, the agent configuration is used to define the docker environment instead of `docker.image(...).inside{...}`  (docs https://www.jenkins.io/doc/book/pipeline/docker)[here]). Stage-level agents work with `withMaven` as well. 
-
-
-=== Sample message displayed in the build logs when using withMaven in a Docker Pipeline execution environment
-
-The warning message displayed in the logs when invoking `withMaven` within Docker Pipeline:
-
-----
- [withMaven] WARNING: "withMaven(){...}" step running within "docker.image('image').inside {...}". Since the Docker Pipeline Plugin version 1.14, you MUST:
- [withMaven] * Either prepend the 'MVN_CMD_DIR' environment variable to the 'PATH' environment variable in every 'sh' step that invokes 'mvn' (e.g. "sh 'export PATH=$MVN_CMD_DIR:$PATH && mvn clean deploy' ").
- [withMaven] * Or use Takari's Maven Wrapper (e.g. "sh './mvnw clean deploy'")
- [withMaven] See Pipeline Maven Plugin FAQ.
-----
 
 == How to disable the Maven Event Spy injected by the Pipeline Maven Plugin in Maven builds?
 

--- a/README.adoc
+++ b/README.adoc
@@ -483,11 +483,11 @@ By default, only the maven builds who reach the `deploy` phase will trigger down
 image:docs/images/downstream-pipeline-trigger-threshold-lifecycle.png[]
 
 [#feature-mvnw]
-=== Support of Takari's Maven Wrapper 'mvnw'
+=== Support of Maven Wrapper 'mvnw'
 
 NOTE: Available since version 3.0.3
 
-The Pipeline Maven Plugin works with https://github.com/takari/maven-wrapper[Takari's Maven wrapper] 'mvnw'.
+The Pipeline Maven Plugin works with https://maven.apache.org/wrapper/[Maven Wrapper] 'mvnw'.
 
 [source,groovy]
 ----


### PR DESCRIPTION
Message warning has been removed in commit c2ebbacab5cc10e974a322ed173cf4fc3815f836 (JENKINS-49337 add backward compatibility)

https://github.com/takari/maven-wrapper
https://github.com/jenkinsci/pipeline-maven-plugin/pull/745

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
