### PR TITLE
Forward compatibility for Java 17 bytecode

### DIFF
--- a/pipeline-maven/pom.xml
+++ b/pipeline-maven/pom.xml
@@ -502,10 +502,10 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>com.spotify</groupId>
-            <artifactId>dockerfile-maven-plugin</artifactId>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
             <configuration>
-              <pullNewerImage>false</pullNewerImage>
+              <imagePullPolicy>IfNotPresent</imagePullPolicy>
             </configuration>
             <executions>
               <execution>
@@ -515,8 +515,14 @@
                 </goals>
                 <phase>process-test-resources</phase>
                 <configuration>
-                  <contextDirectory>src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/SshdContainer/</contextDirectory>
-                  <repository>localhost/pipeline-maven/sshd</repository>
+                  <images>
+                    <image>
+                      <build>
+                        <contextDir>${project.basedir}/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/SshdContainer/</contextDir>
+                      </build>
+                      <name>localhost/pipeline-maven/sshd</name>
+                    </image>
+                  </images>
                 </configuration>
               </execution>
               <execution>
@@ -526,8 +532,14 @@
                 </goals>
                 <phase>process-test-resources</phase>
                 <configuration>
-                  <contextDirectory>src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/</contextDirectory>
-                  <repository>localhost/pipeline-maven/java-git</repository>
+                  <images>
+                    <image>
+                      <build>
+                        <contextDir>${project.basedir}/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/</contextDir>
+                      </build>
+                      <name>localhost/pipeline-maven/java-git</name>
+                    </image>
+                  </images>
                 </configuration>
               </execution>
               <execution>
@@ -537,8 +549,14 @@
                 </goals>
                 <phase>process-test-resources</phase>
                 <configuration>
-                  <contextDirectory>src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaMavenContainer/</contextDirectory>
-                  <repository>localhost/pipeline-maven/java-maven-git</repository>
+                  <images>
+                    <image>
+                      <build>
+                        <contextDir>${project.basedir}/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaMavenContainer/</contextDir>
+                      </build>
+                      <name>localhost/pipeline-maven/java-maven-git</name>
+                    </image>
+                  </images>
                 </configuration>
               </execution>
               <execution>
@@ -548,8 +566,14 @@
                 </goals>
                 <phase>process-test-resources</phase>
                 <configuration>
-                  <contextDirectory>src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavasContainer/</contextDirectory>
-                  <repository>localhost/pipeline-maven/javas</repository>
+                  <images>
+                    <image>
+                      <build>
+                        <contextDir>${project.basedir}/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavasContainer/</contextDir>
+                      </build>
+                      <name>localhost/pipeline-maven/javas</name>
+                    </image>
+                  </images>
                 </configuration>
               </execution>
               <execution>
@@ -559,8 +583,14 @@
                 </goals>
                 <phase>process-test-resources</phase>
                 <configuration>
-                  <contextDirectory>src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaMavenWithMavenHomeContainer/</contextDirectory>
-                  <repository>localhost/pipeline-maven/maven-home</repository>
+                  <images>
+                    <image>
+                      <build>
+                        <contextDir>${project.basedir}/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaMavenWithMavenHomeContainer/</contextDir>
+                      </build>
+                      <name>localhost/pipeline-maven/maven-home</name>
+                    </image>
+                  </images>
                 </configuration>
               </execution>
             </executions>

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepMavenExecResolutionTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepMavenExecResolutionTest.java
@@ -148,7 +148,7 @@ public class WithMavenStepMavenExecResolutionTest extends AbstractIntegrationTes
             );
             // @formatter:on
 
-            jenkinsRule.assertLogContains("Apache Maven 3.6.3", run);
+            jenkinsRule.assertLogContains("Apache Maven 3.8.7", run);
             jenkinsRule.assertLogContains(
                     "using Maven installation provided by the build agent with executable /usr/bin/mvn", run);
         }

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepMavenExecResolutionTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepMavenExecResolutionTest.java
@@ -172,7 +172,7 @@ public class WithMavenStepMavenExecResolutionTest extends AbstractIntegrationTes
             );
             // @formatter:on
 
-            jenkinsRule.assertLogContains("Apache Maven 3.6.3", run);
+            jenkinsRule.assertLogContains("Apache Maven 3.8.7", run);
             jenkinsRule.assertLogContains(
                     "using Maven installation provided by the build agent with the environment variable MAVEN_HOME=/usr/share/maven",
                     run);

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainerTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainerTest.java
@@ -46,7 +46,7 @@ public class JavaGitContainerTest extends AbstractIntegrationTest {
     @Test
     public void smokes() throws Exception {
         assertThat(containerRule.execInContainer("java", "-version").getStderr())
-                .contains("openjdk version \"11");
+                .contains("openjdk version \"17");
         assertThat(containerRule.execInContainer("git", "--version").getStdout())
                 .contains("git version 2.");
     }

--- a/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
+++ b/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/JavaGitContainer/Dockerfile
@@ -3,7 +3,7 @@ FROM localhost/pipeline-maven/sshd
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         software-properties-common \
-        openjdk-11-jdk-headless \
+        openjdk-17-jdk-headless \
         curl \
         ant \
         git

--- a/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/SshdContainer/Dockerfile
+++ b/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/SshdContainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 # install SSHD
 RUN apt-get update -y && \

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.82</version>
+    <version>4.83</version>
     <relativePath />
   </parent>
 
@@ -100,8 +100,8 @@
     <jenkins-plugin-mysql.version>8.4.0-31.va_b_5ce7933762</jenkins-plugin-mysql.version>
     <jenkins-plugin-postgresql.version>42.7.2-40.v76d376d65c77</jenkins-plugin-postgresql.version>
     <jenkins-plugin-tasks.version>4.53</jenkins-plugin-tasks.version>
-    <jenkins-tools-bom.version>2982.vdce2153031a_0</jenkins-tools-bom.version>
-    <jenkins.version>2.414.3</jenkins.version>
+    <jenkins-tools-bom.version>3105.v672692894683</jenkins-tools-bom.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <junit.version>5.10.2</junit.version>
     <mariadb-client.version>3.4.0</mariadb-client.version>
     <maven-plugin-sisu.version>0.3.5</maven-plugin-sisu.version>
@@ -109,7 +109,7 @@
     <maven.version>3.8.8</maven.version>
     <mockito.version>5.6.0</mockito.version>
     <plexus-utils.version>3.5.1</plexus-utils.version>
-    <plugin-dockerfile.version>1.4.13</plugin-dockerfile.version>
+    <plugin-dockerfile.version>0.44.0</plugin-dockerfile.version>
     <plugin-exec.version>3.3.0</plugin-exec.version>
     <slf4j.version>2.0.13</slf4j.version>
     <spotless.check.skip>false</spotless.check.skip>
@@ -120,7 +120,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.414.x</artifactId>
+        <artifactId>bom-2.426.x</artifactId>
         <version>${jenkins-tools-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -252,8 +252,8 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>com.spotify</groupId>
-          <artifactId>dockerfile-maven-plugin</artifactId>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
           <version>${plugin-dockerfile.version}</version>
         </plugin>
         <plugin>


### PR DESCRIPTION
This PR updates the test suite to support versions of Jenkins core that are compiled with Java 17 bytecode, as a forthcoming weekly soon will be this month.

<!-- Please describe your pull request here. -->
I was testing the plugin with `maven.compiler.{testR,r}elease` set to `17` to generate a Java 17 binary. While doing so, I kept getting

```
[ERROR] Failed to execute goal com.spotify:dockerfile-maven-plugin:1.4.13:build (build-first-sshd-image) on project pipeline-maven: Could not build image: java.util.concurrent.ExecutionException: com.spotify.docker.client.shaded.javax.ws.rs.ProcessingException: java.lang.UnsatisfiedLinkError: could not load FFI provider com.spotify.docker.client.shaded.jnr.ffi.provider.jffi.Provider: ExceptionInInitializerError: Can't overwrite cause with java.lang.UnsatisfiedLinkError: java.lang.UnsatisfiedLinkError: /private/var/folders/k3/nxkzrth549l6l1psm72nmsq80000gn/T/jffi6089015994029255767.dylib: dlopen(/private/var/folders/k3/nxkzrth549l6l1psm72nmsq80000gn/T/jffi6089015994029255767.dylib, 0x0001): tried: '/private/var/folders/k3/nxkzrth549l6l1psm72nmsq80000gn/T/jffi6089015994029255767.dylib' (fat file, but missing compatible architecture (have 'i386,x86_64', need 'arm64e' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/private/var/folders/k3/nxkzrth549l6l1psm72nmsq80000gn/T/jffi6089015994029255767.dylib' (no such file), '/private/var/folders/k3/nxkzrth549l6l1psm72nmsq80000gn/T/jffi6089015994029255767.dylib' (fat file, but missing compatible architecture (have 'i386,x86_64', need 'arm64e' or 'arm64'))
```

I discover that `dockerfile-maven-plugin` support was discontinued, so I moved the plugin to use `docker-maven-plugin`.

### Testing done

I ran `mvn verify` locally to validate that the changeset is complete and resolves the problem.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
