### PR TITLE
Moves @DataBoundSetter to setters to avoid reflective access warnings

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverrideProperty.java
@@ -18,13 +18,11 @@ public class MavenConfigFolderOverrideProperty extends AbstractFolderProperty<Ab
     /**
      * Provides access to the settings.xml to be used for a build.
      */
-    @DataBoundSetter
     private SettingsProvider settings;
 
     /**
      * Provides access to the global settings.xml to be used for a build.
      */
-    @DataBoundSetter
     private GlobalSettingsProvider globalSettings;
 
     /**
@@ -51,7 +49,8 @@ public class MavenConfigFolderOverrideProperty extends AbstractFolderProperty<Ab
         return settings;
     }
 
-    protected void setSettings(SettingsProvider settings) {
+    @DataBoundSetter
+    public void setSettings(SettingsProvider settings) {
         this.settings = settings;
     }
 
@@ -59,7 +58,8 @@ public class MavenConfigFolderOverrideProperty extends AbstractFolderProperty<Ab
         return globalSettings;
     }
 
-    protected void setGlobalSettings(GlobalSettingsProvider globalSettings) {
+    @DataBoundSetter
+    public void setGlobalSettings(GlobalSettingsProvider globalSettings) {
         this.globalSettings = globalSettings;
     }
 

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverridePropertyTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/MavenConfigFolderOverridePropertyTest.java
@@ -1,0 +1,61 @@
+package org.jenkinsci.plugins.pipeline.maven;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import org.htmlunit.html.HtmlButton;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlSelect;
+import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
+import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig;
+import org.jenkinsci.plugins.configfiles.maven.job.MvnGlobalSettingsProvider;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+public class MavenConfigFolderOverridePropertyTest {
+
+    @WithJenkins
+    @Test
+    public void testConfigRoundTrip(JenkinsRule r) throws Exception {
+
+        GlobalMavenSettingsConfig mavenGlobalSettingsConfig1 =
+                new GlobalMavenSettingsConfig("maven-global-config-test-folder1", "name 1", "", "");
+        GlobalConfigFiles.get().save(mavenGlobalSettingsConfig1);
+        GlobalMavenSettingsConfig mavenGlobalSettingsConfig2 =
+                new GlobalMavenSettingsConfig("maven-global-config-test-folder2", "name 2", "", "");
+        GlobalConfigFiles.get().save(mavenGlobalSettingsConfig2);
+
+        final Folder folder1 = r.createProject(Folder.class, "folder1");
+        MavenConfigFolderOverrideProperty configOverrideProperty = new MavenConfigFolderOverrideProperty();
+        configOverrideProperty.setOverride(true);
+        configOverrideProperty.setGlobalSettings(new MvnGlobalSettingsProvider(mavenGlobalSettingsConfig1.id));
+        folder1.addProperty(configOverrideProperty);
+
+        JenkinsRule.WebClient webClient = r.createWebClient();
+        HtmlPage page = webClient.getPage(folder1, "configure");
+        HtmlForm form = page.getFormByName("config");
+
+        HtmlSelect select = form.getSelectByName("_.settingsConfigId");
+        assertThat(select.getOptions().size(), equalTo(3));
+        assertThat(select.getOption(0).getText(), equalTo("please select"));
+        assertThat(select.getOption(1).getText(), equalTo("name 1"));
+        assertThat(select.getOption(2).getText(), equalTo("name 2"));
+        assertThat(select.getSelectedOptions().get(0).getText(), equalTo("name 1"));
+
+        select.setSelectedIndex(2);
+        final HtmlButton button = form.getButtonByName("Submit");
+        form.submit(button);
+
+        page = webClient.getPage(folder1, "configure");
+        form = page.getFormByName("config");
+        select = form.getSelectByName("_.settingsConfigId");
+        assertThat(select.getOptions().size(), equalTo(3));
+        assertThat(select.getOption(0).getText(), equalTo("please select"));
+        assertThat(select.getOption(1).getText(), equalTo("name 1"));
+        assertThat(select.getOption(2).getText(), equalTo("name 2"));
+        assertThat(select.getSelectedOptions().get(0).getText(), equalTo("name 2"));
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

To fix Jenkins warnings in system log:
> java.lang.IllegalAccessException: Processing this request relies on deprecated behavior that will be disallowed in future releases of Java. See https://jenkins.io/redirect/stapler-reflective-access/ for more information. Details: class org.kohsuke.stapler.RequestImpl cannot access a member of class org.jenkinsci.plugins.pipeline.maven.MavenConfigFolderOverrideProperty with modifiers "private"


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] ~~Link to relevant issues in GitHub or Jira~~
- [ ] ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
