### PR TITLE
fix: ignore temporary maven-deploy GAV poms for artifact publishing

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisher.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisher.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.ArtifactManager;
@@ -76,12 +77,12 @@ public class GeneratedArtifactsPublisher extends MavenPublisher {
                                                 + mavenArtifact);
                     }
                     continue;
-                    // Ignore artifacts which are not within workspace but in system temp dir
-                } else if (!workspace.child(mavenArtifact.getFile()).exists()
-                        && isUnderGlobalTempDir(mavenArtifact.getFile())) {
+                    // Ignore temporary GAV-Pom created by maven-deploy-plugin
+                    // https://github.com/jenkinsci/pipeline-maven-plugin/pull/1462
+                } else if (isTemporaryMavenDeployPom(mavenArtifact.getFile())) {
                     listener.getLogger()
-                            .println("[withMaven] artifactsPublisher - Skip archiving for temporary artifact '"
-                                    + mavenArtifact.getFile() + "' in tmp dir");
+                            .println("[withMaven] artifactsPublisher - Skip temporary maven deploy pom: "
+                                    + mavenArtifact.getFile());
                     continue;
                 } else if (!(mavenArtifact.getFile().endsWith("." + mavenArtifact.getExtension()))) {
                     FilePath mavenGeneratedArtifact =
@@ -179,21 +180,18 @@ public class GeneratedArtifactsPublisher extends MavenPublisher {
         }
     }
 
-    /**
-     * Returns {@code true} if the given artifact file is located under the global temporary directory
-     * ({@code java.io.tmpdir}) and should therefore be skipped during archiving.
-     *
-     * <p>The artifact path is compared as-is and is intentionally **not** resolved via
-     * {@link Path#toRealPath()}: {@link MavenArtifact#getFile()} may point to a file that no longer exists
-     * (e.g. a temporary file that has already been cleaned up), and {@code toRealPath()} would throw in that
-     * case. As a consequence, if the temporary directory is reached through a symlink (the canonicalized
-     * {@code globalTempPath}) while Maven reports the artifact through the unresolved symlink path, this check
-     * may not match.
-     * @throws IOException
-     */
-    static boolean isUnderGlobalTempDir(String artifactFile) throws IOException {
-        Path globalTempPath = Paths.get(System.getProperty("java.io.tmpdir")).toRealPath();
-        return Paths.get(artifactFile).startsWith(globalTempPath);
+    static boolean isTemporaryMavenDeployPom(@NonNull String artifactPath) {
+        Path tempDir = Paths.get(System.getProperty("java.io.tmpdir"));
+        Path filePath = Paths.get(artifactPath);
+
+        if (!filePath.startsWith(tempDir)) {
+            return false;
+        }
+
+        return Optional.ofNullable(filePath.getFileName())
+                .map(Path::toString)
+                .map(f -> f.startsWith("mvndeploy") && f.endsWith(".pom"))
+                .orElse(false);
     }
 
     @Symbol("artifactsPublisher")

--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisher.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisher.java
@@ -11,6 +11,8 @@ import hudson.model.TaskListener;
 import hudson.tasks.Fingerprinter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +75,13 @@ public class GeneratedArtifactsPublisher extends MavenPublisher {
                                         "[withMaven] artifactsPublisher - Can't archive maven artifact with no file attached: "
                                                 + mavenArtifact);
                     }
+                    continue;
+                    // Ignore artifacts which are not within workspace but in system temp dir
+                } else if (!workspace.child(mavenArtifact.getFile()).exists()
+                        && isUnderGlobalTempDir(mavenArtifact.getFile())) {
+                    listener.getLogger()
+                            .println("[withMaven] artifactsPublisher - Skip archiving for temporary artifact '"
+                                    + mavenArtifact.getFile() + "' in tmp dir");
                     continue;
                 } else if (!(mavenArtifact.getFile().endsWith("." + mavenArtifact.getExtension()))) {
                     FilePath mavenGeneratedArtifact =
@@ -168,6 +177,23 @@ public class GeneratedArtifactsPublisher extends MavenPublisher {
                 fingerprintAction.add(artifactsToFingerPrint);
             }
         }
+    }
+
+    /**
+     * Returns {@code true} if the given artifact file is located under the global temporary directory
+     * ({@code java.io.tmpdir}) and should therefore be skipped during archiving.
+     *
+     * <p>The artifact path is compared as-is and is intentionally **not** resolved via
+     * {@link Path#toRealPath()}: {@link MavenArtifact#getFile()} may point to a file that no longer exists
+     * (e.g. a temporary file that has already been cleaned up), and {@code toRealPath()} would throw in that
+     * case. As a consequence, if the temporary directory is reached through a symlink (the canonicalized
+     * {@code globalTempPath}) while Maven reports the artifact through the unresolved symlink path, this check
+     * may not match.
+     * @throws IOException
+     */
+    static boolean isUnderGlobalTempDir(String artifactFile) throws IOException {
+        Path globalTempPath = Paths.get(System.getProperty("java.io.tmpdir")).toRealPath();
+        return Paths.get(artifactFile).startsWith(globalTempPath);
     }
 
     @Symbol("artifactsPublisher")

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisherTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisherTest.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.pipeline.maven.publishers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+public class GeneratedArtifactsPublisherTest {
+
+    private final Path globalTempPath = Paths.get(System.getProperty("java.io.tmpdir"));
+
+    @Test
+    public void file_directly_under_temp_dir_is_temporary() throws Exception {
+        String artifactFile = globalTempPath.resolve("foo.jar").toString();
+
+        assertThat(GeneratedArtifactsPublisher.isUnderGlobalTempDir(artifactFile))
+                .isTrue();
+    }
+
+    @Test
+    public void file_nested_under_temp_dir_is_temporary() throws Exception {
+        String artifactFile = globalTempPath
+                .resolve(Paths.get("maven-x", "target", "foo.jar"))
+                .toString();
+
+        assertThat(GeneratedArtifactsPublisher.isUnderGlobalTempDir(artifactFile))
+                .isTrue();
+    }
+
+    @Test
+    public void file_in_workspace_is_not_temporary() throws Exception {
+        String artifactFile = globalTempPath
+                .resolveSibling("workspace")
+                .resolve(Paths.get("job", "target", "foo.jar"))
+                .toString();
+
+        assertThat(GeneratedArtifactsPublisher.isUnderGlobalTempDir(artifactFile))
+                .isFalse();
+    }
+
+    @Test
+    public void relative_path_is_not_temporary() throws Exception {
+        String artifactFile = Paths.get("target", "foo.jar").toString();
+
+        assertThat(GeneratedArtifactsPublisher.isUnderGlobalTempDir(artifactFile))
+                .isFalse();
+    }
+}

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisherTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisherTest.java
@@ -8,42 +8,45 @@ import org.junit.jupiter.api.Test;
 
 public class GeneratedArtifactsPublisherTest {
 
-    private final Path globalTempPath = Paths.get(System.getProperty("java.io.tmpdir"));
+    private static final Path TEMP_DIR = Paths.get(System.getProperty("java.io.tmpdir"));
 
     @Test
-    public void file_directly_under_temp_dir_is_temporary() throws Exception {
-        String artifactFile = globalTempPath.resolve("foo.jar").toString();
-
-        assertThat(GeneratedArtifactsPublisher.isUnderGlobalTempDir(artifactFile))
-                .isTrue();
+    public void isTemporaryMavenDeployPom_returns_true_for_matching_pom_in_temp_dir() {
+        String path = TEMP_DIR.resolve("mvndeploy6910712014852835870.pom").toString();
+        assertThat(GeneratedArtifactsPublisher.isTemporaryMavenDeployPom(path))
+                .isTrue()
+                .as("should return true on matching paths within tmp");
     }
 
     @Test
-    public void file_nested_under_temp_dir_is_temporary() throws Exception {
-        String artifactFile = globalTempPath
-                .resolve(Paths.get("maven-x", "target", "foo.jar"))
-                .toString();
-
-        assertThat(GeneratedArtifactsPublisher.isUnderGlobalTempDir(artifactFile))
-                .isTrue();
+    public void isTemporaryMavenDeployPom_returns_false_for_matching_pom_outside_temp_dir() {
+        String path = "/workspace/mvndeploy6910712014852835870.pom";
+        assertThat(GeneratedArtifactsPublisher.isTemporaryMavenDeployPom(path))
+                .isFalse()
+                .as("should return false on paths outside of tmp");
     }
 
     @Test
-    public void file_in_workspace_is_not_temporary() throws Exception {
-        String artifactFile = globalTempPath
-                .resolveSibling("workspace")
-                .resolve(Paths.get("job", "target", "foo.jar"))
-                .toString();
-
-        assertThat(GeneratedArtifactsPublisher.isUnderGlobalTempDir(artifactFile))
-                .isFalse();
+    public void isTemporaryMavenDeployPom_returns_false_for_wrong_extension_in_temp_dir() {
+        String path = TEMP_DIR.resolve("mvndeploy6910712014852835870.jar").toString();
+        assertThat(GeneratedArtifactsPublisher.isTemporaryMavenDeployPom(path))
+                .isFalse()
+                .as("should return false on files without .pom extension");
     }
 
     @Test
-    public void relative_path_is_not_temporary() throws Exception {
-        String artifactFile = Paths.get("target", "foo.jar").toString();
+    public void isTemporaryMavenDeployPom_returns_false_for_wrong_filename_in_temp_dir() {
+        String path = TEMP_DIR.resolve("some-file.pom").toString();
+        assertThat(GeneratedArtifactsPublisher.isTemporaryMavenDeployPom(path))
+                .isFalse()
+                .as("should return false on files without matching filename");
+    }
 
-        assertThat(GeneratedArtifactsPublisher.isUnderGlobalTempDir(artifactFile))
-                .isFalse();
+    @Test
+    public void isTemporaryMavenDeployPom_returns_false_for_paths_without_file() {
+        String path = TEMP_DIR.toString();
+        assertThat(GeneratedArtifactsPublisher.isTemporaryMavenDeployPom(path))
+                .isFalse()
+                .as("should return false on paths without file");
     }
 }


### PR DESCRIPTION
`GeneratedArtifactsPublisher` now skips archiving Maven artifacts whose file path resolves under the JVM's temporary directory (`java.io.tmpdir`).

Fixes #1460, See also #1452

### Testing done

I've added a unit test for `isUnderGlobalTempDir` utility method and tested this manually on our jenkins instance running on Linux.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed