### PR TITLE
Remove obsolete JsonUnit JsonPath dependency after Renovate refresh

### DIFF
--- a/pipeline-maven-ui-tests/pom.xml
+++ b/pipeline-maven-ui-tests/pom.xml
@@ -163,12 +163,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.javacrumbs.json-unit</groupId>
-      <artifactId>json-unit-json-path</artifactId>
-      <version>${json-unit-assertj.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${httpclient.version}</version>


### PR DESCRIPTION
Restores the maintainer-approved fix from [#1513](https://github.com/jenkinsci/pipeline-maven-plugin/pull/1513) after Renovate regenerated [#1489](https://github.com/jenkinsci/pipeline-maven-plugin/pull/1489) without the merged change.

JsonUnit 6 moved JsonPath support into `json-unit-core` and stopped publishing `json-unit-json-path`. `json-unit-assertj:6.2.0` already brings `json-unit-core:6.2.0` transitively, so this removes the obsolete explicit dependency. No production code changes.

The patch is the same six-line deletion previously reviewed and merged, now applied to current Renovate source revision `96e81a0dfc0d746ea015c11f2589fc6152547cc7`.

Verification (JDK 21, Maven 3.9.16):

- `mvn -V -ntp -Pskip -DskipTests install` — all five normal reactor modules passed
- `mvn -V -ntp --file pipeline-maven-ui-tests/pom.xml -DskipTests test` — UI-test module compiled and all dependency/enforcer gates passed
- `mvn -ntp --file pipeline-maven-ui-tests/pom.xml dependency:tree -Dincludes=net.javacrumbs.json-unit` — resolves `json-unit-assertj:6.2.0 -> json-unit-core:6.2.0`; no `json-unit-json-path`
- `git diff --check` and complete diff review — passed

The browser-backed UI matrix remains covered by pull-request CI.

## AI assistance

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot).

- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, `jaipilot-remote-java`, and `jaipilot-review-diff`
- Model: `gpt-5.6-sol`
- Reasoning: `xhigh`
- Service mode: `fast`; final verification ran locally because JAIPilot Remote was unavailable