### PR TITLE
fix JENKINS-69410: Links to Attached Artifacts broken

### DIFF
--- a/pipeline-maven-api/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenArtifact.java
+++ b/pipeline-maven-api/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenArtifact.java
@@ -137,8 +137,9 @@ public class MavenArtifact implements Serializable, Comparable<MavenArtifact> {
     @Nullable
     public String getUrl() {
         if (getRepositoryUrl() == null) return null;
-        return getRepositoryUrl() + "/" + getGroupId().replace('.', '/') + "/" + getArtifactId() + "/"
-                + getBaseVersion() + "/" + getFileNameWithVersion();
+        return getRepositoryUrl() + (getRepositoryUrl().endsWith("/") ? "" : "/")
+                + getGroupId().replace('.', '/') + "/" + getArtifactId() + "/" + getBaseVersion() + "/"
+                + getFileNameWithVersion();
     }
 
     @Override

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtils.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtils.java
@@ -545,6 +545,9 @@ public class XmlUtils {
                         if (attachedArtifactDeployedEvent == null) {
                             // artifact has not been deployed ("mvn deploy")
                         } else {
+                            attachedMavenArtifact.setVersion(
+                                    XmlUtils.getUniqueChildElement(attachedArtifactDeployedEvent, "artifact")
+                                            .getAttribute("version"));
                             attachedMavenArtifact.setRepositoryUrl(
                                     XmlUtils.getUniqueChildElement(attachedArtifactDeployedEvent, "repository")
                                             .getAttribute("url"));

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
@@ -242,7 +242,7 @@ public class XmlUtilsTest {
         InputStream in = Thread.currentThread()
                 .getContextClassLoader()
                 .getResourceAsStream("org/jenkinsci/plugins/pipeline/maven/maven-spy-package-jar.xml");
-        in.getClass(); // check non null
+        assertThat(in).isNotNull();
         Element mavenSpyLogs = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder()
                 .parse(in)
@@ -258,7 +258,7 @@ public class XmlUtilsTest {
         InputStream in = Thread.currentThread()
                 .getContextClassLoader()
                 .getResourceAsStream("org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-jar.xml");
-        in.getClass(); // check non null
+        assertThat(in).isNotNull();
         Element mavenSpyLogs = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder()
                 .parse(in)
@@ -278,7 +278,7 @@ public class XmlUtilsTest {
         InputStream in = Thread.currentThread()
                 .getContextClassLoader()
                 .getResourceAsStream("org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-jar.xml");
-        in.getClass(); // check non null
+        assertThat(in).isNotNull();
         Element mavenSpyLogs = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder()
                 .parse(in)
@@ -302,13 +302,12 @@ public class XmlUtilsTest {
         InputStream in = Thread.currentThread()
                 .getContextClassLoader()
                 .getResourceAsStream("org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-jar.xml");
-        in.getClass(); // check non null
+        assertThat(in).isNotNull();
         Element mavenSpyLogs = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder()
                 .parse(in)
                 .getDocumentElement();
         List<MavenArtifact> generatedArtifacts = XmlUtils.listGeneratedArtifacts(mavenSpyLogs, false);
-        System.out.println(generatedArtifacts);
         assertThat(generatedArtifacts.size()).isEqualTo(2); // a jar file and a pom file are generated
 
         for (MavenArtifact mavenArtifact : generatedArtifacts) {
@@ -331,7 +330,7 @@ public class XmlUtilsTest {
         InputStream in = Thread.currentThread()
                 .getContextClassLoader()
                 .getResourceAsStream("org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-2.8.xml");
-        in.getClass(); // check non null
+        assertThat(in).isNotNull();
         Element mavenSpyLogs = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder()
                 .parse(in)
@@ -365,7 +364,7 @@ public class XmlUtilsTest {
         InputStream in = Thread.currentThread()
                 .getContextClassLoader()
                 .getResourceAsStream("org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-3.0.xml");
-        in.getClass(); // check non null
+        assertThat(in).isNotNull();
         Element mavenSpyLogs = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder()
                 .parse(in)
@@ -399,18 +398,20 @@ public class XmlUtilsTest {
         InputStream in = Thread.currentThread()
                 .getContextClassLoader()
                 .getResourceAsStream("org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-jar.xml");
-        in.getClass(); // check non null
+        assertThat(in).isNotNull();
         Element mavenSpyLogs = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder()
                 .parse(in)
                 .getDocumentElement();
         List<MavenArtifact> generatedArtifacts = XmlUtils.listGeneratedArtifacts(mavenSpyLogs, true);
-        System.out.println(generatedArtifacts);
         assertThat(generatedArtifacts.size()).isEqualTo(3); // a jar file and a pom file are generated
 
         for (MavenArtifact mavenArtifact : generatedArtifacts) {
             assertThat(mavenArtifact.getGroupId()).isEqualTo("com.example");
             assertThat(mavenArtifact.getArtifactId()).isEqualTo("my-jar");
+            assertThat(mavenArtifact.getBaseVersion()).isEqualTo("0.5-SNAPSHOT");
+            assertThat(mavenArtifact.getVersion()).isEqualTo("0.5-20180304.184830-1");
+            assertThat(mavenArtifact.isSnapshot()).isTrue();
             if ("pom".equals(mavenArtifact.getType())) {
                 assertThat(mavenArtifact.getExtension()).isEqualTo("pom");
                 assertThat(mavenArtifact.getClassifier()).isNullOrEmpty();
@@ -430,19 +431,21 @@ public class XmlUtilsTest {
     public void test_listGeneratedArtifacts_includeAttachedArtifacts() throws Exception {
         InputStream in = Thread.currentThread()
                 .getContextClassLoader()
-                .getResourceAsStream("org/jenkinsci/plugins/pipeline/maven/maven-spy-include-attached-artifacts.log");
-        in.getClass(); // check non null
+                .getResourceAsStream("org/jenkinsci/plugins/pipeline/maven/maven-spy-include-attached-artifacts.xml");
+        assertThat(in).isNotNull();
         Element mavenSpyLogs = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder()
                 .parse(in)
                 .getDocumentElement();
         List<MavenArtifact> generatedArtifacts = XmlUtils.listGeneratedArtifacts(mavenSpyLogs, true);
-        System.out.println(generatedArtifacts);
         assertThat(generatedArtifacts.size()).isEqualTo(2); // pom artifact plus 1 attachment
 
         for (MavenArtifact mavenArtifact : generatedArtifacts) {
             assertThat(mavenArtifact.getGroupId()).isEqualTo("com.example");
             assertThat(mavenArtifact.getArtifactId()).isEqualTo("my-jar");
+            assertThat(mavenArtifact.getBaseVersion()).isEqualTo("0.5-SNAPSHOT");
+            assertThat(mavenArtifact.getVersion()).isEqualTo("0.5-20180410.070244-14");
+            assertThat(mavenArtifact.isSnapshot()).isTrue();
             if ("pom".equals(mavenArtifact.getType())) {
                 assertThat(mavenArtifact.getExtension()).isEqualTo("pom");
                 assertThat(mavenArtifact.getClassifier()).isNullOrEmpty();

--- a/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-jar.xml
+++ b/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-deploy-jar.xml
@@ -961,11 +961,11 @@
             <build sourceDirectory="/path/to/my-jar/src/main/java" directory="/path/to/my-jar/target"/>
         </project>
         <no-execution-found/>
-        <artifact extension="jar" baseVersion="0.5-SNAPSHOT" groupId="com.example" artifactId="my-jar" id="com.example:my-jar:jar:0.5-SNAPSHOT" type="jar" version="0.5-20180304.184830-1" snapshot="true">
+        <artifact extension="jar" baseVersion="0.5-SNAPSHOT" groupId="com.example" artifactId="my-jar" id="com.example:my-jar:jar:0.5-SNAPSHOT" type="jar" version="0.5-20180304.184830-2" snapshot="true">
             <file>/path/to/my-jar/target/my-jar-0.5-SNAPSHOT.jar</file>
         </artifact>
         <attachedArtifacts>
-            <artifact extension="jar" baseVersion="0.5-SNAPSHOT" groupId="com.example" classifier="sources" artifactId="my-jar" id="com.example:my-jar:java-source:sources:0.5-SNAPSHOT" type="java-source" version="0.5-20180304.184830-1" snapshot="true">
+            <artifact extension="jar" baseVersion="0.5-SNAPSHOT" groupId="com.example" classifier="sources" artifactId="my-jar" id="com.example:my-jar:java-source:sources:0.5-SNAPSHOT" type="java-source" version="0.5-20180304.184830-2" snapshot="true">
                 <file>/path/to/my-jar/target/my-jar-0.5-SNAPSHOT-sources.jar</file>
             </artifact>
         </attachedArtifacts>

--- a/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-include-attached-artifacts.xml
+++ b/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-include-attached-artifacts.xml
@@ -185,11 +185,11 @@
       <build sourceDirectory="/Users/Shared/Jenkins/Home/workspace/my-jar/src/main/java" directory="/Users/Shared/Jenkins/Home/workspace/my-jar/target"/>
     </project>
     <no-execution-found/>
-    <artifact extension="pom" baseVersion="0.5-SNAPSHOT" groupId="com.example" artifactId="my-jar" id="com.example:my-jar:pom:0.5-SNAPSHOT" type="pom" version="0.5-20180410.070244-14" snapshot="true">
+    <artifact extension="pom" baseVersion="0.5-SNAPSHOT" groupId="com.example" artifactId="my-jar" id="com.example:my-jar:pom:0.5-SNAPSHOT" type="pom" version="0.5-20180410.070244-15" snapshot="true">
       <file/>
     </artifact>
     <attachedArtifacts>
-      <artifact extension="ova" baseVersion="0.5-SNAPSHOT" groupId="com.example" artifactId="my-jar" id="com.example:my-jar:ova:0.5-SNAPSHOT" type="ova" version="0.5-20180410.070244-14" snapshot="true">
+      <artifact extension="ova" baseVersion="0.5-SNAPSHOT" groupId="com.example" artifactId="my-jar" id="com.example:my-jar:ova:0.5-SNAPSHOT" type="ova" version="0.5-20180410.070244-15" snapshot="true">
         <file>/Users/Shared/Jenkins/Home/workspace/my-jar/my-jar-0.5-SNAPSHOT.ova</file>
       </artifact>
     </attachedArtifacts>


### PR DESCRIPTION
### Issue(s)
1. As mentioned by recent comments on [JENKINS-69410](https://issues.jenkins.io/browse/JENKINS-69410?focusedId=442796&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-442796) there are still broken URL links created for artifacts deployed. Those links are related to artifacts that are attached in addition to a modules primary artifacts.
e.g. -sources.jar artifacts attached by the Maven sources plugin do not get proper links in case the deploy plugin will create time stamped filenames deployed (which is the most common usage for deployed snapshot artifacts).
2. If the deploy repository URL configured is ending with a `/` character, then the deployed artifact URL link is containing a `//`. This issue is fixed by this PR as well.

### Root cause
s. details in the commit comment

### Testing done
This has been tested manually for a couple of more or less complex multi module Maven projects with a couple of our companies product specific file types attached.
Existing unit tests did not have been updated yet with this PR since of time constraints.
@bguerin If you could help by giving some hint what test files and unit tests to focus on for an update, maybe I can find some time to cover this.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

