### PR TITLE
fix: skip standalone-pom when listing generated artifacts

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtils.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtils.java
@@ -523,7 +523,14 @@ public class XmlUtils {
                         .getAttribute("url"));
             }
 
-            result.add(pomArtifact);
+            // Dont count Maven Stub Project POM as a generated artifacts
+            // These get created when maven gets executed without a project pom.xml
+            final boolean isMavenStubPomArtifact = ("org.apache.maven".equals(pomArtifact.getGroupId())
+                    && "standalone-pom".equals(pomArtifact.getArtifactId()));
+
+            if (!isMavenStubPomArtifact) {
+                result.add(pomArtifact);
+            }
 
             Element artifactElt = XmlUtils.getUniqueChildElement(projectSucceededElt, "artifact");
             MavenArtifact mavenArtifact = XmlUtils.newMavenArtifact(artifactElt);

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/util/XmlUtilsTest.java
@@ -391,6 +391,20 @@ public class XmlUtilsTest {
     }
 
     @Test
+    public void test_listGeneratedArtifacts_skips_standalone_pom() throws Exception {
+        InputStream in = Thread.currentThread()
+                .getContextClassLoader()
+                .getResourceAsStream("org/jenkinsci/plugins/pipeline/maven/maven-spy-standalone-pom.xml");
+        assertThat(in).isNotNull();
+        Element mavenSpyLogs = DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder()
+                .parse(in)
+                .getDocumentElement();
+        List<MavenArtifact> generatedArtifacts = XmlUtils.listGeneratedArtifacts(mavenSpyLogs, false);
+        assertThat(generatedArtifacts).isEmpty();
+    }
+
+    @Test
     public void test_listGeneratedArtifacts() throws Exception {
         InputStream in = Thread.currentThread()
                 .getContextClassLoader()

--- a/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-standalone-pom.xml
+++ b/pipeline-maven/src/test/resources/org/jenkinsci/plugins/pipeline/maven/maven-spy-standalone-pom.xml
@@ -1,0 +1,27 @@
+<mavenExecution _time="2026-05-27 23:32:32.56">
+    <context _time="2026-05-27 23:32:32.566">
+        <systemProperties/>
+        <userProperties/>
+        <plexus/>
+    </context>
+
+    <ExecutionEvent type="ProjectSucceeded" class="org.apache.maven.lifecycle.internal.DefaultExecutionEvent" _time="2026-05-27 23:32:33.902">
+        <project groupId="org.apache.maven" name="Maven Stub Project (No POM)" artifactId="standalone-pom" packaging="pom" version="1">
+            <build sourceDirectory="${project.basedir}/src/main/java" directory="${project.basedir}/target"/>
+        </project>
+        <no-execution-found/>
+        <artifact extension="pom" baseVersion="1" groupId="org.apache.maven" artifactId="standalone-pom" id="org.apache.maven:standalone-pom:pom:1" type="pom" version="1" snapshot="false">
+            <file/>
+        </artifact>
+        <attachedArtifacts/>
+    </ExecutionEvent>
+    <MavenExecutionResult class="org.apache.maven.execution.DefaultMavenExecutionResult" _time="2026-05-27 23:32:33.903">
+        <buildSummary groupId="org.apache.maven" name="Maven Stub Project (No POM)" artifactId="standalone-pom" packaging="pom" time="1089" version="1" class="org.apache.maven.execution.BuildSuccess">
+            <build sourceDirectory="${project.basedir}/src/main/java" directory="${project.basedir}/target"/>
+        </buildSummary>
+    </MavenExecutionResult>
+    <!-- 2026-05-27 23:32:33.903 - close:                                       -->
+    <!-- ignored:[org.apache.maven.settings.building.DefaultSettingsBuildingResult], -->
+    <!-- blackListed: []                                                        -->
+
+</mavenExecution>


### PR DESCRIPTION
### Summary

When Maven is executed without a project `pom.xml` (e.g. `mvn maven-deploy-plugin:deploy-file`
or similar goal invocations), Maven internally creates a stub project called
`Maven Stub Project (No POM)` with `groupId=org.apache.maven` and
`artifactId=standalone-pom`. This stub project's POM was being reported as a
generated artifact by `XmlUtils.listGeneratedArtifacts`, causing it to be tracked
and potentially published/deployed unintentionally.

### Testing done

- `XmlUtilsTest.java`: Added a test that verifies a Maven spy log containing only
  a standalone-pom execution produces an empty artifact list.
- `maven-spy-standalone-pom.xml`: New test fixture captured from a real Maven
  execution without a project POM.
- Manual Testing on my Jenkins Instance


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
