### PR TITLE
Test with Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,8 @@ buildPlugin(
   // cannot use this with Docker tests
   useContainerAgent: false,
   configurations: [
-    [ platform: "linux", jdk: "21" ],
-    [ platform: "windows", jdk: "17" ]
+    [ platform: "linux", jdk: "25" ],
+    [ platform: "windows", jdk: "21" ]
   ],
   timeout: 120
 )

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepITest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepITest.java
@@ -134,7 +134,8 @@ public class WithMavenStepITest extends AbstractIntegrationTest {
                 arguments("jdk8", "/opt/java/jdk8"),
                 arguments("jdk11", "/opt/java/jdk11"),
                 arguments("jdk17", "/opt/java/jdk17"),
-                arguments("jdk21", "/opt/java/jdk21"));
+                arguments("jdk21", "/opt/java/jdk21"),
+                arguments("jdk25", "/opt/java/jdk25"));
     }
 
     @ParameterizedTest

--- a/pipeline-maven/src/test/resources-filtered/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_hpi_project/pom.xml
+++ b/pipeline-maven/src/test/resources-filtered/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_hpi_project/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.16</version>
+    <version>5.28</version>
     <relativePath />
   </parent>
 
@@ -20,7 +20,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit4.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/Dockerfile
+++ b/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/docker/Dockerfile
@@ -43,10 +43,11 @@ RUN apt-get update && \
 
 FROM java-maven-git as javas
 
-COPY --from=eclipse-temurin:8u382-b05-jdk /opt/java/openjdk /opt/java/jdk8
-COPY --from=eclipse-temurin:11.0.20.1_1-jdk /opt/java/openjdk /opt/java/jdk11
-COPY --from=eclipse-temurin:17.0.8.1_1-jdk /opt/java/openjdk /opt/java/jdk17
-COPY --from=eclipse-temurin:21.0.6_7-jdk  /opt/java/openjdk /opt/java/jdk21
+COPY --from=eclipse-temurin:8u472-b08-jdk /opt/java/openjdk /opt/java/jdk8
+COPY --from=eclipse-temurin:11.0.29_7-jdk /opt/java/openjdk /opt/java/jdk11
+COPY --from=eclipse-temurin:17.0.17_10-jdk /opt/java/openjdk /opt/java/jdk17
+COPY --from=eclipse-temurin:21.0.9_10-jdk  /opt/java/openjdk /opt/java/jdk21
+COPY --from=eclipse-temurin:25.0.1_8-jdk  /opt/java/openjdk /opt/java/jdk25
 
 FROM java-maven-git as maven-home
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
     <maven-findbugs-plugin.version>3.0.5</maven-findbugs-plugin.version>
     <maven-flatten-plugin.version>1.7.0</maven-flatten-plugin.version>
-    <maven-invoker-plugin.version>3.6.0</maven-invoker-plugin.version>
+    <maven-invoker-plugin.version>3.9.1</maven-invoker-plugin.version>
     <maven-jacoco-plugin.version>0.8.13</maven-jacoco-plugin.version>
     <maven-nbm-plugin.version>4.7</maven-nbm-plugin.version>
     <maven-plugin-plugin.version>3.9.0</maven-plugin-plugin.version>


### PR DESCRIPTION
Java 25 released September 16, 2025. The Jenkins project wants to support Java 25 soon. Compile and test on ci.jenkins.io with Java 25 and Java 21.

Intentionally continues to generate Java 17 byte code as configured by the plugin parent pom.

### Testing done

* Confirmed that automated tests pass with Java 25

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
