### PR TITLE
Fix: List poms in summary of Deployed Artifacts

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtils.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtils.java
@@ -519,6 +519,8 @@ public class XmlUtils {
             } else {
                 pomArtifact.setVersion(XmlUtils.getUniqueChildElement(artifactDeployedEvent, "artifact")
                         .getAttribute("version"));
+                pomArtifact.setRepositoryUrl(XmlUtils.getUniqueChildElement(artifactDeployedEvent, "repository")
+                        .getAttribute("url"));
             }
 
             result.add(pomArtifact);

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
@@ -406,6 +406,7 @@ public class XmlUtilsTest {
         for (MavenArtifact mavenArtifact : generatedArtifacts) {
             assertThat(mavenArtifact.getGroupId()).isEqualTo("com.example");
             assertThat(mavenArtifact.getArtifactId()).isEqualTo("my-jar");
+            assertThat(mavenArtifact.isDeployed()).isTrue();
             if ("pom".equals(mavenArtifact.getType())) {
                 assertThat(mavenArtifact.getExtension()).isEqualTo("pom");
                 assertThat(mavenArtifact.getClassifier()).isNullOrEmpty();
@@ -505,6 +506,7 @@ public class XmlUtilsTest {
             assertThat(mavenArtifact.getBaseVersion()).isEqualTo("0.5-SNAPSHOT");
             assertThat(mavenArtifact.getVersion()).isEqualTo("0.5-20180304.184830-1");
             assertThat(mavenArtifact.isSnapshot()).isTrue();
+            assertThat(mavenArtifact.isDeployed()).isTrue();
             if ("pom".equals(mavenArtifact.getType())) {
                 assertThat(mavenArtifact.getExtension()).isEqualTo("pom");
                 assertThat(mavenArtifact.getClassifier()).isNullOrEmpty();
@@ -539,6 +541,7 @@ public class XmlUtilsTest {
             assertThat(mavenArtifact.getBaseVersion()).isEqualTo("0.5-SNAPSHOT");
             assertThat(mavenArtifact.getVersion()).isEqualTo("0.5-20180410.070244-14");
             assertThat(mavenArtifact.isSnapshot()).isTrue();
+            assertThat(mavenArtifact.isDeployed()).isTrue();
             if ("pom".equals(mavenArtifact.getType())) {
                 assertThat(mavenArtifact.getExtension()).isEqualTo("pom");
                 assertThat(mavenArtifact.getClassifier()).isNullOrEmpty();

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
@@ -401,6 +401,7 @@ public class XmlUtilsTest {
                 .parse(in)
                 .getDocumentElement();
         List<MavenArtifact> generatedArtifacts = XmlUtils.listGeneratedArtifacts(mavenSpyLogs, false);
+
         assertThat(generatedArtifacts.size()).isEqualTo(2); // a jar file and a pom file are generated
 
         for (MavenArtifact mavenArtifact : generatedArtifacts) {
@@ -442,6 +443,7 @@ public class XmlUtilsTest {
         assertThat(generatedArtifacts.get(0).getType()).isEqualTo("pom");
         assertThat(generatedArtifacts.get(0).getVersion()).isEqualTo("1.0.2-20220904.210621-1");
         assertThat(generatedArtifacts.get(0).isSnapshot()).isTrue();
+        assertThat(generatedArtifacts.get(0).isDeployed()).isTrue();
 
         assertThat(generatedArtifacts.get(1).getGroupId()).isEqualTo("com.acme.maven.plugins");
         assertThat(generatedArtifacts.get(1).getArtifactId()).isEqualTo("postgresql-compare-maven-plugin");
@@ -451,6 +453,7 @@ public class XmlUtilsTest {
         assertThat(generatedArtifacts.get(1).getType()).isEqualTo("maven-plugin");
         assertThat(generatedArtifacts.get(1).getVersion()).isEqualTo("1.0.2-20220904.210621-1");
         assertThat(generatedArtifacts.get(1).isSnapshot()).isTrue();
+        assertThat(generatedArtifacts.get(1).isDeployed()).isTrue();
     }
 
     @Test
@@ -476,6 +479,7 @@ public class XmlUtilsTest {
         assertThat(generatedArtifacts.get(0).getType()).isEqualTo("pom");
         assertThat(generatedArtifacts.get(0).getVersion()).isEqualTo("1.0.2-20220904.210621-1");
         assertThat(generatedArtifacts.get(0).isSnapshot()).isTrue();
+        assertThat(generatedArtifacts.get(0).isDeployed()).isTrue();
 
         assertThat(generatedArtifacts.get(1).getGroupId()).isEqualTo("com.acme.maven.plugins");
         assertThat(generatedArtifacts.get(1).getArtifactId()).isEqualTo("postgresql-compare-maven-plugin");
@@ -485,6 +489,7 @@ public class XmlUtilsTest {
         assertThat(generatedArtifacts.get(1).getType()).isEqualTo("maven-plugin");
         assertThat(generatedArtifacts.get(1).getVersion()).isEqualTo("1.0.2-20220904.210621-1");
         assertThat(generatedArtifacts.get(1).isSnapshot()).isTrue();
+        assertThat(generatedArtifacts.get(1).isDeployed()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
### Issue
POM artifacts having been deployed are not listed in the summary of deployed files.
Fixes issue #1300

### Root cause
Repository url is not set in `XmlUtils.java` for the POM artifact in case it has been successfully deployed.

### Changes made
- XmlUtils.java:
  - set repository url for pom artifact

- XmlUtilsTest.java:
  - test_listGeneratedArtifacts(), test_listGeneratedArtifacts_including_generated_artifacts(), test_listGeneratedArtifacts_includeAttachedArtifacts():
    - add validation of artifact deployed state

<!-- Please describe your pull request here. -->

### Testing done
Unit test extended to cover `artifact.isDeployed()`:
- `XmlUtilsTest.java`
  - `test_listGeneratedArtifacts()`, `test_listGeneratedArtifacts_including_generated_artifacts()`, `test_listGeneratedArtifacts_includeAttachedArtifacts()`:
    - add validation of artifact deployed state

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
