### PR TITLE
Remove test dependency to junit plugin test artifact

### DIFF
--- a/pipeline-maven/pom.xml
+++ b/pipeline-maven/pom.xml
@@ -320,15 +320,7 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>junit</artifactId>
-      <version>1322.v1556dc1c59a_f</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <!-- move the related test to pipeline-maven-database and remove this dependency
-    -->
+    <!-- move the related test to pipeline-maven-database and remove this dependency -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-maven-database</artifactId>


### PR DESCRIPTION
Remove the `test` artifact dependency on the `junit-plugin` in order to resolve test failure reported by https://github.com/jenkinsci/bom/pull/5041

I copied the now inaccessible assertion methods in order to break the dependency as I found that to be the easiest solution.

This change needs to be released in order to fix the test failure in `bom`.

@basil @timja FYI

### Testing done

`mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
