### PR TITLE
bugfix: support MySQL up to 9.4 and PostgreSQL up to 17 [JENKINS-75858]

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -535,7 +535,7 @@ By default, the Jenkins Pipeline Maven Plugin uses an H2 embedded database, but 
 Configuration steps to use a MySQL:
 
 * Create an empty MySQL database with a dedicated MySQL user with permissions for Data Manipulation Language actions (DML) and Data Definition Language (DDL) actions
-** Tested with MySQL up to 8.1, with MariaDB up to 11.1 and with Amazon Aurora MySQL 5.6
+** Tested with MySQL up to 9.4, with MariaDB up to 11.1 and with Amazon Aurora MySQL 5.6
 * Install the Jenkins `MySQL Database` plugin
 ** Navigate to `Manage Jenkins / Manage Plugins / Available`, select the `MySQL Database` plugin and click on `Download now and install after restart`
 *  Configure the Pipeline Maven Plugin to use the created MySQL database
@@ -564,7 +564,7 @@ By default, the Jenkins Pipeline Maven Plugin uses an H2 embedded database, but 
 Configuration steps to use a PostgreSQL:
 
 * Create an empty PostgreSQL database with a dedicated PostgreSQL user with permissions for Data Manipulation Language actions (DML) and Data Definition Language (DDL) actions
-** Tested with PostgreSQL up to 16
+** Tested with PostgreSQL up to 17
 * Install the Jenkins the https://plugins.jenkins.io/postgresql-api/[PostgreSQL API] plugin
 ** Navigate to `Manage Jenkins / Manage Plugins / Available`, select the `PostgreSQL API` plugin and click on `Download now and install after restart`.
 *  Configure the Pipeline Maven Plugin to use the created PostgreSQL database

--- a/pipeline-maven-database/src/main/java/org/jenkinsci/plugins/pipeline/maven/db/AbstractPipelineMavenPluginDao.java
+++ b/pipeline-maven-database/src/main/java/org/jenkinsci/plugins/pipeline/maven/db/AbstractPipelineMavenPluginDao.java
@@ -296,7 +296,7 @@ public abstract class AbstractPipelineMavenPluginDao implements PipelineMavenPlu
                                 metaData.getDatabaseProductName() + " " + metaData.getDatabaseProductVersion();
                         LOGGER.log(Level.INFO, "Checking JDBC connection against " + databaseVersionDescription);
                         String databaseRequirement =
-                                "MySQL Server up to 8.1 or Amazon Aurora MySQL 5.6+ or MariaDB up to 11.1 or PostgreSQL up to 16 is required";
+                                "MySQL Server up to 8.1 or Amazon Aurora MySQL 5.6+ or MariaDB up to 11.1 or PostgreSQL up to 17 is required";
                         if ("MariaDB".equals(metaData.getDatabaseProductName())) {
                             @Nullable
                             String mariaDbVersion = PipelineMavenPluginMySqlDao.extractMariaDbVersion(
@@ -327,6 +327,9 @@ public abstract class AbstractPipelineMavenPluginDao implements PipelineMavenPlu
                                     metaData.getDatabaseProductVersion());
 
                             switch (metaData.getDatabaseMajorVersion()) {
+                                case 9:
+                                    // OK
+                                    break;
                                 case 8:
                                     // OK
                                     break;
@@ -380,6 +383,7 @@ public abstract class AbstractPipelineMavenPluginDao implements PipelineMavenPlu
                                 }
                             }
                             switch (metaData.getDatabaseMajorVersion()) {
+                                case 17:
                                 case 16:
                                 case 15:
                                 case 14:

--- a/pipeline-maven-database/src/test/java/org/jenkinsci/plugins/pipeline/maven/db/PipelineMavenPluginMySqlDaoIT.java
+++ b/pipeline-maven-database/src/test/java/org/jenkinsci/plugins/pipeline/maven/db/PipelineMavenPluginMySqlDaoIT.java
@@ -56,7 +56,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public class PipelineMavenPluginMySqlDaoIT extends PipelineMavenPluginDaoAbstractTest {
 
     @Container
-    public static MySQLContainer<?> DB = new MySQLContainer<>(MySQLContainer.NAME).withImagePullPolicy(alwaysPull());
+    public static LatestMySQLContainer DB = new LatestMySQLContainer().withImagePullPolicy(alwaysPull());
 
     @Override
     public DataSource before_newDataSource() {
@@ -110,6 +110,25 @@ public class PipelineMavenPluginMySqlDaoIT extends PipelineMavenPluginDaoAbstrac
             FormValidation result = dao.getBuilder().validateConfiguration(config);
 
             assertThat(result.toString()).isEqualTo("OK: MySQL " + version + " is a supported database");
+        }
+    }
+
+    // Need
+    // https://github.com/testcontainers/testcontainers-java/issues/10184
+    // https://github.com/testcontainers/testcontainers-java/pull/10185
+    // to be fixed
+    static class LatestMySQLContainer extends MySQLContainer<LatestMySQLContainer> {
+
+        public LatestMySQLContainer() {
+            super(MySQLContainer.NAME + ":9");
+        }
+
+        protected void configure() {
+            addEnv("MYSQL_DATABASE", getDatabaseName());
+            addEnv("MYSQL_USER", getUsername());
+            addEnv("MYSQL_PASSWORD", getPassword());
+            addEnv("MYSQL_ROOT_PASSWORD", getPassword());
+            setStartupAttempts(3);
         }
     }
 }

--- a/pipeline-maven-database/src/test/java/org/jenkinsci/plugins/pipeline/maven/db/PipelineMavenPluginPostgreSqlDaoIT.java
+++ b/pipeline-maven-database/src/test/java/org/jenkinsci/plugins/pipeline/maven/db/PipelineMavenPluginPostgreSqlDaoIT.java
@@ -57,7 +57,7 @@ public class PipelineMavenPluginPostgreSqlDaoIT extends PipelineMavenPluginDaoAb
 
     @Container
     public static PostgreSQLContainer<?> DB =
-            new PostgreSQLContainer<>(PostgreSQLContainer.IMAGE).withImagePullPolicy(alwaysPull());
+            new PostgreSQLContainer<>(PostgreSQLContainer.IMAGE + ":17").withImagePullPolicy(alwaysPull());
 
     @Override
     public DataSource before_newDataSource() throws Exception {


### PR DESCRIPTION
Add support to MySQL up to 9.4 and to PostgreSQL up to 17

See https://issues.jenkins.io/browse/JENKINS-75858

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
