### PR TITLE
Fix AssertionError when publisher descriptor is missing

### DIFF
--- a/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherStrategy.java
+++ b/pipeline-maven/src/main/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherStrategy.java
@@ -47,7 +47,22 @@ public enum MavenPublisherStrategy {
                 if (mavenPublisher == null) {
                     // skip null publisher options injected by Jenkins pipeline, probably caused by a missing plugin
                 } else {
-                    configuredPublishersById.put(mavenPublisher.getDescriptor().getId(), mavenPublisher);
+                    try {
+                        configuredPublishersById.put(
+                                mavenPublisher.getDescriptor().getId(), mavenPublisher);
+                    } catch (AssertionError e) {
+                        // Descriptor missing — plugin uninstalled/deprecated
+                        listener.getLogger()
+                                .println("[withMaven] WARNING: Skipping publisher '"
+                                        + mavenPublisher.getClass().getSimpleName()
+                                        + "' as its descriptor is missing. "
+                                        + "The associated plugin may be uninstalled or deprecated.");
+                        LOGGER.log(
+                                Level.WARNING,
+                                "Skipping publisher with missing descriptor: "
+                                        + mavenPublisher.getClass().getName(),
+                                e);
+                    }
                 }
             }
 
@@ -62,8 +77,21 @@ public enum MavenPublisherStrategy {
                 globallyConfiguredPublishers = Collections.emptyList();
             }
             for (MavenPublisher mavenPublisher : globallyConfiguredPublishers) {
-                globallyConfiguredPublishersById.put(
-                        mavenPublisher.getDescriptor().getId(), mavenPublisher);
+                try {
+                    globallyConfiguredPublishersById.put(
+                            mavenPublisher.getDescriptor().getId(), mavenPublisher);
+                } catch (AssertionError e) {
+                    listener.getLogger()
+                            .println("[withMaven] WARNING: Skipping globally configured publisher '"
+                                    + mavenPublisher.getClass().getSimpleName()
+                                    + "' as its descriptor is missing. "
+                                    + "The associated plugin may be uninstalled or deprecated.");
+                    LOGGER.log(
+                            Level.WARNING,
+                            "Skipping globally configured publisher with missing descriptor: "
+                                    + mavenPublisher.getClass().getName(),
+                            e);
+                }
             }
 
             // mavenPublisher.descriptor.id -> mavenPublisher

--- a/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherStrategyTest.java
+++ b/pipeline-maven/src/test/java/org/jenkinsci/plugins/pipeline/maven/MavenPublisherStrategyTest.java
@@ -1,6 +1,8 @@
 package org.jenkinsci.plugins.pipeline.maven;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
@@ -56,5 +58,19 @@ public class MavenPublisherStrategyTest {
         assertThat(reportersByDescriptorId).containsKey(new MavenLinkerPublisher2.DescriptorImpl().getId());
         assertThat(reportersByDescriptorId).containsKey(new PipelineGraphPublisher.DescriptorImpl().getId());
         assertThat(reportersByDescriptorId).containsKey(new CoveragePublisher.DescriptorImpl().getId());
+    }
+
+    @Test
+    public void buildPublishersListShouldSkipPublisherWithMissingDescriptor(JenkinsRule r) throws Exception {
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        MavenPublisher brokenPublisher = mock(MavenPublisher.class);
+        when(brokenPublisher.getDescriptor()).thenThrow(new AssertionError("Descriptor is missing!"));
+
+        List<MavenPublisher> result = MavenPublisherStrategy.IMPLICIT.buildPublishersList(
+                Collections.singletonList(brokenPublisher), new StreamTaskListener(baos));
+
+        assertThat(baos.toString()).contains("WARNING");
     }
 }


### PR DESCRIPTION
Fixes #1319

Root cause: When findbugs plugin is not installed,
descriptor is not registered, causing AssertionError
in buildPublishersList().

Fix: Added try-catch around getDescriptor() calls
in both configuredPublishers and globallyConfiguredPublishers
loops to gracefully skip publishers with missing descriptors.

Added unit test to cover this scenario.