### PR TITLE
Ban JUnit 4 imports

### DIFF
--- a/pipeline-maven-ui-tests/pom.xml
+++ b/pipeline-maven-ui-tests/pom.xml
@@ -37,6 +37,7 @@
 
   <properties>
     <argLine>-Djava.awt.headless=true -Xmx1024m -Djenkins.test.timeout=1000 --add-opens java.base/sun.reflect.annotation=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED</argLine>
+    <ban-junit4-imports.skip>true</ban-junit4-imports.skip>
     <browser>firefox-container</browser>
     <commons-codec.version>1.21.0</commons-codec.version>
     <commons-io.version>2.21.0</commons-io.version>

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import junit.framework.AssertionFailedError;
 import org.jenkinsci.plugins.pipeline.maven.MavenArtifact;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -414,7 +413,7 @@ public class XmlUtilsTest {
                 assertThat(mavenArtifact.getExtension()).isEqualTo("jar");
                 assertThat(mavenArtifact.getClassifier()).isNullOrEmpty();
             } else {
-                throw new AssertionFailedError("Unsupported type for " + mavenArtifact);
+                fail("Unsupported type for " + mavenArtifact);
             }
         }
     }
@@ -516,7 +515,7 @@ public class XmlUtilsTest {
                 assertThat(mavenArtifact.getExtension()).isEqualTo("jar");
                 assertThat(mavenArtifact.getClassifier()).isEqualTo("sources");
             } else {
-                throw new AssertionFailedError("Unsupported type for " + mavenArtifact);
+                fail("Unsupported type for " + mavenArtifact);
             }
         }
     }
@@ -547,7 +546,7 @@ public class XmlUtilsTest {
                 assertThat(mavenArtifact.getExtension()).isEqualTo("ova");
                 assertThat(mavenArtifact.getClassifier()).isNullOrEmpty();
             } else {
-                throw new AssertionFailedError("Unsupported type for " + mavenArtifact);
+                fail("Unsupported type for " + mavenArtifact);
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
 
   <properties>
     <assertj.version>3.27.7</assertj.version>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <changelist>999999-SNAPSHOT</changelist>
     <error-prone.version>2.46.0</error-prone.version>
     <gson.version>2.10.1</gson.version>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Ban JUnit 4 imports
To prevent regressions when adding new tests, [jenkinsci/plugin-pom#1178](https://github.com/jenkinsci/plugin-pom/pull/1178) introduced a new flag that enables a Maven Enforcer rule banning `org.junit.*` imports while allowing `org.junit.jupiter.*`.

With this change, the build will fail if any `org.junit.*` imports are introduced.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Testing done
None. Rely on `ci.jenkins.io`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
