### PR TITLE
Attach maven-deploy-plugin:deploy-file artifacts to project artifacts for downstream reporting

### DIFF
--- a/pipeline-maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/DeployDeployFileExecutionHandler.java
+++ b/pipeline-maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/DeployDeployFileExecutionHandler.java
@@ -3,31 +3,100 @@ package org.jenkinsci.plugins.pipeline.maven.eventspy.handler;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.ExecutionEvent.Type;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.DefaultMavenProjectHelper;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.aether.RepositoryEvent;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter;
 
 /**
- * Handler to alter the
- * <code>org.apache.maven.plugins:maven-deploy-plugin:deploy-file</code> goal : it will
- * set the <code>lifecyclePhase</code> to <code>deploy</code> when no lifecycle is set.
+ * Handler for the {@code org.apache.maven.plugins:maven-deploy-plugin:deploy-file} goal.
  *
- * This can happen when the plugin is invoked directly
+ * Does two things:
  *
- * @author <a href="mailto:r.schleuse@gmail.com">René Schleusner</a>
+ * 1. Sets {@code lifecyclePhase} to {@code deploy} when none is set (direct
+ *    invocation, e.g. {@code mvn deploy:deploy-file -Dfile=...}).
+ * 2. Correlates {@code ARTIFACT_DEPLOYED} repository events that fire between
+ *    {@code MojoStarted} and {@code MojoSucceeded} for each distinct execution and attaches
+ *    those artifacts to the Maven project. This makes them visible in the
+ *    {@code ProjectSucceeded} report so that downstream Jenkins processing
+ *    ({@code XmlUtils.listGeneratedArtifacts}) can pick them up via the normal
+ *    file-path correlation with the top-level {@code RepositoryEvent} elements.
  *
+ * @author René Schleusner
  */
 public class DeployDeployFileExecutionHandler extends AbstractExecutionHandler {
+
+    /**
+     * Repository events buffered per executionId while a {@code deploy-file} mojo is in flight.
+     * Keyed by {@link MojoExecution#getExecutionId()}.
+     */
+    private final Map<String, List<RepositoryEvent>> repositoryEventsByExecutionId = new LinkedHashMap<>();
+
     public DeployDeployFileExecutionHandler(@NonNull MavenEventReporter reporter) {
         super(reporter);
     }
 
+    /**
+     * Intercepts three event kinds in addition to the normal {@code MojoSucceeded} delegation:
+     *
+     * - {@code MojoStarted} for deploy-file: opens a per-executionId buffer.
+     * - {@code RepositoryEvent.ARTIFACT_DEPLOYED} while any buffer is open: appends to every
+     *   open buffer but returns {@code false} so {@link ArtifactDeployedEventHandler} still
+     *   emits the top-level {@code <RepositoryEvent>} element that
+     *   {@code XmlUtils.getArtifactDeployedEvents()} expects.
+     * - {@code MojoFailed} for deploy-file: discards the buffer to avoid leaks.
+     */
+    @Override
+    public boolean handle(@NonNull Object event) {
+        if (event instanceof ExecutionEvent) {
+            ExecutionEvent executionEvent = (ExecutionEvent) event;
+            MojoExecution mojoExecution = executionEvent.getMojoExecution();
+            if (isDeployFile(mojoExecution)) {
+                if (ExecutionEvent.Type.MojoStarted.equals(executionEvent.getType())) {
+                    repositoryEventsByExecutionId.put(mojoExecution.getExecutionId(), new ArrayList<>());
+                    return false;
+                } else if (ExecutionEvent.Type.MojoFailed.equals(executionEvent.getType())) {
+                    repositoryEventsByExecutionId.remove(mojoExecution.getExecutionId());
+                    return false;
+                }
+            }
+        }
+
+        if (event instanceof RepositoryEvent && !repositoryEventsByExecutionId.isEmpty()) {
+            RepositoryEvent repositoryEvent = (RepositoryEvent) event;
+            if (RepositoryEvent.EventType.ARTIFACT_DEPLOYED.equals(repositoryEvent.getType())) {
+                for (List<RepositoryEvent> buffer : repositoryEventsByExecutionId.values()) {
+                    buffer.add(repositoryEvent);
+                }
+                // Return false: ArtifactDeployedEventHandler must still emit the top-level
+                // <RepositoryEvent> element so XmlUtils.getArtifactDeployedEvents() finds it.
+                return false;
+            }
+        }
+
+        return super.handle(event);
+    }
+
+    private boolean isDeployFile(@Nullable MojoExecution mojoExecution) {
+        return mojoExecution != null
+                && "org.apache.maven.plugins".equals(mojoExecution.getGroupId())
+                && "maven-deploy-plugin".equals(mojoExecution.getArtifactId())
+                && "deploy-file".equals(mojoExecution.getGoal());
+    }
+
     @Override
     protected List<String> getConfigurationParametersToReport(ExecutionEvent executionEvent) {
-        return new ArrayList<String>();
+        return new ArrayList<>();
     }
 
     @Override
@@ -50,6 +119,42 @@ public class DeployDeployFileExecutionHandler extends AbstractExecutionHandler {
                 plugin.setAttribute("lifecyclePhase", "deploy");
             }
         }
+
+        List<RepositoryEvent> repositoryEvents = repositoryEventsByExecutionId.remove(execution.getExecutionId());
+        if (repositoryEvents == null || repositoryEvents.isEmpty()) {
+            return;
+        }
+
+        MavenProject project = executionEvent.getProject();
+        DefaultMavenProjectHelper projectHelper = new DefaultMavenProjectHelper();
+
+        for (RepositoryEvent repositoryEvent : repositoryEvents) {
+            Artifact artifact = convertAetherToMavenArtifact(repositoryEvent.getArtifact());
+            if (artifact == null || artifact.getFile() == null) {
+                continue;
+            }
+            projectHelper.attachArtifact(project, artifact);
+        }
+    }
+
+    private @Nullable Artifact convertAetherToMavenArtifact(
+            @Nullable org.eclipse.aether.artifact.Artifact aetherArtifact) {
+        if (aetherArtifact == null || aetherArtifact.getFile() == null) {
+            return null;
+        }
+
+        String classifier = aetherArtifact.getClassifier();
+        DefaultArtifactHandler artifactHandler = new DefaultArtifactHandler(aetherArtifact.getExtension());
+        DefaultArtifact mavenArtifact = new DefaultArtifact(
+                aetherArtifact.getGroupId(),
+                aetherArtifact.getArtifactId(),
+                aetherArtifact.getVersion(),
+                null,
+                aetherArtifact.getExtension(),
+                classifier != null && !classifier.isEmpty() ? classifier : null,
+                artifactHandler);
+        mavenArtifact.setFile(aetherArtifact.getFile());
+        return mavenArtifact;
     }
 
     @Override

--- a/pipeline-maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/DeployDeployFileExecutionHandler.java
+++ b/pipeline-maven-spy/src/main/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/DeployDeployFileExecutionHandler.java
@@ -36,6 +36,10 @@ import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.MavenEventReporter
  */
 public class DeployDeployFileExecutionHandler extends AbstractExecutionHandler {
 
+    private static final String PLUGIN_GROUP_ID = "org.apache.maven.plugins";
+    private static final String PLUGIN_ARTIFACT_ID = "maven-deploy-plugin";
+    private static final String PLUGIN_GOAL = "deploy-file";
+
     /**
      * Repository events buffered per executionId while a {@code deploy-file} mojo is in flight.
      * Keyed by {@link MojoExecution#getExecutionId()}.
@@ -89,9 +93,9 @@ public class DeployDeployFileExecutionHandler extends AbstractExecutionHandler {
 
     private boolean isDeployFile(@Nullable MojoExecution mojoExecution) {
         return mojoExecution != null
-                && "org.apache.maven.plugins".equals(mojoExecution.getGroupId())
-                && "maven-deploy-plugin".equals(mojoExecution.getArtifactId())
-                && "deploy-file".equals(mojoExecution.getGoal());
+                && PLUGIN_GROUP_ID.equals(mojoExecution.getGroupId())
+                && PLUGIN_ARTIFACT_ID.equals(mojoExecution.getArtifactId())
+                && PLUGIN_GOAL.equals(mojoExecution.getGoal());
     }
 
     @Override
@@ -165,6 +169,6 @@ public class DeployDeployFileExecutionHandler extends AbstractExecutionHandler {
     @Nullable
     @Override
     protected String getSupportedPluginGoal() {
-        return "org.apache.maven.plugins:maven-deploy-plugin:deploy-file";
+        return String.join(":", PLUGIN_GROUP_ID, PLUGIN_ARTIFACT_ID, PLUGIN_GOAL);
     }
 }

--- a/pipeline-maven-spy/src/test/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/DeployDeployFileExecutionHandlerTest.java
+++ b/pipeline-maven-spy/src/test/java/org/jenkinsci/plugins/pipeline/maven/eventspy/handler/DeployDeployFileExecutionHandlerTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
+import java.util.List;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Model;
@@ -14,7 +17,10 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositoryEvent;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.jenkinsci.plugins.pipeline.maven.eventspy.reporter.OutputStreamEventReporter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +53,7 @@ public class DeployDeployFileExecutionHandlerTest {
     public void testWithExistingLifecyclePhase() throws Exception {
         MojoExecution execution = new MojoExecution(this.createTestingMojoDescriptor());
         execution.setLifecyclePhase("install");
-        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution);
+        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution, ExecutionEvent.Type.MojoSucceeded);
 
         this.handler._handle(event);
 
@@ -61,7 +67,7 @@ public class DeployDeployFileExecutionHandlerTest {
     @Test
     public void testWithoutExistingLifecyclePhase() throws Exception {
         MojoExecution execution = new MojoExecution(this.createTestingMojoDescriptor());
-        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution);
+        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution, ExecutionEvent.Type.MojoSucceeded);
 
         this.handler._handle(event);
 
@@ -76,7 +82,7 @@ public class DeployDeployFileExecutionHandlerTest {
     public void testWithEmptyLifecyclePhase() throws Exception {
         MojoExecution execution = new MojoExecution(this.createTestingMojoDescriptor());
         execution.setLifecyclePhase("");
-        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution);
+        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution, ExecutionEvent.Type.MojoSucceeded);
 
         this.handler._handle(event);
 
@@ -91,7 +97,7 @@ public class DeployDeployFileExecutionHandlerTest {
     public void testWithNullLifecyclePhase() throws Exception {
         MojoExecution execution = new MojoExecution(this.createTestingMojoDescriptor());
         execution.setLifecyclePhase(null);
-        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution);
+        ExecutionEvent event = this.createTestDeployFileExecutionEvent(execution, ExecutionEvent.Type.MojoSucceeded);
 
         this.handler._handle(event);
 
@@ -102,18 +108,67 @@ public class DeployDeployFileExecutionHandlerTest {
         assertThat(plugin.getAttribute("lifecyclePhase")).isEqualTo("deploy");
     }
 
-    /**
-     * Creates a ExecutionEvent which describes a successfull invocation of passed
-     * MojoExecution on a dummy-project
-     *
-     * @param mojoExecution
-     * @return
-     */
-    private ExecutionEvent createTestDeployFileExecutionEvent(MojoExecution mojoExecution) {
+    @Test
+    public void testRepositoryEventsBufferedBetweenStartAndSucceeded() throws Exception {
+        MojoExecution execution = new MojoExecution(this.createTestingMojoDescriptor());
+
+        // MojoStarted opens the buffer; should not be consumed
+        ExecutionEvent startedEvent =
+                this.createTestDeployFileExecutionEvent(execution, ExecutionEvent.Type.MojoStarted);
+        boolean startedHandled = this.handler.handle(startedEvent);
+        assertThat(startedHandled).isFalse();
+
+        // ARTIFACT_DEPLOYED event during the execution window: buffered, not consumed
+        File deployedFile = new File("/tmp/mylib-1.0.jar");
+        RepositoryEvent repositoryEvent =
+                createArtifactDeployedEvent("com.example", "mylib", "1.0", "jar", "", deployedFile);
+        boolean repoEventHandled = this.handler.handle(repositoryEvent);
+        assertThat(repoEventHandled).isFalse();
+
+        // MojoSucceeded drains the buffer and attaches the artifact
+        ExecutionEvent succeededEvent =
+                this.createTestDeployFileExecutionEvent(execution, ExecutionEvent.Type.MojoSucceeded);
+        this.handler.handle(succeededEvent);
+
+        List<Artifact> attachedArtifacts = project.getAttachedArtifacts();
+        assertThat(attachedArtifacts).hasSize(1);
+        Artifact attached = attachedArtifacts.get(0);
+        assertThat(attached.getGroupId()).isEqualTo("com.example");
+        assertThat(attached.getArtifactId()).isEqualTo("mylib");
+        assertThat(attached.getVersion()).isEqualTo("1.0");
+        assertThat(attached.getFile()).isEqualTo(deployedFile);
+    }
+
+    @Test
+    public void testRepositoryEventsNotBufferedAfterMojoFailed() throws Exception {
+        MojoExecution execution = new MojoExecution(this.createTestingMojoDescriptor());
+
+        this.handler.handle(this.createTestDeployFileExecutionEvent(execution, ExecutionEvent.Type.MojoStarted));
+        this.handler.handle(this.createTestDeployFileExecutionEvent(execution, ExecutionEvent.Type.MojoFailed));
+
+        // After failure the buffer is gone; a subsequent RepositoryEvent must not be buffered
+        RepositoryEvent repositoryEvent =
+                createArtifactDeployedEvent("com.example", "mylib", "1.0", "jar", "", new File("/tmp/mylib-1.0.jar"));
+        boolean repoEventHandled = this.handler.handle(repositoryEvent);
+        assertThat(repoEventHandled).isFalse();
+        assertThat(project.getAttachedArtifacts()).isEmpty();
+    }
+
+    @Test
+    public void testRepositoryEventBeforeStartNotBuffered() throws Exception {
+        // No MojoStarted yet → RepositoryEvent must pass through unaffected
+        RepositoryEvent repositoryEvent =
+                createArtifactDeployedEvent("com.example", "mylib", "1.0", "jar", "", new File("/tmp/mylib-1.0.jar"));
+        boolean handled = this.handler.handle(repositoryEvent);
+        assertThat(handled).isFalse();
+        assertThat(project.getAttachedArtifacts()).isEmpty();
+    }
+
+    private ExecutionEvent createTestDeployFileExecutionEvent(MojoExecution mojoExecution, ExecutionEvent.Type type) {
         return new ExecutionEvent() {
             @Override
             public Type getType() {
-                return Type.MojoSucceeded;
+                return type;
             }
 
             @Override
@@ -139,7 +194,7 @@ public class DeployDeployFileExecutionHandlerTest {
     }
 
     /**
-     * Create a dummy Maven-Projet
+     * Create a dummy Maven-Project
      *
      * @return
      * @throws IOException
@@ -176,6 +231,19 @@ public class DeployDeployFileExecutionHandlerTest {
         desc.setGoal("deploy-file");
 
         return desc;
+    }
+
+    private RepositoryEvent createArtifactDeployedEvent(
+            String groupId, String artifactId, String version, String extension, String classifier, File file) {
+        org.eclipse.aether.artifact.Artifact artifact =
+                new DefaultArtifact(groupId, artifactId, classifier, extension, version).setFile(file);
+        RemoteRepository repository =
+                new RemoteRepository.Builder("central", "default", "https://repo.example.com/releases").build();
+        return new RepositoryEvent.Builder(
+                        new DefaultRepositorySystemSession(), RepositoryEvent.EventType.ARTIFACT_DEPLOYED)
+                .setArtifact(artifact)
+                .setRepository(repository)
+                .build();
     }
 
     /**


### PR DESCRIPTION
When `maven-deploy-plugin:deploy-file` is invoked directly (outside a lifecycle), the deployed artifacts were not visible to downstream Jenkins processing because they never appeared as attached artifacts on the MavenProject.

`DeployDeployFileExecutionHandler` now buffers `ARTIFACT_DEPLOYED` repository events that fire between `MojoStarted` and `MojoSucceeded` for each execution, then converts and attaches them to the `MavenProject` on success. On failure the buffer is discarded to avoid leaks.

See:

- https://github.com/jenkinsci/pipeline-maven-plugin/issues/1451
- https://github.com/jenkinsci/pipeline-maven-plugin/issues/1277

### Testing done

- I've tested it manually on our production jenkins
- I've written some unit tests to tests whether the artifacts get's attached properly


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
