### PR TITLE
bugfix: mark all extensions depending on optional plugins as optional

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/ConcordionTestsPublisher.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/ConcordionTestsPublisher.java
@@ -21,7 +21,6 @@ package org.jenkinsci.plugins.pipeline.maven.publishers;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import htmlpublisher.HtmlPublisher;
 import htmlpublisher.HtmlPublisherTarget;
-import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.StreamBuildListener;
@@ -41,6 +40,7 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.maven.MavenPublisher;
 import org.jenkinsci.plugins.pipeline.maven.Messages;
 import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.w3c.dom.Element;
@@ -168,7 +168,7 @@ public class ConcordionTestsPublisher extends MavenPublisher {
     }
 
     @Symbol("concordionPublisher")
-    @Extension
+    @OptionalExtension(requirePlugins = "htmlpublisher")
     public static class DescriptorImpl extends MavenPublisher.DescriptorImpl {
         @NonNull
         @Override

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/FindbugsAnalysisPublisher.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/FindbugsAnalysisPublisher.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.pipeline.maven.publishers;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
@@ -42,6 +41,7 @@ import org.jenkinsci.plugins.pipeline.maven.MavenArtifact;
 import org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor;
 import org.jenkinsci.plugins.pipeline.maven.Messages;
 import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.w3c.dom.Element;
@@ -249,7 +249,7 @@ public class FindbugsAnalysisPublisher extends AbstractHealthAwarePublisher {
      * Don't use symbol "findbugs", it would collide with hudson.plugins.findbugs.FindBugsPublisher
      */
     @Symbol("findbugsPublisher")
-    @Extension
+    @OptionalExtension(requirePlugins = "findbugs")
     public static class DescriptorImpl extends AbstractHealthAwarePublisher.DescriptorImpl {
         @NonNull
         @Override

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/InvokerRunsPublisher.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/InvokerRunsPublisher.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.pipeline.maven.publishers;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
@@ -46,6 +45,7 @@ import org.jenkinsci.plugins.pipeline.maven.MavenPublisher;
 import org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor;
 import org.jenkinsci.plugins.pipeline.maven.Messages;
 import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -299,7 +299,7 @@ public class InvokerRunsPublisher extends MavenPublisher {
      * Don't use the symbol "junit", it would collide with hudson.tasks.junit.JUnitResultArchiver
      */
     @Symbol("invokerPublisher")
-    @Extension
+    @OptionalExtension(requirePlugins = "maven-invoker-plugin")
     public static class DescriptorImpl extends MavenPublisher.DescriptorImpl {
         @NonNull
         @Override

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JGivenTestsPublisher.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JGivenTestsPublisher.java
@@ -21,7 +21,6 @@ package org.jenkinsci.plugins.pipeline.maven.publishers;
 import static org.jenkinsci.plugins.pipeline.maven.publishers.DependenciesLister.listDependencies;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
@@ -38,6 +37,7 @@ import org.jenkinsci.plugins.jgiven.JgivenReportGenerator;
 import org.jenkinsci.plugins.pipeline.maven.MavenDependency;
 import org.jenkinsci.plugins.pipeline.maven.MavenPublisher;
 import org.jenkinsci.plugins.pipeline.maven.Messages;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.w3c.dom.Element;
@@ -120,7 +120,7 @@ public class JGivenTestsPublisher extends MavenPublisher {
     }
 
     @Symbol("jgivenPublisher")
-    @Extension
+    @OptionalExtension(requirePlugins = "jgiven")
     public static class DescriptorImpl extends MavenPublisher.DescriptorImpl {
         @NonNull
         @Override

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JacocoReportPublisher.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JacocoReportPublisher.java
@@ -122,6 +122,7 @@ public class JacocoReportPublisher extends MavenPublisher {
 
     @Symbol("jacocoPublisher")
     @Extension
+    // @OptionalExtension(requirePlugins = "jacoco")
     public static class DescriptorImpl extends AbstractHealthAwarePublisher.DescriptorImpl {
         @NonNull
         @Override

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JunitTestsPublisher.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/JunitTestsPublisher.java
@@ -27,7 +27,6 @@ package org.jenkinsci.plugins.pipeline.maven.publishers;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
@@ -48,6 +47,7 @@ import org.jenkinsci.plugins.pipeline.maven.MavenPublisher;
 import org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor;
 import org.jenkinsci.plugins.pipeline.maven.Messages;
 import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -399,7 +399,7 @@ public class JunitTestsPublisher extends MavenPublisher {
      * Don't use the symbol "junit", it would collide with hudson.tasks.junit.JUnitResultArchiver
      */
     @Symbol("junitPublisher")
-    @Extension
+    @OptionalExtension(requirePlugins = "junit")
     public static class DescriptorImpl extends MavenPublisher.DescriptorImpl {
         @NonNull
         @Override

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/SpotBugsAnalysisPublisher.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/SpotBugsAnalysisPublisher.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.pipeline.maven.publishers;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
@@ -40,6 +39,7 @@ import org.jenkinsci.plugins.pipeline.maven.MavenArtifact;
 import org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor;
 import org.jenkinsci.plugins.pipeline.maven.Messages;
 import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.w3c.dom.Element;
@@ -247,7 +247,7 @@ public class SpotBugsAnalysisPublisher extends AbstractHealthAwarePublisher {
     }
 
     @Symbol("spotbugsPublisher")
-    @Extension
+    @OptionalExtension(requirePlugins = "findbugs")
     public static class DescriptorImpl extends AbstractHealthAwarePublisher.DescriptorImpl {
         @NonNull
         @Override

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/TasksScannerPublisher.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/TasksScannerPublisher.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.pipeline.maven.publishers;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
@@ -19,6 +18,7 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.maven.MavenArtifact;
 import org.jenkinsci.plugins.pipeline.maven.Messages;
 import org.jenkinsci.plugins.pipeline.maven.util.XmlUtils;
+import org.jenkinsci.plugins.variant.OptionalExtension;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -250,7 +250,7 @@ public class TasksScannerPublisher extends AbstractHealthAwarePublisher {
     }
 
     @Symbol("openTasksPublisher")
-    @Extension
+    @OptionalExtension(requirePlugins = "tasks")
     public static class DescriptorImpl extends AbstractHealthAwarePublisher.DescriptorImpl {
         @NonNull
         @Override

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepNoOptionalsTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepNoOptionalsTest.java
@@ -36,9 +36,8 @@ public class WithMavenStepNoOptionalsTest {
     @Rule
     public RealJenkinsRule jenkinsRule = new RealJenkinsRule()
             .omitPlugins(
-                    "mysql-api",
-                    "postgresql-api",
-                    "maven-plugin",
+                    "coverage",
+                    "findbugs",
                     "flaky-test-handler",
                     "htmlpublisher",
                     "jacoco",
@@ -47,8 +46,10 @@ public class WithMavenStepNoOptionalsTest {
                     "junit-attachments",
                     "matrix-project",
                     "maven-invoker-plugin",
+                    "maven-plugin",
+                    "mysql-api",
                     "pipeline-build-step",
-                    "findbugs",
+                    "postgresql-api",
                     "tasks");
 
     @Test


### PR DESCRIPTION
mark all extensions depending on optional plugins as optional

Follow up of https://github.com/jenkinsci/pipeline-maven-plugin/pull/931 and  [JENKINS-75966](https://issues.jenkins.io/browse/JENKINS-75966)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
