### PR TITLE
Adds support to detect Maven 4 beta versions

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersion.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersion.java
@@ -8,7 +8,7 @@ public class MavenVersion {
 
     public static MavenVersion fromString(String str) {
         try {
-            String[] parts = str.split("\\.");
+            String[] parts = str.split("[.\\-]");
             return new MavenVersion(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]));
         } catch (Exception ex) {
             throw new IllegalArgumentException("'" + str + "' is not a valid maven version", ex);

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionUtils.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionUtils.java
@@ -5,7 +5,7 @@ import java.util.function.Predicate;
 public class MavenVersionUtils {
 
     public static Predicate<String> containsMavenVersion() {
-        return string -> string != null && string.matches("Apache Maven \\d+\\.\\d+\\.\\d+ \\(.*\\)");
+        return string -> string != null && string.matches("Apache Maven \\d+\\.\\d+\\.\\d+(.*) \\(.*\\)");
     }
 
     public static MavenVersion parseMavenVersion(String outputLine) {

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionUtilsTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionUtilsTest.java
@@ -20,6 +20,10 @@ class MavenVersionUtilsTest {
         assertThat(MavenVersionUtils.containsMavenVersion()
                         .test("Apache Maven 3.9.6 (bc0240f3c744dd6b6ec2920b3cd08dcc295161ae)"))
                 .isTrue();
+
+        assertThat(MavenVersionUtils.containsMavenVersion()
+                        .test("Apache Maven 4.0.0-beta-3 (e92f645c2749eb2a4f5a8843cf01e7441e4b559f)"))
+                .isTrue();
     }
 
     @Test
@@ -30,5 +34,6 @@ class MavenVersionUtilsTest {
                 .isEqualTo(new MavenVersion(3, 8, 8));
         assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 3.6.1")).isEqualTo(new MavenVersion(3, 6, 1));
         assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 3.5.4")).isEqualTo(new MavenVersion(3, 5, 4));
+        assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 4.0.0-beta-3")).isEqualTo(new MavenVersion(4, 0, 0));
     }
 }

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionUtilsTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/MavenVersionUtilsTest.java
@@ -34,6 +34,7 @@ class MavenVersionUtilsTest {
                 .isEqualTo(new MavenVersion(3, 8, 8));
         assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 3.6.1")).isEqualTo(new MavenVersion(3, 6, 1));
         assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 3.5.4")).isEqualTo(new MavenVersion(3, 5, 4));
-        assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 4.0.0-beta-3")).isEqualTo(new MavenVersion(4, 0, 0));
+        assertThat(MavenVersionUtils.parseMavenVersion("Apache Maven 4.0.0-beta-3"))
+                .isEqualTo(new MavenVersion(4, 0, 0));
     }
 }


### PR DESCRIPTION
Using Maven 4.0.0-beta-3, this plugins warns with:
> [withMaven] WARNING: You are running an old version of Maven (UNKNOWN), you should update to at least 3.8.x


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] ~~Link to relevant issues in GitHub or Jira~~
- [x] ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
