### PR TITLE
Explicitly declare dependencies

### DIFF
--- a/pipeline-maven-api/pom.xml
+++ b/pipeline-maven-api/pom.xml
@@ -10,6 +10,11 @@
   <packaging>hpi</packaging>
   <name>Pipeline Maven Plugin API</name>
 
+  <properties>
+    <hpi.bundledArtifacts />
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/pipeline-maven-database/pom.xml
+++ b/pipeline-maven-database/pom.xml
@@ -10,6 +10,11 @@
   <packaging>hpi</packaging>
   <name>Pipeline Maven Plugin Database</name>
 
+  <properties>
+    <hpi.bundledArtifacts>HikariCP</hpi.bundledArtifacts>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/pipeline-maven-spy/pom.xml
+++ b/pipeline-maven-spy/pom.xml
@@ -37,6 +37,11 @@
   <description>Maven Spy injected with "-Dmaven.ext.class.path" to generatesMaven execution reports that are consumed by the
         Jenkins Pipeline withMaven(){} step.</description>
 
+  <properties>
+    <hpi.bundledArtifacts />
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/pipeline-maven-ui-tests/pom.xml
+++ b/pipeline-maven-ui-tests/pom.xml
@@ -42,6 +42,8 @@
     <commons-io.version>2.21.0</commons-io.version>
     <crypto-util.version>1.11</crypto-util.version>
     <guava.version>33.5.0-jre</guava.version>
+    <hpi.bundledArtifacts />
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <maven.version>3.9.12</maven.version>
     <remoting.version>3355.v388858a_47b_33</remoting.version>
     <servlet-api.version>6.1.0</servlet-api.version>

--- a/pipeline-maven/pom.xml
+++ b/pipeline-maven/pom.xml
@@ -40,8 +40,10 @@
   <url>https://github.com/jenkinsci/pipeline-maven-plugin/</url>
 
   <properties>
+    <hpi.bundledArtifacts />
     <hpi.compatibleSinceVersion>1333</hpi.compatibleSinceVersion>
     <hpi.pluginChangelogUrl>https://github.com/jenkinsci/pipeline-maven-plugin/releases</hpi.pluginChangelogUrl>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Explicitly declare dependencies

Reduce the risk that new dependencies will be injected accidentally from a dependency update.

The [developer documentation](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#build-time-validation-of-bundled-artifacts) provides more details.

Originally added to Maven hpi plugin in pull request:

* jenkinsci/maven-hpi-plugin#771

### Testing done

* Confirmed that automated tests pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
