### PR TITLE
Remove obsolete JsonUnit JsonPath dependency

### DIFF
--- a/pipeline-maven-ui-tests/pom.xml
+++ b/pipeline-maven-ui-tests/pom.xml
@@ -163,12 +163,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.javacrumbs.json-unit</groupId>
-      <artifactId>json-unit-json-path</artifactId>
-      <version>${json-unit-assertj.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${httpclient.version}</version>


### PR DESCRIPTION
Fixes the UI-test dependency resolution failure in #1489.

JsonUnit 6 moved JsonPath support into `json-unit-core` and stopped publishing
`json-unit-json-path`. `json-unit-assertj:6.2.0` already brings
`json-unit-core:6.2.0` transitively, so this removes the obsolete explicit dependency.
No production code is changed.

Verification (JDK 21, Maven 3.9.16):

- `mvn -V -ntp -Pskip -DskipTests install`
- `mvn -V -ntp --file pipeline-maven-ui-tests/pom.xml -DskipTests test`
- `mvn -ntp --file pipeline-maven-ui-tests/pom.xml dependency:tree -Dincludes=net.javacrumbs.json-unit`

The final dependency tree resolves
`json-unit-assertj:6.2.0 -> json-unit-core:6.2.0`. The browser-backed UI matrix is
left to the pull request CI.
